### PR TITLE
add zed directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,10 @@ src/data/eips.json
 .vscode/*
 !.vscode/extensions.json
 .idea
+.zed
 .DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
-*.sw? 
+*.sw?


### PR DESCRIPTION
ignores local project settings for zed editor users