### PR TITLE
Use discriminated union for statusHistory entries

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -55,27 +55,42 @@
       }
     },
     "StatusHistoryEntry": {
-      "type": "object",
-      "required": ["status", "call", "date"],
-      "additionalProperties": false,
-      "properties": {
-        "status": {
-          "type": "string",
-          "enum": ["Proposed", "Considered", "Scheduled", "Declined", "Included", "Withdrawn"]
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["status"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["Proposed", "Included"]
+            }
+          }
         },
-        "call": {
-          "oneOf": [
-            { "type": "string", "pattern": "^(acdc|acde|acdt)/[0-9]+$" },
-            { "type": "null" }
-          ]
-        },
-        "date": {
-          "oneOf": [
-            { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
-            { "type": "null" }
-          ]
+        {
+          "type": "object",
+          "required": ["status", "call", "date"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["Considered", "Scheduled", "Declined", "Withdrawn"]
+            },
+            "call": {
+              "oneOf": [
+                { "type": "string", "pattern": "^(acdc|acde|acdt)/[0-9]+$" },
+                { "type": "null" }
+              ]
+            },
+            "date": {
+              "oneOf": [
+                { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+                { "type": "null" }
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "Champion": {
       "type": "object",

--- a/src/data/eips/2537.json
+++ b/src/data/eips/2537.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/2780.json
+++ b/src/data/eips/2780.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/2926.json
+++ b/src/data/eips/2926.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/2935.json
+++ b/src/data/eips/2935.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/4844.json
+++ b/src/data/eips/4844.json
@@ -14,9 +14,7 @@
       "forkName": "Dencun",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/5920.json
+++ b/src/data/eips/5920.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/6110.json
+++ b/src/data/eips/6110.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/6404.json
+++ b/src/data/eips/6404.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/6466.json
+++ b/src/data/eips/6466.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7002.json
+++ b/src/data/eips/7002.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7251.json
+++ b/src/data/eips/7251.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7549.json
+++ b/src/data/eips/7549.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7594.json
+++ b/src/data/eips/7594.json
@@ -14,9 +14,7 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ],
       "isHeadliner": true

--- a/src/data/eips/7610.json
+++ b/src/data/eips/7610.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7619.json
+++ b/src/data/eips/7619.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7623.json
+++ b/src/data/eips/7623.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7642.json
+++ b/src/data/eips/7642.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     },
@@ -24,9 +22,7 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7668.json
+++ b/src/data/eips/7668.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7685.json
+++ b/src/data/eips/7685.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7686.json
+++ b/src/data/eips/7686.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7691.json
+++ b/src/data/eips/7691.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7702.json
+++ b/src/data/eips/7702.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7708.json
+++ b/src/data/eips/7708.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7745.json
+++ b/src/data/eips/7745.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7778.json
+++ b/src/data/eips/7778.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7791.json
+++ b/src/data/eips/7791.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7793.json
+++ b/src/data/eips/7793.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7819.json
+++ b/src/data/eips/7819.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7823.json
+++ b/src/data/eips/7823.json
@@ -14,9 +14,7 @@
       "forkName": "Fusaka",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7825.json
+++ b/src/data/eips/7825.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7840.json
+++ b/src/data/eips/7840.json
@@ -14,9 +14,7 @@
       "forkName": "Pectra",
       "statusHistory": [
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7843.json
+++ b/src/data/eips/7843.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7872.json
+++ b/src/data/eips/7872.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7883.json
+++ b/src/data/eips/7883.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7892.json
+++ b/src/data/eips/7892.json
@@ -18,9 +18,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7903.json
+++ b/src/data/eips/7903.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7907.json
+++ b/src/data/eips/7907.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7910.json
+++ b/src/data/eips/7910.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ],
       "layer": "EL"

--- a/src/data/eips/7917.json
+++ b/src/data/eips/7917.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7918.json
+++ b/src/data/eips/7918.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7923.json
+++ b/src/data/eips/7923.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7932.json
+++ b/src/data/eips/7932.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7934.json
+++ b/src/data/eips/7934.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7935.json
+++ b/src/data/eips/7935.json
@@ -18,9 +18,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7939.json
+++ b/src/data/eips/7939.json
@@ -19,9 +19,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7949.json
+++ b/src/data/eips/7949.json
@@ -24,9 +24,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7951.json
+++ b/src/data/eips/7951.json
@@ -34,9 +34,7 @@
           "date": null
         },
         {
-          "status": "Included",
-          "call": null,
-          "date": null
+          "status": "Included"
         }
       ]
     }

--- a/src/data/eips/7971.json
+++ b/src/data/eips/7971.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7973.json
+++ b/src/data/eips/7973.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7979.json
+++ b/src/data/eips/7979.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7997.json
+++ b/src/data/eips/7997.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/7999.json
+++ b/src/data/eips/7999.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Withdrawn",

--- a/src/data/eips/8011.json
+++ b/src/data/eips/8011.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8013.json
+++ b/src/data/eips/8013.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8024.json
+++ b/src/data/eips/8024.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/8030.json
+++ b/src/data/eips/8030.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8032.json
+++ b/src/data/eips/8032.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8037.json
+++ b/src/data/eips/8037.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8038.json
+++ b/src/data/eips/8038.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/8045.json
+++ b/src/data/eips/8045.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/8051.json
+++ b/src/data/eips/8051.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8053.json
+++ b/src/data/eips/8053.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8057.json
+++ b/src/data/eips/8057.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8058.json
+++ b/src/data/eips/8058.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8059.json
+++ b/src/data/eips/8059.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8062.json
+++ b/src/data/eips/8062.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8068.json
+++ b/src/data/eips/8068.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/data/eips/8070.json
+++ b/src/data/eips/8070.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Considered",

--- a/src/data/eips/8071.json
+++ b/src/data/eips/8071.json
@@ -14,9 +14,7 @@
       "forkName": "Glamsterdam",
       "statusHistory": [
         {
-          "status": "Proposed",
-          "call": null,
-          "date": null
+          "status": "Proposed"
         },
         {
           "status": "Declined",

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -5,13 +5,23 @@ export interface ClientTeamPerspective {
   candidateBlogPostUrl?: string; // For non-headliner (CFI/PFI) commentary
 }
 
+// Statuses not tied to ACD calls
+type NonAcdStatus = {
+  status: 'Proposed' | 'Included';
+};
+
+// Statuses decided in ACD calls (null allowed for legacy data)
+type AcdStatus = {
+  status: 'Considered' | 'Scheduled' | 'Declined' | 'Withdrawn';
+  call: `${'acdc' | 'acde' | 'acdt'}/${number}` | null;
+  date: string | null;
+};
+
+export type ForkStatus = NonAcdStatus | AcdStatus;
+
 export interface ForkRelationship {
   forkName: string;
-  statusHistory: Array<{
-    status: 'Proposed' | 'Considered' | 'Scheduled' | 'Declined' | 'Included' | 'Withdrawn';
-    call: `${'acdc' | 'acde' | 'acdt'}/${number}` | null;
-    date: string | null;
-  }>; // Ordered oldest -> newest
+  statusHistory: ForkStatus[]; // Ordered oldest -> newest
   isHeadliner?: boolean;
   wasHeadlinerCandidate?: boolean;
   headlinerDiscussionLink?: string;


### PR DESCRIPTION
## Summary
- Statuses decided outside ACD calls (`Proposed`, `Included`) no longer have `call`/`date` fields
- Statuses decided in ACD calls (`Considered`, `Scheduled`, `Declined`, `Withdrawn`) require `call`/`date` (null allowed for legacy data)
- Removes 73 unnecessary null values from Proposed/Included entries

## Validation
Schema now enforces:
- Adding `call`/`date` to Proposed/Included → fails validation
- Omitting `call`/`date` from Considered/Scheduled/Declined/Withdrawn → fails validation