### PR TITLE
Changes based on ACDE #228

### DIFF
--- a/src/data/eips/5920.json
+++ b/src/data/eips/5920.json
@@ -27,6 +27,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7793.json
+++ b/src/data/eips/7793.json
@@ -27,6 +27,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7903.json
+++ b/src/data/eips/7903.json
@@ -27,6 +27,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7907.json
+++ b/src/data/eips/7907.json
@@ -27,6 +27,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/7971.json
+++ b/src/data/eips/7971.json
@@ -17,6 +17,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8032.json
+++ b/src/data/eips/8032.json
@@ -17,6 +17,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",

--- a/src/data/eips/8051.json
+++ b/src/data/eips/8051.json
@@ -17,6 +17,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/228",
+          "date": "2025-01-15"
         }
       ],
       "layer": "EL",


### PR DESCRIPTION
Based on ACDE #228 the following EIPs were CFI and DFI for Glamsterdam

CFI EIPs: 7954 (Need to be added in forkcast)

DFI EIPs: 5920, 7903, 7907, 7971, 7793, 8032, 8051

Decision delayed (ACDT Jan 19th) on EIP: 8037