### PR TITLE
Changes based on ACDE#229

### DIFF
--- a/src/data/eips/7610.json
+++ b/src/data/eips/7610.json
@@ -18,6 +18,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Considered",
+          "call": "acde/229",
+          "date": "2026-01-29"
         }
       ],
       "champion": {

--- a/src/data/eips/7872.json
+++ b/src/data/eips/7872.json
@@ -18,6 +18,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/229",
+          "date": "2026-01-29"
         }
       ],
       "champion": {

--- a/src/data/eips/7949.json
+++ b/src/data/eips/7949.json
@@ -28,6 +28,11 @@
           "status": "Proposed",
           "call": null,
           "date": null
+        },
+        {
+          "status": "Declined",
+          "call": "acde/229",
+          "date": "2026-01-29"
         }
       ],
       "champion": {


### PR DESCRIPTION
Based on ACDE #229 (2026-01-29) the following EIPs were CFI and DFI for Glamsterdam  
CFI EIPs: 7610 (For now)  
DFI EIPs: 7872, 7949