### PR TITLE
CFI and DFI decisions based on ACDE 226

### DIFF
--- a/src/data/eips/2780.json
+++ b/src/data/eips/2780.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Considered",
       "layer": "EL",
       "champion": {
         "name": "Ben Adams",

--- a/src/data/eips/2926.json
+++ b/src/data/eips/2926.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Declined",
       "layer": "EL",
       "champion": {
         "name": "Guillaume Ballet",

--- a/src/data/eips/7686.json
+++ b/src/data/eips/7686.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Declined",
       "layer": "EL",
       "champion": {
         "name": "Carl Beekhuizen",

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Considered",
       "layer": "EL",
       "champion": {
         "name": "Maria Silva",

--- a/src/data/eips/7923.json
+++ b/src/data/eips/7923.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Declined",
       "layer": "EL",
       "champion": {
         "name": "Charles Cooper",

--- a/src/data/eips/7973.json
+++ b/src/data/eips/7973.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Declined",
       "layer": "EL",
       "champion": {
         "name": "Charles Cooper",

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Considered",
       "layer": "EL",
       "champion": {
         "name": "Toni Wahrstätter",

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Considered",
       "layer": "EL",
       "champion": {
         "name": "Toni Wahrstätter",

--- a/src/data/eips/8038.json
+++ b/src/data/eips/8038.json
@@ -12,7 +12,7 @@
   "forkRelationships": [
     {
       "forkName": "Glamsterdam",
-      "status": "Proposed",
+      "status": "Considered",
       "layer": "EL",
       "champion": {
         "name": "Maria Silva",


### PR DESCRIPTION
Based on ACDE #226, the following EIPs were CFI and DFI for Glamsterdam:

CFI EIPs: 2780, 7904, 7976, 7981, 8038
DFI EIPs: 2926, 7686, 7923, 7973

Decision delayed (to Jan 5) on EIPs: 7971, 8032, 8037.