### PR TITLE
Add presentationHistory to ForkRelationship

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -49,7 +49,6 @@
         },
         "isHeadliner": { "type": "boolean" },
         "wasHeadlinerCandidate": { "type": "boolean" },
-        "headlinerDiscussionLink": { "type": "string" },
         "layer": { "type": "string" },
         "champion": { "$ref": "#/$defs/Champion" },
         "presentationHistory": {
@@ -60,13 +59,19 @@
     },
     "PresentationHistoryEntry": {
       "type": "object",
-      "required": ["date"],
+      "required": ["type", "date"],
       "additionalProperties": false,
-      "anyOf": [
-        { "required": ["call"] },
-        { "required": ["link"] }
-      ],
       "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "headliner_proposal",
+            "headliner_presentation",
+            "presentation",
+            "debate"
+          ],
+          "description": "Type of presentation event: headliner_proposal (forum post), headliner_presentation (initial call), presentation (regular call), debate (follow-up discussion)"
+        },
         "call": {
           "type": "string",
           "pattern": "^(acdc|acde|acdt)/[0-9]+$"
@@ -77,11 +82,26 @@
         "date": {
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-        },
-        "headlinerProposal": {
-          "type": "boolean"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "headliner_proposal" } }
+          },
+          "then": { "required": ["link"] }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["headliner_presentation", "presentation", "debate"]
+              }
+            }
+          },
+          "then": { "required": ["call"] }
+        }
+      ]
     },
     "StatusHistoryEntry": {
       "type": "object",

--- a/src/data/eips/7692.json
+++ b/src/data/eips/7692.json
@@ -25,10 +25,13 @@
       "statusHistory": [],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464",
       "layer": "EL",
       "presentationHistory": [
-        { "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464", "date": "2025-06-05", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-eof/24464",
+          "date": "2025-06-05"
+        }
       ]
     }
   ],

--- a/src/data/eips/7732.json
+++ b/src/data/eips/7732.json
@@ -31,14 +31,22 @@
       ],
       "isHeadliner": true,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7732-the-case-for-inclusion-in-glamsterdam/24306",
       "layer": "CL",
       "champion": {
         "name": "potuz",
         "discord": "potuz"
       },
       "presentationHistory": [
-        { "call": "acdc/158", "date": "2025-05-29", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/eip-7732-the-case-for-inclusion-in-glamsterdam/24306",
+          "date": "2025-05-22"
+        },
+        {
+          "date": "2025-05-29",
+          "type": "headliner_presentation",
+          "call": "acdc/158"
+        }
       ]
     }
   ],

--- a/src/data/eips/7782.json
+++ b/src/data/eips/7782.json
@@ -21,10 +21,18 @@
       ],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7782-the-case-for-2x-shorter-slot-times-in-glamsterdam/24616",
       "layer": "CL",
       "presentationHistory": [
-        { "call": "acdc/159", "date": "2025-06-26", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/eip-7782-the-case-for-2x-shorter-slot-times-in-glamsterdam/24616",
+          "date": "2025-06-20"
+        },
+        {
+          "date": "2025-06-26",
+          "type": "headliner_presentation",
+          "call": "acdc/159"
+        }
       ]
     }
   ],

--- a/src/data/eips/7805.json
+++ b/src/data/eips/7805.json
@@ -36,14 +36,22 @@
       ],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7805-fork-choice-inclusion-lists-focil-as-a-candidate-for-glamsterdam/24342",
       "layer": "CL",
       "champion": {
         "name": "soispoke",
         "discord": "soispoke"
       },
       "presentationHistory": [
-        { "call": "acdc/158", "date": "2025-05-29", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/eip-7805-fork-choice-inclusion-lists-focil-as-a-candidate-for-glamsterdam/24342",
+          "date": "2025-05-26"
+        },
+        {
+          "date": "2025-05-29",
+          "type": "headliner_presentation",
+          "call": "acdc/158"
+        }
       ]
     },
     {
@@ -56,12 +64,12 @@
         }
       ],
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7805-fork-choice-inclusion-lists-focil-as-a-candidate-for-glamsterdam/24342",
       "layer": "CL",
       "champion": {
         "name": "soispoke",
         "discord": "soispoke"
-      }
+      },
+      "presentationHistory": []
     }
   ],
   "laymanDescription": "FOCIL empowers multiple validators to mandate the inclusion of specific transactions in each block, thereby improving the network's censorship resistance properties.",

--- a/src/data/eips/7886.json
+++ b/src/data/eips/7886.json
@@ -15,10 +15,13 @@
       "statusHistory": [],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500",
       "layer": "EL",
       "presentationHistory": [
-        { "link": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500", "date": "2025-06-09", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/eip-7886-delayed-execution-the-case-for-glamsterdam/24500",
+          "date": "2025-06-09"
+        }
       ]
     }
   ],

