### PR TITLE
Fix dark mode flicker on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <script>
+      try {
+        const theme = localStorage.getItem('theme');
+        const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches;
+        if (theme === 'dark' || (theme !== 'light' && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/ethereum-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,48 +1,26 @@
-import React from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
 
-const ThemeToggle: React.FC = () => {
-  const { theme, toggleTheme } = useTheme();
+export default function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
 
   return (
     <button
-      onClick={toggleTheme}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
       className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 transition-colors"
-      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
     >
-      {theme === 'light' ? (
-        // Moon icon for dark mode
-        <svg
-          className="w-5 h-5 text-slate-700 dark:text-slate-300"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-          />
+      {isDark ? (
+        // Sun icon (click to switch to light)
+        <svg className="w-5 h-5 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
         </svg>
       ) : (
-        // Sun icon for light mode
-        <svg
-          className="w-5 h-5 text-slate-300"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-          />
+        // Moon icon (click to switch to dark)
+        <svg className="w-5 h-5 text-slate-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
         </svg>
       )}
     </button>
   );
 };
-
-export default ThemeToggle;


### PR DESCRIPTION
## Problem

Dark mode flickers on hard refresh. With dark mode set, the page briefly flashes white and some components render in light mode before correcting.

## Solution

Add an inline script that applies the theme **synchronously before first paint**. This is the standard technique used by [next-themes](https://github.com/pacocoursey/next-themes) and [Svelte mode-watcher](https://github.com/svecosystem/mode-watcher).

### API

Following the next-themes/mode-watcher pattern, we expose:

```ts
const { theme, resolvedTheme, setTheme } = useTheme();

// theme: 'light' | 'dark' | 'system' (user's preference)
// resolvedTheme: 'light' | 'dark' (actual applied theme)
// setTheme: update the preference
```

### Changes

| File | Change | +/- |
|------|--------|-----|
| `index.html` | inline script | +9 |
| `ThemeContext.tsx` | provider with `resolvedTheme` | +42 / -51 |
| `ThemeToggle.tsx` | uses `resolvedTheme` | +11 / -37 |

New users default to OS preference (`system` theme).

## Demo

<!-- 
📹 Record a short clip showing:
1. Hard refresh in dark mode → no flicker
2. Hard refresh in light mode → no flicker  
3. Toggle working
-->


https://github.com/user-attachments/assets/cbcb07df-4c68-46db-897c-baec253c9e33


---

🤖 Generated with [Claude Code](https://claude.ai/code)

🔍 Reviewed by [Codex](https://codex.openai.com)