### PR TITLE
Make call and date required fields with null backfill

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -56,7 +56,7 @@
     },
     "StatusHistoryEntry": {
       "type": "object",
-      "required": ["status"],
+      "required": ["status", "call", "date"],
       "additionalProperties": false,
       "properties": {
         "status": {
@@ -64,12 +64,16 @@
           "enum": ["Proposed", "Considered", "Scheduled", "Declined", "Included", "Withdrawn"]
         },
         "call": {
-          "type": "string",
-          "pattern": "^(acdc|acde|acdt)/[0-9]+$"
+          "oneOf": [
+            { "type": "string", "pattern": "^(acdc|acde|acdt)/[0-9]+$" },
+            { "type": "null" }
+          ]
         },
         "date": {
-          "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "oneOf": [
+            { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+            { "type": "null" }
+          ]
         }
       }
     },

--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -10,8 +10,8 @@ interface EipTimelineProps {
 
 interface TimelineEvent {
   type: 'created' | 'fork_status';
-  date?: string;
-  call?: string;
+  date?: string | null;
+  call?: string | null;
   forkName?: string;
   status?: string;
   champion?: { name: string };
@@ -106,7 +106,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
     // If there's a champion and no "Proposed" in history, prepend it
     const hasProposedStep = fork.statusHistory.some(entry => entry.status === 'Proposed');
     const effectiveHistory = (fork.champion && !hasProposedStep)
-      ? [{ status: 'Proposed' as const }, ...fork.statusHistory]
+      ? [{ status: 'Proposed' as const, call: null, date: null }, ...fork.statusHistory]
       : fork.statusHistory;
 
     // Reverse the status history so most recent is first

--- a/src/data/eips/2537.json
+++ b/src/data/eips/2537.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/2780.json
+++ b/src/data/eips/2780.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/2926.json
+++ b/src/data/eips/2926.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/2935.json
+++ b/src/data/eips/2935.json
@@ -14,10 +14,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/3540.json
+++ b/src/data/eips/3540.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/3670.json
+++ b/src/data/eips/3670.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/4200.json
+++ b/src/data/eips/4200.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/4750.json
+++ b/src/data/eips/4750.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/4844.json
+++ b/src/data/eips/4844.json
@@ -14,7 +14,9 @@
       "forkName": "Dencun",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/5450.json
+++ b/src/data/eips/5450.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/5920.json
+++ b/src/data/eips/5920.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/6110.json
+++ b/src/data/eips/6110.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/6206.json
+++ b/src/data/eips/6206.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/6404.json
+++ b/src/data/eips/6404.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/6466.json
+++ b/src/data/eips/6466.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/663.json
+++ b/src/data/eips/663.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7002.json
+++ b/src/data/eips/7002.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7069.json
+++ b/src/data/eips/7069.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7251.json
+++ b/src/data/eips/7251.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7480.json
+++ b/src/data/eips/7480.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,10 +24,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7547.json
+++ b/src/data/eips/7547.json
@@ -14,10 +14,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7549.json
+++ b/src/data/eips/7549.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7594.json
+++ b/src/data/eips/7594.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ],
       "isHeadliner": true

--- a/src/data/eips/7610.json
+++ b/src/data/eips/7610.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7619.json
+++ b/src/data/eips/7619.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7620.json
+++ b/src/data/eips/7620.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7623.json
+++ b/src/data/eips/7623.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7642.json
+++ b/src/data/eips/7642.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7666.json
+++ b/src/data/eips/7666.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7668.json
+++ b/src/data/eips/7668.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7685.json
+++ b/src/data/eips/7685.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7686.json
+++ b/src/data/eips/7686.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7688.json
+++ b/src/data/eips/7688.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },

--- a/src/data/eips/7691.json
+++ b/src/data/eips/7691.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7692.json
+++ b/src/data/eips/7692.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },

--- a/src/data/eips/7698.json
+++ b/src/data/eips/7698.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7702.json
+++ b/src/data/eips/7702.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7708.json
+++ b/src/data/eips/7708.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7732.json
+++ b/src/data/eips/7732.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         }
       ],
       "isHeadliner": true,

--- a/src/data/eips/7745.json
+++ b/src/data/eips/7745.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7761.json
+++ b/src/data/eips/7761.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7762.json
+++ b/src/data/eips/7762.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7778.json
+++ b/src/data/eips/7778.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7782.json
+++ b/src/data/eips/7782.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ],
       "isHeadliner": false,

