### PR TITLE
DFI 7085 and 8062

### DIFF
--- a/src/data/eips.json
+++ b/src/data/eips.json
@@ -4933,7 +4933,7 @@
     "forkRelationships": [
       {
         "forkName": "Glamsterdam",
-        "status": "Proposed",
+        "status": "Considered",
         "layer": "CL",
         "champion": {
           "name": "Barnabas Busa",
@@ -5512,7 +5512,7 @@
     "forkRelationships": [
       {
         "forkName": "Glamsterdam",
-        "status": "Proposed",
+        "status": "Declined",
         "layer": "CL",
         "champion": {
           "name": "Francesco D'Amato",


### PR DESCRIPTION
During ACDC #170 (https://www.youtube.com/watch?v=1IA-NZa4VZ8&t=4890s), it was decided that EIP-7085 (FOCIL) EIP 8071 (Prevent using consolidations as withdrawals) and EIP-8062 (Add sweep withdrawal fee for 0x01 validators) are DFI items for Glamsterdam while 8045 (Exclude slashed validators from proposing) is CFI for Glamsterdam. 

Discussion of EIPs 7688, 8061, and 8080 will be taken up in the next ACDC.