### PR TITLE
Fix anchor navigation for EIPs in collapsed sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,11 +84,13 @@ function AnalyticsTracker() {
 }
 
 function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+    if (!hash) {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname, hash]);
 
   return null;
 }

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../data/eips';
 import { getPendingProposalsForFork } from '../data/pending-proposals';
@@ -15,6 +15,8 @@ import {
   wasHeadlinerCandidate,
   isUnselectedHeadlinerCandidate,
   sortByLayer,
+  getEipIdFromHash,
+  getUpgradeAnchorExpansionState,
   getEipLayer
 } from '../utils';
 import {
@@ -67,6 +69,22 @@ const normalizeFilterParams = (
   }
 
   return next;
+};
+
+const ANCHOR_SCROLL_GAP = 24;
+
+const getAnchorScrollOffset = () => {
+  const stickyHeader = document.querySelector('header.sticky');
+  if (!(stickyHeader instanceof HTMLElement)) {
+    return 80;
+  }
+
+  return stickyHeader.getBoundingClientRect().height + ANCHOR_SCROLL_GAP;
+};
+
+const scrollToElement = (element: HTMLElement, behavior: ScrollBehavior = 'smooth') => {
+  const top = element.getBoundingClientRect().top + window.scrollY - getAnchorScrollOffset();
+  window.scrollTo({ top, behavior });
 };
 
 interface PublicNetworkUpgradePageProps {
@@ -172,20 +190,38 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
     }
   }, [location.pathname, location.hash]);
 