--- a/src/data/eips/7783.json
+++ b/src/data/eips/7783.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7791.json
+++ b/src/data/eips/7791.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7793.json
+++ b/src/data/eips/7793.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7805.json
+++ b/src/data/eips/7805.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7819.json
+++ b/src/data/eips/7819.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7823.json
+++ b/src/data/eips/7823.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7825.json
+++ b/src/data/eips/7825.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7834.json
+++ b/src/data/eips/7834.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7840.json
+++ b/src/data/eips/7840.json
@@ -14,7 +14,9 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7843.json
+++ b/src/data/eips/7843.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7872.json
+++ b/src/data/eips/7872.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7873.json
+++ b/src/data/eips/7873.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7880.json
+++ b/src/data/eips/7880.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7883.json
+++ b/src/data/eips/7883.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7889.json
+++ b/src/data/eips/7889.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7892.json
+++ b/src/data/eips/7892.json
@@ -13,10 +13,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7898.json
+++ b/src/data/eips/7898.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7903.json
+++ b/src/data/eips/7903.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7907.json
+++ b/src/data/eips/7907.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7910.json
+++ b/src/data/eips/7910.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL"

--- a/src/data/eips/7912.json
+++ b/src/data/eips/7912.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7917.json
+++ b/src/data/eips/7917.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7918.json
+++ b/src/data/eips/7918.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Withdrawn"
+          "status": "Withdrawn",
+          "call": null,
+          "date": null
         }
       ],
       "isHeadliner": false,

--- a/src/data/eips/7923.json
+++ b/src/data/eips/7923.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7928.json
+++ b/src/data/eips/7928.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         }
       ],
       "isHeadliner": true,

--- a/src/data/eips/7932.json
+++ b/src/data/eips/7932.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7934.json
+++ b/src/data/eips/7934.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7935.json
+++ b/src/data/eips/7935.json
@@ -13,10 +13,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7939.json
+++ b/src/data/eips/7939.json
@@ -14,10 +14,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7949.json
+++ b/src/data/eips/7949.json
@@ -14,7 +14,9 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -22,7 +24,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7951.json
+++ b/src/data/eips/7951.json
@@ -14,10 +14,14 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Considered"
+          "status": "Considered",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Declined"
+          "status": "Declined",
+          "call": null,
+          "date": null
         }
       ]
     },
@@ -25,10 +29,14 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Scheduled"
+          "status": "Scheduled",
+          "call": null,
+          "date": null
         },
         {
-          "status": "Included"
+          "status": "Included",
+          "call": null,
+          "date": null
         }
       ]
     }

--- a/src/data/eips/7971.json
+++ b/src/data/eips/7971.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7973.json
+++ b/src/data/eips/7973.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7979.json
+++ b/src/data/eips/7979.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7997.json
+++ b/src/data/eips/7997.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/7999.json
+++ b/src/data/eips/7999.json
@@ -14,10 +14,13 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Withdrawn",
+          "call": null,
           "date": "2025-10-29"
         }
       ],

--- a/src/data/eips/8011.json
+++ b/src/data/eips/8011.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8013.json
+++ b/src/data/eips/8013.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8024.json
+++ b/src/data/eips/8024.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/8030.json
+++ b/src/data/eips/8030.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8032.json
+++ b/src/data/eips/8032.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8037.json
+++ b/src/data/eips/8037.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8038.json
+++ b/src/data/eips/8038.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/8045.json
+++ b/src/data/eips/8045.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/8051.json
+++ b/src/data/eips/8051.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8053.json
+++ b/src/data/eips/8053.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8057.json
+++ b/src/data/eips/8057.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8058.json
+++ b/src/data/eips/8058.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8059.json
+++ b/src/data/eips/8059.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8062.json
+++ b/src/data/eips/8062.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8068.json
+++ b/src/data/eips/8068.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/data/eips/8070.json
+++ b/src/data/eips/8070.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Considered",

--- a/src/data/eips/8071.json
+++ b/src/data/eips/8071.json
@@ -14,7 +14,9 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed"
+          "status": "Proposed",
+          "call": null,
+          "date": null
         },
         {
           "status": "Declined",

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -9,8 +9,8 @@ export interface ForkRelationship {
   forkName: string;
   statusHistory: Array<{
     status: 'Proposed' | 'Considered' | 'Scheduled' | 'Declined' | 'Included' | 'Withdrawn';
-    call?: `${'acdc' | 'acde' | 'acdt'}/${number}`;
-    date?: string;
+    call: `${'acdc' | 'acde' | 'acdt'}/${number}` | null;
+    date: string | null;
   }>; // Ordered oldest -> newest
   isHeadliner?: boolean;
   wasHeadlinerCandidate?: boolean;


### PR DESCRIPTION
## Summary

- Makes `call` and `date` required fields in `statusHistory` entries
- Allows `null` for legacy data that predates these fields
- Backfills existing entries with explicit `null` values

## Why null instead of a CI check?

We want parity between local builds and CI. With `npm run build` enforcing the schema via AJV, contributors get immediate feedback when adding status changes without `call`/`date`. A separate CI check would create a situation where local builds pass but PRs fail unexpectedly.

While someone could technically still add `null` values for new entries, this is unlikely in practice—PR reviewers will catch it, and the schema validation makes the expectation clear. The goal is to make the correct path (providing `call`/`date`) the obvious one, not to make `null` impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)