### PR TITLE
7919 withdrawn rather than proposed

### DIFF
--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -22,7 +22,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Withdrawn"
         }
       ],
       "isHeadliner": false,


### PR DESCRIPTION
7919 was moved to Glamsterdam non-headliners after being proposed (and declined) as a headliner but it wasn't actually proposed as a non-headliner, 6466 and 6406 were proposed instead, and superseded 7919. up to @wolovim how to handle