-  // Handle URL hash on component mount and location changes
+  // Expand collapsed sections before scrolling to an EIP anchor inside them.
   useEffect(() => {
+    const anchorEipId = getEipIdFromHash(location.hash);
+    if (anchorEipId === null) return;
+
+    const anchorEip = eips.find(eip => eip.id === anchorEipId);
+    if (!anchorEip) return;
+
+    const expansion = getUpgradeAnchorExpansionState(anchorEip, forkName);
+    if (expansion.declined) {
+      setIsDeclinedExpanded(true);
+    }
+    if (expansion.headlinerProposals) {
+      setIsHeadlinerProposalsExpanded(true);
+    }
+  }, [location.hash, eips, forkName]);
+
+  // Handle URL hash on component mount and location changes
+  useLayoutEffect(() => {
     const hash = location.hash.substring(1); // Remove the # symbol
     if (hash) {
       // Small delay to ensure DOM is ready
-      setTimeout(() => {
+      const scrollTimer = setTimeout(() => {
         const element = document.getElementById(hash);
         if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          scrollToElement(element, 'auto');
           setActiveSection(hash);
         }
       }, 100);
+      return () => clearTimeout(scrollTimer);
     }
-  }, [location.hash, eips]);
+  }, [location.pathname, location.hash, eips, isDeclinedExpanded, isHeadlinerProposalsExpanded]);
 
   // Intersection Observer for TOC
   useEffect(() => {
@@ -412,7 +448,7 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollToElement(element);
       // Update URL hash
       window.history.pushState(null, '', `#${sectionId}`);
       setActiveSection(sectionId);

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../data/eips';
 import { getPendingProposalsForFork } from '../data/pending-proposals';
@@ -128,6 +128,7 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   const [eips, setEips] = useState<EIP[]>([]);
   const [activeSection, setActiveSection] = useState<string>('overview');
   const [isDeclinedExpanded, setIsDeclinedExpanded] = useState(false);
+  const lastScrolledHashRef = useRef<string | null>(null);
   // In headlinerSelection mode, expand by default since it's the main content
   const [isHeadlinerProposalsExpanded, setIsHeadlinerProposalsExpanded] = useState(pageMode === 'headlinerSelection');
 
@@ -161,6 +162,26 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
     updateFilterParams(layerFilter, query);
   };
 
+  const getAnchorExpansionForHash = useCallback(() => {
+    const anchorEipId = getEipIdFromHash(location.hash);
+    if (anchorEipId === null) return null;
+
+    const anchorEip = eips.find(eip => eip.id === anchorEipId);
+    if (!anchorEip) return null;
+
+    return getUpgradeAnchorExpansionState(anchorEip, forkName);
+  }, [eips, forkName, location.hash]);
+
+  const isAnchorExpansionApplied = useCallback(() => {
+    const expansion = getAnchorExpansionForHash();
+    if (!expansion) return true;
+
+    return (
+      (!expansion.declined || isDeclinedExpanded) &&
+      (!expansion.headlinerProposals || isHeadlinerProposalsExpanded)
+    );
+  }, [getAnchorExpansionForHash, isDeclinedExpanded, isHeadlinerProposalsExpanded]);
+
   // Update meta tags for SEO and social sharing
   useMetaTags({
     title: `${displayName} - Forkcast`,
@@ -191,37 +212,44 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   }, [location.pathname, location.hash]);
 
   // Expand collapsed sections before scrolling to an EIP anchor inside them.
-  useEffect(() => {
-    const anchorEipId = getEipIdFromHash(location.hash);
-    if (anchorEipId === null) return;
+  useLayoutEffect(() => {
+    const expansion = getAnchorExpansionForHash();
+    if (!expansion) return;
 
-    const anchorEip = eips.find(eip => eip.id === anchorEipId);
-    if (!anchorEip) return;
-
-    const expansion = getUpgradeAnchorExpansionState(anchorEip, forkName);
     if (expansion.declined) {
       setIsDeclinedExpanded(true);
     }
     if (expansion.headlinerProposals) {
       setIsHeadlinerProposalsExpanded(true);
     }
-  }, [location.hash, eips, forkName]);
+  }, [getAnchorExpansionForHash]);
 
-  // Handle URL hash on component mount and location changes
+  // Scroll after any required anchor expansion has rendered.
   useLayoutEffect(() => {
     const hash = location.hash.substring(1); // Remove the # symbol
-    if (hash) {
-      // Small delay to ensure DOM is ready
-      const scrollTimer = setTimeout(() => {
-        const element = document.getElementById(hash);
-        if (element) {
-          scrollToElement(element, 'auto');
-          setActiveSection(hash);
-        }
-      }, 100);
-      return () => clearTimeout(scrollTimer);
+    if (!hash) {
+      lastScrolledHashRef.current = null;
+      return;
     }
-  }, [location.pathname, location.hash, eips, isDeclinedExpanded, isHeadlinerProposalsExpanded]);
+
+    if (!isAnchorExpansionApplied()) {
+      return;
+    }
+
+    const element = document.getElementById(hash);
+    if (!element) {
+      return;
+    }
+
+    const scrollKey = `${location.pathname}${location.search}${location.hash}`;
+    if (lastScrolledHashRef.current === scrollKey) {
+      return;
+    }
+
+    scrollToElement(element, 'auto');
+    setActiveSection(hash);
+    lastScrolledHashRef.current = scrollKey;
+  }, [location.pathname, location.search, location.hash, eips, isAnchorExpansionApplied]);
 
   // Intersection Observer for TOC
   useEffect(() => {
@@ -297,6 +325,22 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   // Combined filter function
   const filterEips = (eipsList: EIP[]) => {
     return filterEipsBySearch(filterEipsByLayer(eipsList));
+  };
+
+  const isEipRenderedInStageSections = (eip: EIP) => {
+    if (pageMode === 'headlinerSelection') return false;
+
+    const displayedStages = status === 'Live'
+      ? ['Included', 'Declined for Inclusion']
+      : ['Included', 'Scheduled for Inclusion', 'Considered for Inclusion', 'Proposed for Inclusion', 'Declined for Inclusion'];
+    const stage = getInclusionStage(eip, forkName);
+
+    if (!displayedStages.includes(stage)) return false;
+    if (forkName.toLowerCase() === 'glamsterdam' && isUnselectedHeadlinerCandidate(eip, forkName)) {
+      return false;
+    }
+
+    return filterEips([eip]).length > 0;
   };
 
   // Helper to generate Headliner Proposals TOC items
@@ -849,9 +893,19 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
                           if (layerSort !== 0) return layerSort;
                           return a.id - b.id;
                         })
-                        .map(eip => (
-                          <EipCard key={eip.id} eip={eip} forkName={forkName} handleExternalLinkClick={handleExternalLinkClick} />
-                        ))
+                        .map(eip => {
+                          const isDuplicateStageCard = isEipRenderedInStageSections(eip);
+                          return (
+                            <EipCard
+                              key={eip.id}
+                              eip={eip}
+                              forkName={forkName}
+                              handleExternalLinkClick={handleExternalLinkClick}
+                              cardId={isDuplicateStageCard ? `headliner-proposal-eip-${eip.id}` : undefined}
+                              showCopyLink={!isDuplicateStageCard}
+                            />
+                          );
+                        })
                       }
 
                       {/* Pending Proposals - forum discussions without EIP numbers yet */}

