### PR TITLE
Add presentationHistory to ForkRelationship

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -51,7 +51,36 @@
         "wasHeadlinerCandidate": { "type": "boolean" },
         "headlinerDiscussionLink": { "type": "string" },
         "layer": { "type": "string" },
-        "champion": { "$ref": "#/$defs/Champion" }
+        "champion": { "$ref": "#/$defs/Champion" },
+        "presentationHistory": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PresentationHistoryEntry" }
+        }
+      }
+    },
+    "PresentationHistoryEntry": {
+      "type": "object",
+      "required": ["date"],
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["call"] },
+        { "required": ["link"] }
+      ],
+      "properties": {
+        "call": {
+          "type": "string",
+          "pattern": "^(acdc|acde|acdt)/[0-9]+$"
+        },
+        "link": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "headlinerProposal": {
+          "type": "boolean"
+        }
       }
     },
     "StatusHistoryEntry": {

--- a/src/data/eips/7692.json
+++ b/src/data/eips/7692.json
@@ -26,7 +26,10 @@
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
       "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464",
-      "layer": "EL"
+      "layer": "EL",
+      "presentationHistory": [
+        { "call": "acdc/159", "date": "2025-06-26", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This introduces a new container format for EVM bytecode that enables code versioning, removes complex jump analysis, and paves the way for new execution environments like RISC-V and EVM64 within the same contract. This EIP was Declined for Inclusion from Fusaka on [April 28th](https://blog.ethereum.org/2025/04/29/checkpoint-2#eof) due to a lack of consensus on implementation details and the resulting potential slowdown of shipping PeerDAS. It has been re-proposed as a headlining feature in Glamsterdam with multiple variants to address community concerns.",

--- a/src/data/eips/7732.json
+++ b/src/data/eips/7732.json
@@ -36,7 +36,10 @@
       "champion": {
         "name": "potuz",
         "discord": "potuz"
-      }
+      },
+      "presentationHistory": [
+        { "call": "acdc/158", "date": "2025-05-29", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "Proposes the decoupling of the consensus block from the execution payload, both in broadcast and validation. This feature enables L1 scaling by significantly changing the time required to both broadcast and executing the payload together with all the blob data, from the current ~2 seconds to aproximately ~9 seconds. It allows for a maximum portion of the slot to be spent in propagation large data.",

--- a/src/data/eips/7782.json
+++ b/src/data/eips/7782.json
@@ -22,7 +22,10 @@
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
       "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7782-the-case-for-2x-shorter-slot-times-in-glamsterdam/24616",
-      "layer": "CL"
+      "layer": "CL",
+      "presentationHistory": [
+        { "call": "acdc/159", "date": "2025-06-26", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This reduces Ethereum's slot time from 12 seconds to 6 seconds, making Ethereum a better confirmation engine for apps and rollups. Everyone benefits: users get faster confirmations with better censorship resistance, DeFi gets more efficient trading with lower fees, stakers get lower reward variability, and nodes get better resource utilization with smoother bandwidth usage.",

--- a/src/data/eips/7805.json
+++ b/src/data/eips/7805.json
@@ -41,7 +41,10 @@
       "champion": {
         "name": "soispoke",
         "discord": "soispoke"
-      }
+      },
+      "presentationHistory": [
+        { "call": "acdc/158", "date": "2025-05-29", "headlinerProposal": true }
+      ]
     },
     {
       "forkName": "Hegota",

--- a/src/data/eips/7886.json
+++ b/src/data/eips/7886.json
@@ -16,7 +16,10 @@
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
       "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500",
-      "layer": "EL"
+      "layer": "EL",
+      "presentationHistory": [
+        { "link": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500", "date": "2025-06-09", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "Lets validators attest before execution by deferring execution outputs, improving throughput headroom.",

--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -36,7 +36,10 @@
       "champion": {
         "name": "Etan Kissling",
         "discord": "etan_status"
-      }
+      },
+      "presentationHistory": [
+        { "call": "acde/214", "date": "2025-06-19", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This enables Ethereum nodes to provide cryptographic proofs with their responses, eliminating the need to trust RPC providers. Users can verify that data from any source is authentic without running their own full node.",

--- a/src/data/eips/7928.json
+++ b/src/data/eips/7928.json
@@ -26,7 +26,10 @@
       "champion": {
         "name": "Toni Wahrstätter",
         "discord": "nero_eth"
-      }
+      },
+      "presentationHistory": [
+        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This introduces access lists at the block level rather than individual transactions, dramatically reducing gas costs for applications that access similar state and enabling new optimization patterns.",

--- a/src/data/eips/7937.json
+++ b/src/data/eips/7937.json
@@ -16,7 +16,10 @@
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
       "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-evm64/24311",
-      "layer": "EL"
+      "layer": "EL",
+      "presentationHistory": [
+        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This is the core EIP of the EVM64 collection, introducing 64-bit arithmetic operations to the EVM. The full EVM64 suite includes multiple EIPs enabling much more efficient mathematical computations by adding 64-bit operations alongside existing 256-bit ones.",

--- a/src/data/eips/7942.json
+++ b/src/data/eips/7942.json
@@ -16,7 +16,10 @@
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
       "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-available-attestation/24377",
-      "layer": "CL"
+      "layer": "CL",
+      "presentationHistory": [
+        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+      ]
     }
   ],
   "laymanDescription": "This is a comprehensive solution to eliminate all known reorganization attacks on Ethereum. Instead of fixing attacks one-by-one, Available Attestation redesigns how consensus works to make reorg attacks fundamentally impossible.",

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -17,6 +17,12 @@ export interface ForkRelationship {
   headlinerDiscussionLink?: string;
   layer?: string;
   champion?: Champion;
+  presentationHistory?: Array<{
+    call?: `${'acdc' | 'acde' | 'acdt'}/${number}`;
+    link?: string;
+    date: string;
+    headlinerProposal?: boolean;
+  }>;
 }
 
 export interface Champion {


### PR DESCRIPTION
Tracks when EIPs are presented at ACD calls or proposed via forum posts, distinct from inclusion status changes. Seeds 9 Glamsterdam headliner candidates with presentation data.