--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -31,14 +31,22 @@
       ],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-pureth/24459",
       "layer": "EL",
       "champion": {
         "name": "Etan Kissling",
         "discord": "etan_status"
       },
       "presentationHistory": [
-        { "call": "acde/214", "date": "2025-06-19", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-pureth/24459",
+          "date": "2025-06-05"
+        },
+        {
+          "date": "2025-06-19",
+          "type": "headliner_presentation",
+          "call": "acde/214"
+        }
       ]
     }
   ],

--- a/src/data/eips/7928.json
+++ b/src/data/eips/7928.json
@@ -21,14 +21,22 @@
       ],
       "isHeadliner": true,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/eip-7928-block-level-access-lists-the-case-for-glamsterdam/24343",
       "layer": "EL",
       "champion": {
         "name": "Toni Wahrstätter",
         "discord": "nero_eth"
       },
       "presentationHistory": [
-        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/eip-7928-block-level-access-lists-the-case-for-glamsterdam/24343",
+          "date": "2025-05-26"
+        },
+        {
+          "date": "2025-06-05",
+          "type": "headliner_presentation",
+          "call": "acde/213"
+        }
       ]
     }
   ],

--- a/src/data/eips/7937.json
+++ b/src/data/eips/7937.json
@@ -15,10 +15,18 @@
       "statusHistory": [],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-evm64/24311",
       "layer": "EL",
       "presentationHistory": [
-        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-evm64/24311",
+          "date": "2025-05-22"
+        },
+        {
+          "date": "2025-06-05",
+          "type": "headliner_presentation",
+          "call": "acde/213"
+        }
       ]
     }
   ],

--- a/src/data/eips/7942.json
+++ b/src/data/eips/7942.json
@@ -15,10 +15,18 @@
       "statusHistory": [],
       "isHeadliner": false,
       "wasHeadlinerCandidate": true,
-      "headlinerDiscussionLink": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-available-attestation/24377",
       "layer": "CL",
       "presentationHistory": [
-        { "call": "acde/213", "date": "2025-06-05", "headlinerProposal": true }
+        {
+          "type": "headliner_proposal",
+          "link": "https://ethereum-magicians.org/t/glamsterdam-headliner-proposal-available-attestation/24377",
+          "date": "2025-05-29"
+        },
+        {
+          "date": "2025-06-05",
+          "type": "headliner_presentation",
+          "call": "acde/213"
+        }
       ]
     }
   ],

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -14,14 +14,13 @@ export interface ForkRelationship {
   }>; // Ordered oldest -> newest
   isHeadliner?: boolean;
   wasHeadlinerCandidate?: boolean;
-  headlinerDiscussionLink?: string;
   layer?: string;
   champion?: Champion;
   presentationHistory?: Array<{
+    type: 'headliner_proposal' | 'headliner_presentation' | 'presentation' | 'debate';
     call?: `${'acdc' | 'acde' | 'acdt'}/${number}`;
     link?: string;
     date: string;
-    headlinerProposal?: boolean;
   }>;
 }
 

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -34,6 +34,7 @@ export const getInclusionStage = (eip: EIP, forkName?: string): InclusionStage =
 
 /**
  * Get the headliner discussion link for an EIP in a specific fork
+ * Looks for a headliner_proposal entry in presentationHistory
  */
 export const getHeadlinerDiscussionLink = (eip: EIP, forkName?: string): string | null => {
   if (!forkName) return null;
@@ -41,7 +42,14 @@ export const getHeadlinerDiscussionLink = (eip: EIP, forkName?: string): string 
   const forkRelationship = eip.forkRelationships.find(fork =>
     fork.forkName.toLowerCase() === forkName.toLowerCase()
   );
-  return forkRelationship?.headlinerDiscussionLink || null;
+
+  if (!forkRelationship?.presentationHistory) return null;
+
+  const headlinerProposal = forkRelationship.presentationHistory.find(
+    p => p.type === 'headliner_proposal'
+  );
+
+  return headlinerProposal?.link || null;
 };
 
 /**


### PR DESCRIPTION
Tracks when EIPs are presented at ACD calls or proposed via forum posts, distinct from inclusion status changes. Seeds 9 Glamsterdam headliner candidates with presentation data.

I also included frontend changes as an example, but in a separate commit. Happy to remove/iterate frontend changes as I didn't get a chance to tidy it up.

<img width="744" height="217" alt="image" src="https://github.com/user-attachments/assets/f86341cb-11cb-4915-a445-665806e0cd05" />