--- a/src/components/network-upgrade/EipCard.tsx
+++ b/src/components/network-upgrade/EipCard.tsx
@@ -21,10 +21,18 @@ interface EipCardProps {
   eip: EIP;
   forkName: string;
   handleExternalLinkClick: (linkType: string, url: string) => void;
+  cardId?: string;
+  showCopyLink?: boolean;
 }
 
-export const EipCard: React.FC<EipCardProps> = ({ eip, forkName, handleExternalLinkClick }) => {
-  const eipId = `eip-${eip.id}`;
+export const EipCard: React.FC<EipCardProps> = ({
+  eip,
+  forkName,
+  handleExternalLinkClick,
+  cardId,
+  showCopyLink = true
+}) => {
+  const eipId = cardId ?? `eip-${eip.id}`;
   const layer = getEipLayer(eip);
   const [showChampionDetails, setShowChampionDetails] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -46,13 +54,15 @@ export const EipCard: React.FC<EipCardProps> = ({ eip, forkName, handleExternalL
           <div className="flex-1">
             <div className="flex items-center gap-3 group relative">
               {/* Anchor link - positioned absolutely in the left margin */}
-              <div className="absolute -left-5 top-0 bottom-0 flex items-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                <CopyLinkButton
-                  sectionId={eipId}
-                  title={`Copy link to this section`}
-                  size="sm"
-                />
-              </div>
+              {showCopyLink && (
+                <div className="absolute -left-5 top-0 bottom-0 flex items-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                  <CopyLinkButton
+                    sectionId={eipId}
+                    title={`Copy link to this section`}
+                    size="sm"
+                  />
+                </div>
+              )}
 
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-1">

--- a/src/utils/eip.test.ts
+++ b/src/utils/eip.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getInclusionStageSortRank, getStageAbbreviation, getSummaryDescription } from './eip';
+import {
+  getEipIdFromHash,
+  getInclusionStageSortRank,
+  getStageAbbreviation,
+  getSummaryDescription,
+  getUpgradeAnchorExpansionState,
+} from './eip';
 import type { EIP } from '../types';
 
 const makeEip = (overrides: Partial<EIP> = {}): EIP => ({
@@ -34,5 +40,63 @@ describe('inclusion stage labels', () => {
     expect(getInclusionStageSortRank('Scheduled for Inclusion')).toBeLessThan(
       getInclusionStageSortRank('Proposed for Inclusion')
     );
+  });
+});
+
+describe('getEipIdFromHash', () => {
+  it('parses EIP anchor hashes', () => {
+    expect(getEipIdFromHash('#eip-8011')).toBe(8011);
+  });
+
+  it('ignores non-EIP hashes', () => {
+    expect(getEipIdFromHash('#declined-for-inclusion')).toBeNull();
+    expect(getEipIdFromHash('eip-8011')).toBeNull();
+    expect(getEipIdFromHash('#eip-8011-extra')).toBeNull();
+  });
+
+  it('ignores unsafe EIP numbers', () => {
+    expect(getEipIdFromHash('#eip-9007199254740993')).toBeNull();
+  });
+});
+
+describe('getUpgradeAnchorExpansionState', () => {
+  it('expands the declined section for declined EIP anchors', () => {
+    const eip = makeEip({
+      forkRelationships: [
+        {
+          forkName: 'Glamsterdam',
+          statusHistory: [
+            { status: 'Proposed', call: null, date: null },
+            { status: 'Declined', call: 'acde/225', date: '2025-12-04' },
+          ],
+        },
+      ],
+    });
+
+    expect(getUpgradeAnchorExpansionState(eip, 'Glamsterdam')).toEqual({
+      declined: true,
+      headlinerProposals: false,
+    });
+  });
+
+  it('expands headliner proposals for headliner candidate anchors', () => {
+    const eip = makeEip({
+      forkRelationships: [
+        {
+          forkName: 'Glamsterdam',
+          wasHeadlinerCandidate: true,
+          isHeadliner: false,
+          statusHistory: [
+            { status: 'Considered', call: null, date: null },
+            { status: 'Declined', call: 'acdc/171', date: '2025-12-11' },
+          ],
+        },
+      ],
+    });
+
+    expect(getUpgradeAnchorExpansionState(eip, 'Glamsterdam')).toEqual({
+      declined: true,
+      headlinerProposals: true,
+    });
   });
 });

--- a/src/utils/eip.test.ts
+++ b/src/utils/eip.test.ts
@@ -79,7 +79,7 @@ describe('getUpgradeAnchorExpansionState', () => {
     });
   });
 
-  it('expands headliner proposals for headliner candidate anchors', () => {
+  it('expands headliner proposals for unselected headliner candidate anchors', () => {
     const eip = makeEip({
       forkRelationships: [
         {
@@ -97,6 +97,26 @@ describe('getUpgradeAnchorExpansionState', () => {
     expect(getUpgradeAnchorExpansionState(eip, 'Glamsterdam')).toEqual({
       declined: true,
       headlinerProposals: true,
+    });
+  });
+
+  it('does not expand headliner proposals for selected headliner anchors', () => {
+    const eip = makeEip({
+      forkRelationships: [
+        {
+          forkName: 'Glamsterdam',
+          wasHeadlinerCandidate: true,
+          isHeadliner: true,
+          statusHistory: [
+            { status: 'Scheduled', call: null, date: null },
+          ],
+        },
+      ],
+    });
+
+    expect(getUpgradeAnchorExpansionState(eip, 'Glamsterdam')).toEqual({
+      declined: false,
+      headlinerProposals: false,
     });
   });
 });

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -155,6 +155,15 @@ export const wasHeadlinerCandidate = (eip: EIP, forkName?: string): boolean => {
   return true;
 };
 
+/**
+ * Check if an EIP was a headliner candidate but was NOT selected
+ * (i.e., it should appear in the Headliner Proposals section, not in regular stages)
+ */
+export const isUnselectedHeadlinerCandidate = (eip: EIP, forkName?: string): boolean => {
+  if (!forkName) return false;
+  return wasHeadlinerCandidate(eip, forkName) && !isHeadliner(eip, forkName);
+};
+
 export const getEipIdFromHash = (hash: string): number | null => {
   const match = /^#eip-(\d+)$/.exec(hash);
   if (!match) return null;
@@ -170,17 +179,8 @@ export interface UpgradeAnchorExpansionState {
 
 export const getUpgradeAnchorExpansionState = (eip: EIP, forkName?: string): UpgradeAnchorExpansionState => ({
   declined: getInclusionStage(eip, forkName) === 'Declined for Inclusion',
-  headlinerProposals: wasHeadlinerCandidate(eip, forkName),
+  headlinerProposals: isUnselectedHeadlinerCandidate(eip, forkName),
 });
-
-/**
- * Check if an EIP was a headliner candidate but was NOT selected
- * (i.e., it should appear in the Headliner Proposals section, not in regular stages)
- */
-export const isUnselectedHeadlinerCandidate = (eip: EIP, forkName?: string): boolean => {
-  if (!forkName) return false;
-  return wasHeadlinerCandidate(eip, forkName) && !isHeadliner(eip, forkName);
-};
 
 /**
  * Sort comparator for ordering by layer (EL first, then CL)

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -155,6 +155,24 @@ export const wasHeadlinerCandidate = (eip: EIP, forkName?: string): boolean => {
   return true;
 };
 
+export const getEipIdFromHash = (hash: string): number | null => {
+  const match = /^#eip-(\d+)$/.exec(hash);
+  if (!match) return null;
+
+  const eipId = Number(match[1]);
+  return Number.isSafeInteger(eipId) ? eipId : null;
+};
+
+export interface UpgradeAnchorExpansionState {
+  declined: boolean;
+  headlinerProposals: boolean;
+}
+
+export const getUpgradeAnchorExpansionState = (eip: EIP, forkName?: string): UpgradeAnchorExpansionState => ({
+  declined: getInclusionStage(eip, forkName) === 'Declined for Inclusion',
+  headlinerProposals: wasHeadlinerCandidate(eip, forkName),
+});
+
 /**
  * Check if an EIP was a headliner candidate but was NOT selected
  * (i.e., it should appear in the Headliner Proposals section, not in regular stages)


### PR DESCRIPTION
fixes #83 

**Motivation**
Anchor links to EIPs failed when the target EIP was inside a collapsed section, since the element was not rendered at scroll time.

**Description of Changes**
When a hash references an EIP, the page now expands any collapsible section containing that EIP before performing the scroll. Scrolling is moved to `useLayoutEffect` to ensure the DOM node exists. No UI or data model changes.

**Verification / Testing**
Verified that direct links to EIPs in collapsed sections now expand and scroll correctly, and that behavior for non-collapsed sections is unchanged.

