### PR TITLE
feat: add devnet spec page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+
+FROM base AS dev
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+
+FROM base AS build
+RUN npm run build
+
+FROM nginx:alpine AS prod
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: install dev build lint format format-check preview clean validate-eips sync-calls docker-dev docker-build
+
+install: ## Install dependencies
+	npm ci
+
+dev: ## Start local dev server
+	npm run dev
+
+build: ## Production build
+	npm run build
+
+preview: ## Preview production build locally
+	npm run preview
+
+lint: ## Run ESLint
+	npm run lint
+
+format: ## Format code with Prettier
+	npm run format
+
+format-check: ## Check code formatting
+	npm run format:check
+
+validate-eips: ## Validate EIP metadata
+	npm run validate-eips
+
+sync-calls: ## Sync call assets (transcripts, chat logs)
+	npm run sync-calls
+
+clean: ## Remove build artifacts
+	rm -rf dist node_modules/.vite
+
+docker-dev: ## Start dev server via Docker (no node/npm required)
+	docker compose up --build dev
+
+docker-build: ## Production build via Docker
+	docker build --target prod -t forkcast .
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ Additional personas served in various capacities:
 * App developers
 * End users and enthusiasts
 
+### Development
+
+**With Docker (recommended):**
+
+```bash
+git clone https://github.com/ethereum/forkcast.git
+cd forkcast
+make docker-dev
+```
+
+**Without Docker:**
+
+```bash
+git clone https://github.com/ethereum/forkcast.git
+cd forkcast
+make install
+make dev
+```
+
+Open http://localhost:5173 in your browser.
+
+Run `make help` for all available commands.
+
 ### How we serve
 
 Forkcast:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  dev:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "5173:5173"
+    volumes:
+      - .:/app
+      - /app/node_modules

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "generate-configs": "node scripts/generate-configs.cjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "sync-calls": "node scripts/sync-call-assets.mjs"
+    "sync-calls": "node scripts/sync-call-assets.mjs",
+    "fetch-pr-statuses": "node scripts/fetch-pr-statuses.mjs"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",

--- a/scripts/fetch-pr-statuses.mjs
+++ b/scripts/fetch-pr-statuses.mjs
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEVNET_SPECS_DIR = path.join(__dirname, '../src/data/devnet-specs');
+
+async function fetchEIPLatestCommit(eipId) {
+  try {
+    const result = execSync(
+      `gh api repos/ethereum/EIPs/commits?path=EIPS/eip-${eipId}.md&per_page=1`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    const commits = JSON.parse(result);
+    if (commits.length > 0) {
+      return commits[0].sha;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPRStatus(repo, number) {
+  try {
+    const result = execSync(`gh api repos/${repo}/pulls/${number}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const data = JSON.parse(result);
+
+    let state;
+    if (data.merged_at) {
+      state = 'merged';
+    } else if (data.draft) {
+      state = 'draft';
+    } else if (data.state === 'closed') {
+      state = 'closed';
+    } else {
+      state = 'open';
+    }
+
+    return {
+      state,
+      title: data.title,
+      headSha: state === 'merged' ? data.merge_commit_sha : data.head?.sha,
+    };
+  } catch (error) {
+    throw new Error(`Failed to fetch PR ${repo}#${number}: ${error.message}`);
+  }
+}
+
+async function fetchAllPRStatuses() {
+  console.log('Fetching PR statuses from GitHub using gh CLI...');
+
+  if (!fs.existsSync(DEVNET_SPECS_DIR)) {
+    console.error(`Error: Devnet specs directory not found at ${DEVNET_SPECS_DIR}`);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(DEVNET_SPECS_DIR).filter(f => f.endsWith('.json'));
+
+  if (files.length === 0) {
+    console.log('No devnet spec files found.');
+    return;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(DEVNET_SPECS_DIR, file);
+    console.log(`\nProcessing ${file}...`);
+
+    const spec = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+    if (spec.eips && spec.eips.length > 0) {
+      console.log('  Fetching EIP commits...');
+      for (const eip of spec.eips) {
+        if (eip.changeStatus === 'new' || eip.changeStatus === 'updated') {
+          const sha = await fetchEIPLatestCommit(eip.id);
+          if (sha) {
+            eip.lastCommitSha = sha;
+            console.log(`  ✓ EIP-${eip.id}: ${sha.substring(0, 7)}`);
+          }
+          await new Promise(r => setTimeout(r, 100));
+        }
+      }
+    }
+
+    if (!spec.prs || spec.prs.length === 0) {
+      console.log('  No PRs to fetch.');
+      fs.writeFileSync(filePath, JSON.stringify(spec, null, 2) + '\n');
+      continue;
+    }
+
+    console.log('  Fetching PR statuses...');
+    let updated = 0;
+    let skipped = 0;
+    for (const pr of spec.prs) {
+      if (pr.status === 'merged' || pr.status === 'closed') {
+        console.log(`  - ${pr.repo}#${pr.number}: ${pr.status} (cached)`);
+        skipped++;
+        continue;
+      }
+      try {
+        const status = await fetchPRStatus(pr.repo, pr.number);
+        pr.status = status.state;
+        pr.title = status.title;
+        pr.headSha = status.headSha;
+        console.log(`  ✓ ${pr.repo}#${pr.number}: ${status.state}`);
+        updated++;
+        await new Promise(r => setTimeout(r, 100));
+      } catch (error) {
+        console.error(`  ✗ ${pr.repo}#${pr.number}: ${error.message}`);
+      }
+    }
+    if (skipped > 0) {
+      console.log(`  Skipped ${skipped} merged/closed PRs`);
+    }
+
+    fs.writeFileSync(filePath, JSON.stringify(spec, null, 2) + '\n');
+    console.log(`  Updated ${updated}/${spec.prs.length} PRs in ${file}`);
+  }
+
+  console.log('\n✓ PR status fetch complete!');
+}
+
+fetchAllPRStatuses().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { StakeholderUpgradePage } from './components/stakeholder';
 import ComplexityPage from './components/ComplexityPage';
 import PrioritizationPage from './components/PrioritizationPage';
 import DevnetPrioritizationPage from './components/DevnetPrioritizationPage';
+import DevnetSpecPage from './components/DevnetSpecPage';
 import { getUpgradeById } from './data/upgrades';
 import { useAnalytics } from './hooks/useAnalytics';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -131,6 +132,7 @@ function App() {
           <Route path="/complexity" element={<ComplexityPage />} />
           <Route path="/priority" element={<PrioritizationPage />} />
           <Route path="/devnets" element={<DevnetPrioritizationPage />} />
+          <Route path="/devnets/:id" element={<DevnetSpecPage />} />
           {/* Catch-all route that redirects to home page */}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/src/components/DevnetPrioritizationPage.tsx
+++ b/src/components/DevnetPrioritizationPage.tsx
@@ -624,6 +624,13 @@ const DevnetPrioritizationPage: React.FC = () => {
 
                     {/* Right: Actions */}
                     <div className="flex items-center gap-3 shrink-0">
+                      <Link
+                        to={`/devnets/${devnet.id}`}
+                        onClick={(e) => e.stopPropagation()}
+                        className="hidden sm:inline-flex items-center gap-1 text-xs text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 transition-colors"
+                      >
+                        <span className="underline decoration-1 underline-offset-2">Spec Sheet</span>
+                      </Link>
                       <a
                         href={notesUrl}
                         target="_blank"

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -1,0 +1,705 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Logo } from './ui/Logo';
+import ThemeToggle from './ui/ThemeToggle';
+import { useDevnetSpec } from '../hooks/useDevnetSpec';
+import { useMetaTags } from '../hooks/useMetaTags';
+import { ImplementationStatus, DevnetSpecPR } from '../types/devnet-spec';
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function ChangeStatusBadge({ status, commitSha }: { status: string; commitSha?: string }) {
+  const baseClasses = 'px-1.5 py-0.5 text-[10px] font-semibold rounded-full uppercase tracking-wide';
+
+  let colorClasses = '';
+  let label = '';
+
+  switch (status) {
+    case 'new':
+      colorClasses = 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300';
+      label = 'new';
+      break;
+    case 'updated':
+      colorClasses = 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300';
+      label = 'updated';
+      break;
+    default:
+      return null;
+  }
+
+  if (commitSha) {
+    return (
+      <a
+        href={`https://github.com/ethereum/EIPs/commit/${commitSha}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${baseClasses} ${colorClasses} hover:opacity-80`}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <span className={`${baseClasses} ${colorClasses}`}>
+      {label}
+    </span>
+  );
+}
+
+function ImplStatusCell({ status }: { status: ImplementationStatus }) {
+  switch (status) {
+    case 'done':
+      return (
+        <span className="inline-flex items-center justify-center size-6 rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400" title="Done">
+          <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </span>
+      );
+    case 'in-progress':
+      return (
+        <span className="inline-flex items-center justify-center size-6 rounded-full bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400" title="In Progress">
+          <svg className="size-4" fill="currentColor" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="5" />
+          </svg>
+        </span>
+      );
+    case 'not-started':
+      return (
+        <span className="inline-flex items-center justify-center size-6 rounded-full bg-red-100 text-red-500 dark:bg-red-900/30 dark:text-red-400" title="Not Started">
+          <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center justify-center size-6 rounded-full bg-slate-100 text-slate-400 dark:bg-slate-700 dark:text-slate-500" title="Unknown">
+          ?
+        </span>
+      );
+  }
+}
+
+function PRStatusBadge({ pr }: { pr: DevnetSpecPR }) {
+  if (!pr.status) {
+    return (
+      <span className="px-2 py-0.5 text-xs rounded-full bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+        unknown
+      </span>
+    );
+  }
+
+  const commitUrl = pr.headSha ? `https://github.com/${pr.repo}/commit/${pr.headSha}` : undefined;
+  const badgeClasses: Record<NonNullable<DevnetSpecPR['status']>, string> = {
+    merged: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+    open: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+    closed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    draft: 'bg-slate-200 text-slate-600 dark:bg-slate-600 dark:text-slate-300',
+  };
+
+  if (commitUrl) {
+    return (
+      <a
+        href={commitUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`px-2 py-0.5 text-xs font-medium rounded-full hover:opacity-80 ${badgeClasses[pr.status]}`}
+      >
+        {pr.status}
+      </a>
+    );
+  }
+
+  return (
+    <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${badgeClasses[pr.status]}`}>
+      {pr.status}
+    </span>
+  );
+}
+
+const DevnetSpecPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { spec, loading, error } = useDevnetSpec(id);
+
+  useMetaTags({
+    title: spec ? `${spec.id} Spec Sheet - Forkcast` : 'Devnet Spec Sheet - Forkcast',
+    description: spec
+      ? `Spec sheet for ${spec.id}: EIP list, client implementation matrix, and PR tracker.`
+      : 'Devnet spec sheet with EIP list, implementation matrix, and PR tracker.',
+    url: `https://forkcast.org/devnets/${id}`,
+  });
+
+  if (loading) {
+    return (
+      <div className="min-h-dvh bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
+        <div className="max-w-5xl mx-auto">
+          <Logo size="md" className="mb-4" />
+          <div className="flex items-center justify-center py-20">
+            <svg className="size-6 animate-spin text-purple-600" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !spec) {
+    return (
+      <div className="min-h-dvh bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
+        <div className="max-w-5xl mx-auto">
+          <Logo size="md" className="mb-4" />
+          <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-8 text-center">
+            <h2 className="text-lg font-semibold mb-2">Spec sheet not found</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+              No spec sheet exists for devnet "{id}".
+            </p>
+            <Link
+              to="/devnets"
+              className="text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 underline"
+            >
+              Back to devnets
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const elClients = spec.implementations.el.length > 0
+    ? Object.keys(spec.implementations.el[0].clients).sort()
+    : [];
+  const clClients = spec.implementations.cl.length > 0
+    ? Object.keys(spec.implementations.cl[0].clients).sort()
+    : [];
+
+  const eipPrMap = new Map<number, typeof spec.prs>();
+  for (const pr of spec.prs) {
+    if (pr.eipId) {
+      const existing = eipPrMap.get(pr.eipId) || [];
+      existing.push(pr);
+      eipPrMap.set(pr.eipId, existing);
+    }
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-8 relative">
+          <div className="absolute top-0 right-0">
+            <ThemeToggle />
+          </div>
+          <Logo size="md" className="mb-4" />
+          <div className="flex items-center gap-3 mb-2 flex-wrap">
+            <Link
+              to="/devnets"
+              className="text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+            >
+              Devnets
+            </Link>
+            <span className="text-slate-300 dark:text-slate-600">/</span>
+            <h1 className="text-xl font-semibold">{spec.id}</h1>
+            <span className="px-2 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded">
+              {spec.upgrade}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-4 text-sm text-slate-500 dark:text-slate-400 mt-2">
+            {spec.launchDate && (
+              <div className="flex items-center gap-1.5">
+                <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span>Launch: {formatDate(spec.launchDate)}</span>
+              </div>
+            )}
+            <div className="flex items-center gap-1.5">
+              <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>Updated: {formatDate(spec.lastUpdated)}</span>
+            </div>
+          </div>
+
+          {/* Spec Versions */}
+          <div className="flex flex-wrap gap-2 mt-3">
+            {spec.specVersions.consensusSpecs && (
+              <span className="px-2 py-0.5 text-xs bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 rounded">
+                Consensus Specs: {spec.specVersions.consensusSpecs}
+              </span>
+            )}
+            {spec.specVersions.executionSpecs && (
+              <span className="px-2 py-0.5 text-xs bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 rounded">
+                Execution Specs: {spec.specVersions.executionSpecs}
+              </span>
+            )}
+            {spec.specVersions.engineApi && (
+              <span className="px-2 py-0.5 text-xs bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 rounded">
+                Engine API: {spec.specVersions.engineApi}
+              </span>
+            )}
+          </div>
+
+          {/* Notes */}
+          {spec.notes && spec.notes.length > 0 && (
+            <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800/30 rounded-lg">
+              {spec.notes.map((note, i) => (
+                <p key={i} className="text-sm text-amber-800 dark:text-amber-300">{note}</p>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* EIP List */}
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold mb-3">EIP List</h2>
+
+          {/* Desktop Table */}
+          <div className="hidden md:block bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-700/50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400 w-12">Status</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">EIP</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">Title</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">Summary</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">PRs</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                {spec.eips.map((eip) => {
+                  const relatedPrs = eipPrMap.get(eip.id) || [];
+                  return (
+                    <tr key={eip.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                      <td className="px-4 py-2.5">
+                        <ChangeStatusBadge status={eip.changeStatus} commitSha={eip.lastCommitSha} />
+                      </td>
+                      <td className="px-4 py-2.5 whitespace-nowrap">
+                        <Link
+                          to={`/eips/${eip.id}`}
+                          className="font-mono text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                        >
+                          EIP-{eip.id}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-slate-900 dark:text-slate-100">
+                        {eip.title}
+                      </td>
+                      <td className="px-4 py-2.5 text-slate-600 dark:text-slate-400 text-xs">
+                        {eip.summary}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        {relatedPrs.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {relatedPrs.map((pr) => (
+                              <a
+                                key={`${pr.repo}#${pr.number}`}
+                                href={`https://github.com/${pr.repo}/pull/${pr.number}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-xs text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 underline decoration-1 underline-offset-2"
+                              >
+                                #{pr.number}
+                              </a>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-xs text-slate-400 dark:text-slate-500">&mdash;</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile Cards */}
+          <div className="md:hidden flex flex-col gap-2">
+            {spec.eips.map((eip) => {
+              const relatedPrs = eipPrMap.get(eip.id) || [];
+              return (
+                <div key={eip.id} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+                  <div className="flex items-center gap-2 mb-1">
+                    <ChangeStatusBadge status={eip.changeStatus} commitSha={eip.lastCommitSha} />
+                    <Link
+                      to={`/eips/${eip.id}`}
+                      className="font-mono text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                    >
+                      EIP-{eip.id}
+                    </Link>
+                  </div>
+                  <p className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">{eip.title}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mb-2">{eip.summary}</p>
+                  {relatedPrs.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {relatedPrs.map((pr) => (
+                        <a
+                          key={`${pr.repo}#${pr.number}`}
+                          href={`https://github.com/${pr.repo}/pull/${pr.number}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 underline decoration-1 underline-offset-2"
+                        >
+                          #{pr.number}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Implementation Matrix - EL */}
+        {spec.implementations.el.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-1">Execution Layer Implementation</h2>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mb-3">Client readiness per EIP</p>
+
+            {/* Desktop Table */}
+            <div className="hidden md:block bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 dark:bg-slate-700/50">
+                    <tr>
+                      <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">EIP</th>
+                      {elClients.map((client) => (
+                        <th key={client} className="px-3 py-2.5 text-center font-medium text-slate-600 dark:text-slate-400">
+                          {client}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                    {spec.implementations.el.map((row) => {
+                      const eip = spec.eips.find((e) => e.id === row.eipId);
+                      return (
+                        <tr key={row.eipId} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                          <td className="px-4 py-2.5">
+                            <Link
+                              to={`/eips/${row.eipId}`}
+                              className="font-mono text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                            >
+                              EIP-{row.eipId}
+                            </Link>
+                            {eip && (
+                              <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">{eip.title}</span>
+                            )}
+                          </td>
+                          {elClients.map((client) => (
+                            <td key={client} className="px-3 py-2.5 text-center">
+                              <ImplStatusCell status={row.clients[client] || 'unknown'} />
+                            </td>
+                          ))}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Mobile Cards */}
+            <div className="md:hidden flex flex-col gap-2">
+              {spec.implementations.el.map((row) => {
+                const eip = spec.eips.find((e) => e.id === row.eipId);
+                return (
+                  <div key={row.eipId} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+                    <Link
+                      to={`/eips/${row.eipId}`}
+                      className="font-mono text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                    >
+                      EIP-{row.eipId}
+                    </Link>
+                    {eip && <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">{eip.title}</span>}
+                    <div className="mt-2 grid grid-cols-3 gap-2">
+                      {elClients.map((client) => (
+                        <div key={client} className="flex items-center gap-1.5">
+                          <ImplStatusCell status={row.clients[client] || 'unknown'} />
+                          <span className="text-xs text-slate-600 dark:text-slate-400">{client}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Implementation Matrix - CL */}
+        {spec.implementations.cl.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-1">Consensus Layer Implementation</h2>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mb-3">Client readiness per EIP</p>
+
+            {/* Desktop Table */}
+            <div className="hidden md:block bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 dark:bg-slate-700/50">
+                    <tr>
+                      <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">EIP</th>
+                      {clClients.map((client) => (
+                        <th key={client} className="px-3 py-2.5 text-center font-medium text-slate-600 dark:text-slate-400">
+                          {client}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                    {spec.implementations.cl.map((row) => {
+                      const eip = spec.eips.find((e) => e.id === row.eipId);
+                      return (
+                        <tr key={row.eipId} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                          <td className="px-4 py-2.5">
+                            <Link
+                              to={`/eips/${row.eipId}`}
+                              className="font-mono text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                            >
+                              EIP-{row.eipId}
+                            </Link>
+                            {eip && (
+                              <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">{eip.title}</span>
+                            )}
+                          </td>
+                          {clClients.map((client) => (
+                            <td key={client} className="px-3 py-2.5 text-center">
+                              <ImplStatusCell status={row.clients[client] || 'unknown'} />
+                            </td>
+                          ))}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Mobile Cards */}
+            <div className="md:hidden flex flex-col gap-2">
+              {spec.implementations.cl.map((row) => {
+                const eip = spec.eips.find((e) => e.id === row.eipId);
+                return (
+                  <div key={row.eipId} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+                    <Link
+                      to={`/eips/${row.eipId}`}
+                      className="font-mono text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                    >
+                      EIP-{row.eipId}
+                    </Link>
+                    {eip && <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">{eip.title}</span>}
+                    <div className="mt-2 grid grid-cols-3 gap-2">
+                      {clClients.map((client) => (
+                        <div key={client} className="flex items-center gap-1.5">
+                          <ImplStatusCell status={row.clients[client] || 'unknown'} />
+                          <span className="text-xs text-slate-600 dark:text-slate-400">{client}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Implementation Legend */}
+        <div className="mb-8 flex flex-wrap gap-4 text-xs text-slate-500 dark:text-slate-400">
+          <div className="flex items-center gap-1.5">
+            <ImplStatusCell status="done" />
+            <span>Done</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ImplStatusCell status="in-progress" />
+            <span>In Progress</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ImplStatusCell status="not-started" />
+            <span>Not Started</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ImplStatusCell status="unknown" />
+            <span>Unknown</span>
+          </div>
+        </div>
+
+        {/* PR Tracker */}
+        {spec.prs.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-3">Tracked PRs</h2>
+
+            {/* Desktop Table */}
+            <div className="hidden md:block bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 dark:bg-slate-700/50">
+                  <tr>
+                    <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">Repo</th>
+                    <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">PR</th>
+                    <th className="px-4 py-2.5 text-left font-medium text-slate-600 dark:text-slate-400">Description</th>
+                    <th className="px-4 py-2.5 text-center font-medium text-slate-600 dark:text-slate-400">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                  {(() => {
+                    const categoryOrder = ['ethereum/EIPs', 'ethereum/execution-specs', 'ethereum/consensus-specs', 'ethereum/execution-apis'];
+                    const categoryLabels: Record<string, string> = {
+                      'ethereum/EIPs': 'EIPs',
+                      'ethereum/execution-specs': 'Execution Specs',
+                      'ethereum/consensus-specs': 'Consensus Specs',
+                      'ethereum/execution-apis': 'Execution APIs',
+                    };
+                    const groupedPrs = new Map<string, typeof spec.prs>();
+                    for (const pr of spec.prs) {
+                      const existing = groupedPrs.get(pr.repo) || [];
+                      existing.push(pr);
+                      groupedPrs.set(pr.repo, existing);
+                    }
+                    const sortedCategories = [...groupedPrs.keys()].sort((a, b) => {
+                      const aIdx = categoryOrder.indexOf(a);
+                      const bIdx = categoryOrder.indexOf(b);
+                      if (aIdx === -1 && bIdx === -1) return a.localeCompare(b);
+                      if (aIdx === -1) return 1;
+                      if (bIdx === -1) return -1;
+                      return aIdx - bIdx;
+                    });
+                    const rows: React.ReactNode[] = [];
+                    sortedCategories.forEach((repo, catIndex) => {
+                      const prs = groupedPrs.get(repo) || [];
+                      if (catIndex > 0) {
+                        rows.push(
+                          <tr key={`sep-${repo}`}>
+                            <td colSpan={4} className="px-4 py-2 bg-slate-100 dark:bg-slate-700/70">
+                              <span className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">
+                                {categoryLabels[repo] || repo}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      } else {
+                        rows.push(
+                          <tr key={`sep-${repo}`}>
+                            <td colSpan={4} className="px-4 py-2 bg-slate-100 dark:bg-slate-700/70">
+                              <span className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">
+                                {categoryLabels[repo] || repo}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      }
+                      prs.forEach((pr) => {
+                        const key = `${pr.repo}#${pr.number}`;
+                        rows.push(
+                          <tr key={key} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                            <td className="px-4 py-2.5 text-xs text-slate-500 dark:text-slate-400 font-mono">
+                              {pr.repo}
+                            </td>
+                            <td className="px-4 py-2.5">
+                              <a
+                                href={`https://github.com/${pr.repo}/pull/${pr.number}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="font-mono text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                              >
+                                #{pr.number}
+                              </a>
+                            </td>
+                            <td className="px-4 py-2.5 text-slate-900 dark:text-slate-100">
+                              {pr.title || pr.description}
+                            </td>
+                            <td className="px-4 py-2.5 text-center">
+                              <PRStatusBadge pr={pr} />
+                            </td>
+                          </tr>
+                        );
+                      });
+                    });
+                    return rows;
+                  })()}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile Cards */}
+            <div className="md:hidden flex flex-col gap-2">
+              {(() => {
+                const categoryOrder = ['ethereum/EIPs', 'ethereum/execution-specs', 'ethereum/consensus-specs', 'ethereum/execution-apis'];
+                const categoryLabels: Record<string, string> = {
+                  'ethereum/EIPs': 'EIPs',
+                  'ethereum/execution-specs': 'Execution Specs',
+                  'ethereum/consensus-specs': 'Consensus Specs',
+                  'ethereum/execution-apis': 'Execution APIs',
+                };
+                const groupedPrs = new Map<string, typeof spec.prs>();
+                for (const pr of spec.prs) {
+                  const existing = groupedPrs.get(pr.repo) || [];
+                  existing.push(pr);
+                  groupedPrs.set(pr.repo, existing);
+                }
+                const sortedCategories = [...groupedPrs.keys()].sort((a, b) => {
+                  const aIdx = categoryOrder.indexOf(a);
+                  const bIdx = categoryOrder.indexOf(b);
+                  if (aIdx === -1 && bIdx === -1) return a.localeCompare(b);
+                  if (aIdx === -1) return 1;
+                  if (bIdx === -1) return -1;
+                  return aIdx - bIdx;
+                });
+                const items: React.ReactNode[] = [];
+                sortedCategories.forEach((repo) => {
+                  const prs = groupedPrs.get(repo) || [];
+                  items.push(
+                    <div key={`sep-${repo}`} className="px-2 py-1.5 bg-slate-100 dark:bg-slate-700/70 rounded-md">
+                      <span className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">
+                        {categoryLabels[repo] || repo}
+                      </span>
+                    </div>
+                  );
+                  prs.forEach((pr) => {
+                    const key = `${pr.repo}#${pr.number}`;
+                    items.push(
+                      <div key={key} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <a
+                            href={`https://github.com/${pr.repo}/pull/${pr.number}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-mono text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300"
+                          >
+                            {pr.repo}#{pr.number}
+                          </a>
+                          <PRStatusBadge pr={pr} />
+                        </div>
+                        <p className="text-sm text-slate-900 dark:text-slate-100">{pr.title || pr.description}</p>
+                      </div>
+                    );
+                  });
+                });
+                return items;
+              })()}
+            </div>
+          </section>
+        )}
+
+        {/* Footer */}
+        <div className="mt-8 text-center text-xs text-slate-400 dark:text-slate-500">
+          <p>
+            <Link to="/devnets" className="underline hover:text-slate-600 dark:hover:text-slate-300">
+              Back to Devnets
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DevnetSpecPage;

--- a/src/data/devnet-specs/bal-devnet-2.json
+++ b/src/data/devnet-specs/bal-devnet-2.json
@@ -1,0 +1,329 @@
+{
+  "id": "bal-devnet-2",
+  "upgrade": "glamsterdam",
+  "headliner": "BAL",
+  "version": 2,
+  "launchDate": "2026-02-04",
+  "lastUpdated": "2026-02-03",
+  "notes": [
+    "EL clients: please add flags to enable/disable BAL optimizations batch/parallel io and parallel execution."
+  ],
+  "specVersions": {
+    "consensusSpecs": "v1.6.1",
+    "executionSpecs": "BAL v5.1.0"
+  },
+  "eips": [
+    {
+      "id": 7928,
+      "title": "Block-Level Access Lists",
+      "summary": "Enforced block access lists enabling parallel validation and executionless state updates",
+      "changeStatus": "updated",
+      "lastCommitSha": "fad1a1acab0a433970e47e0b73a4f8a28c220675"
+    },
+    {
+      "id": 8024,
+      "title": "Backward compatible SWAPN, DUPN, EXCHANGE",
+      "summary": "New instructions for stack manipulation beyond the 16-item limit",
+      "changeStatus": "updated",
+      "lastCommitSha": "05146bfcf2a3b0b5962b289ab2bd79b706a45906"
+    },
+    {
+      "id": 7843,
+      "title": "SLOTNUM opcode",
+      "summary": "New opcode (0x4b) returning the current slot number",
+      "changeStatus": "new",
+      "lastCommitSha": "c3bfd4ba41cf0fcbfe8c404f33ba89f5174971e0"
+    },
+    {
+      "id": 7708,
+      "title": "ETH transfers emit a log",
+      "summary": "All ETH transfers emit a log for unified tracking",
+      "changeStatus": "updated",
+      "lastCommitSha": "04026e96ac58077f98a848d0e15ae0e8a599875f"
+    },
+    {
+      "id": 7778,
+      "title": "Block Gas Accounting without Refunds",
+      "summary": "Exclude refunds from block gas accounting to prevent limit circumvention",
+      "changeStatus": "new",
+      "lastCommitSha": "3929b1aab57b493417eccec7457d1485eccb9768"
+    }
+  ],
+  "implementations": {
+    "el": [
+      {
+        "eipId": 7928,
+        "clients": {
+          "Besu": "done",
+          "Erigon": "done",
+          "Geth": "done",
+          "Nethermind": "done",
+          "Nimbus-EL": "done",
+          "Reth": "done"
+        }
+      },
+      {
+        "eipId": 7708,
+        "clients": {
+          "Besu": "done",
+          "Erigon": "done",
+          "Geth": "done",
+          "Nethermind": "done",
+          "Nimbus-EL": "done",
+          "Reth": "done"
+        }
+      },
+      {
+        "eipId": 7778,
+        "clients": {
+          "Besu": "done",
+          "Erigon": "in-progress",
+          "Geth": "done",
+          "Nethermind": "done",
+          "Nimbus-EL": "done",
+          "Reth": "done"
+        }
+      },
+      {
+        "eipId": 7843,
+        "clients": {
+          "Besu": "done",
+          "Erigon": "in-progress",
+          "Geth": "done",
+          "Nethermind": "done",
+          "Nimbus-EL": "done",
+          "Reth": "done"
+        }
+      },
+      {
+        "eipId": 8024,
+        "clients": {
+          "Besu": "done",
+          "Erigon": "in-progress",
+          "Geth": "done",
+          "Nethermind": "done",
+          "Nimbus-EL": "done",
+          "Reth": "done"
+        }
+      }
+    ],
+    "cl": [
+      {
+        "eipId": 7928,
+        "clients": {
+          "Lighthouse": "done",
+          "Lodestar": "done",
+          "Prysm": "done"
+        }
+      },
+      {
+        "eipId": 7843,
+        "clients": {
+          "Lighthouse": "done",
+          "Lodestar": "done",
+          "Prysm": "not-started"
+        }
+      }
+    ]
+  },
+  "prs": [
+    {
+      "repo": "ethereum/EIPs",
+      "number": 9003,
+      "description": "EIP-7708: Respec topic & emitting addr + add LOG2 for SELFDESTRUCT @ self",
+      "eipId": 7708,
+      "status": "merged",
+      "title": "Update EIP-7708: Move to Draft",
+      "headSha": "e8f1b9a9cd4803e6e84c25a6afce0f980c7c9483"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11127,
+      "description": "EIP-7708: Clarify SELFDESTRUCT LOG2 events",
+      "eipId": 7708,
+      "status": "merged",
+      "title": "Update EIP-7708: Clarify selfdestruct event",
+      "headSha": "b6ddf5a275423a31497411acab623fea3e46bbe2"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11187,
+      "description": "EIP-7708: Clarify CALL to self does not emit transfer log",
+      "eipId": 7708,
+      "status": "merged",
+      "title": "Update EIP-7708: Clarify CALL to self does not emit transfer log",
+      "headSha": "723c1b17e541193088d3c0f2ba3dba8f73cd7616"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11190,
+      "description": "EIP-7708: clarify order of burn logs and coinbase transfer logs",
+      "eipId": 7708,
+      "status": "merged",
+      "title": "Update EIP-7708: clarify order of burn logs and coinbase transfer logs",
+      "headSha": "04026e96ac58077f98a848d0e15ae0e8a599875f"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11191,
+      "description": "EIP-7778: Revert back to not having a receipt field",
+      "eipId": 7778,
+      "status": "merged",
+      "title": "Update EIP-7778: Revert back to not having a receipt field",
+      "headSha": "3929b1aab57b493417eccec7457d1485eccb9768"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11138,
+      "description": "EIP-7778: clarify that user gas accounting remains unchanged",
+      "eipId": 7778,
+      "status": "merged",
+      "title": "Update EIP-7778: clarify that user gas accounting remains unchanged",
+      "headSha": "5f39588a18582804d63a59ee8cc1d3dba1fc0d68"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11083,
+      "description": "EIP-7843: consistent naming, engine api",
+      "eipId": 7843,
+      "status": "merged",
+      "title": "Update EIP-7843: Move to Draft",
+      "headSha": "c3bfd4ba41cf0fcbfe8c404f33ba89f5174971e0"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 10990,
+      "description": "EIP-7928: spurious entry detection",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "Update EIP-7928: clarify spurious entry detection and fix typos",
+      "headSha": "f397e6ce2dfd15b6ea26e00fdaa228920fa13e5e"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11066,
+      "description": "EIP-7928: gas validation",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "Update EIP-7928: Further clarify access",
+      "headSha": "78143cb526938f7ce9176afe7b0be8af4a3c7ef8"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 10895,
+      "description": "EIP-7928: System contract access clarification",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "Update EIP-7928: Clarify system contract caller",
+      "headSha": "293d1a708b7e504b4823c04aab727bdd63ad2c2c"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 10940,
+      "description": "EIP-7928: BAL retention period WSP",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "Update EIP-7928: change BAL retention period to WSP",
+      "headSha": "f7efd2acb666456d5e9237e02a8de5f54547e0ee"
+    },
+    {
+      "repo": "ethereum/EIPs",
+      "number": 11094,
+      "description": "EIP-8024: Switch encoding to push-postfix (NOT included in devnet-2)",
+      "eipId": 8024,
+      "status": "draft",
+      "title": "Update EIP-8024: Switch ecoding to push-postfix",
+      "headSha": "670dd10072ad79b5333155f618070524997065df"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 2023,
+      "description": "EIP-7708: ETH Transfer Emit",
+      "eipId": 7708,
+      "status": "merged",
+      "title": "feat(spec-specs): EIP-7708 ETH Transfers Emit a Log",
+      "headSha": "bfa2cf03e7fbe24bba556b53c4e57f8e089005e9"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 1401,
+      "description": "EIP-7778: Block Gas Accounting",
+      "eipId": 7778,
+      "status": "merged",
+      "title": "feat(spec-specs): Implement EIP-7778 Block Gas Accounting without Refunds",
+      "headSha": "52258b0da55bc52cae2a6851f349bb49a43b136f"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 2007,
+      "description": "EIP-7843: SlotNum Opcode",
+      "eipId": 7843,
+      "status": "merged",
+      "title": "feat(src): EIP-7843 (SLOTNUM) Draft",
+      "headSha": "8682b5df60a2abddba76d8e43f48e73cac9e0151"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 1719,
+      "description": "EIP-7928: Implement Block-Level Access Lists",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "feat(specs,tests): Implement EIP-7928 Block-Level Access Lists",
+      "headSha": "1d11d8d2e0ca104a4731e37aaa671fc19a6d66f1"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 1917,
+      "description": "EIP-7928: move bal from payload",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "feat(specs): EIP-7928 move bal from payload",
+      "headSha": "2344445f9e74e9dd2ca8bbed70754137150fc9fe"
+    },
+    {
+      "repo": "ethereum/execution-specs",
+      "number": 2021,
+      "description": "EIP-8024: tests added",
+      "eipId": 8024,
+      "status": "merged",
+      "title": "feat(src): EIP-8024 tests added",
+      "headSha": "1a231a67bc29945fb648df5348e4976048ca671b"
+    },
+    {
+      "repo": "ethereum/execution-apis",
+      "number": 731,
+      "description": "EIP-7843: engine_forkchoiceUpdatedV4",
+      "eipId": 7843,
+      "status": "merged",
+      "title": "engine: EIP-7843 changes - adding slot number to fcU",
+      "headSha": "dc4dbca37ef8697d782f431af19120beaf5517f5"
+    },
+    {
+      "repo": "ethereum/execution-apis",
+      "number": 691,
+      "description": "EIP-7928: ExecutionPayloadV4",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "Add Amsterdam execution-api specs",
+      "headSha": "4ec8e5735ebb3f2ce0702726385cdde70034f78c"
+    },
+    {
+      "repo": "ethereum/execution-apis",
+      "number": 726,
+      "description": "EIP-7928: Add Block-level Access Lists JSON RPC methods",
+      "eipId": 7928,
+      "status": "open",
+      "title": "Add EIP-7928 Block-level Access Lists JSON RPC methods",
+      "headSha": "8e63546491f63919915b2cf75d004e35eb1980b6"
+    },
+    {
+      "repo": "ethereum/execution-apis",
+      "number": 727,
+      "description": "EIP-7928: define API methods",
+      "eipId": 7928,
+      "status": "merged",
+      "title": "engine: define EIP-7928 API methods",
+      "headSha": "585763b34564202d4611d318006ea1f3efb43616"
+    }
+  ]
+}

--- a/src/hooks/useDevnetSpec.ts
+++ b/src/hooks/useDevnetSpec.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DevnetSpec } from '../types/devnet-spec';
+
+interface UseDevnetSpecResult {
+  spec: DevnetSpec | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useDevnetSpec(id: string | undefined): UseDevnetSpecResult {
+  const [spec, setSpec] = useState<DevnetSpec | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadSpec = useCallback(async () => {
+    if (!id) {
+      setLoading(false);
+      setError(new Error('No devnet id provided'));
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const specModule = await import(`../data/devnet-specs/${id}.json`);
+      const specData: DevnetSpec = specModule.default;
+      setSpec(specData);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(`Failed to load devnet spec: ${id}`));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadSpec();
+  }, [loadSpec]);
+
+  return { spec, loading, error };
+}

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -1,0 +1,49 @@
+export type ChangeStatus = 'new' | 'updated' | 'unchanged';
+
+export type ImplementationStatus = 'done' | 'in-progress' | 'not-started' | 'unknown';
+
+export interface DevnetSpecEip {
+  id: number;
+  title: string;
+  summary: string;
+  changeStatus: ChangeStatus;
+  lastCommitSha?: string;
+}
+
+export interface ImplementationRow {
+  eipId: number;
+  clients: Record<string, ImplementationStatus>;
+}
+
+export interface DevnetSpecPR {
+  repo: string;
+  number: number;
+  description: string;
+  eipId?: number;
+  status?: 'open' | 'merged' | 'closed' | 'draft';
+  title?: string;
+  headSha?: string;
+}
+
+export interface DevnetSpecVersions {
+  consensusSpecs?: string;
+  executionSpecs?: string;
+  engineApi?: string;
+}
+
+export interface DevnetSpec {
+  id: string;
+  upgrade: string;
+  headliner: string;
+  version: number;
+  launchDate?: string;
+  lastUpdated: string;
+  notes?: string[];
+  specVersions: DevnetSpecVersions;
+  eips: DevnetSpecEip[];
+  implementations: {
+    el: ImplementationRow[];
+    cl: ImplementationRow[];
+  };
+  prs: DevnetSpecPR[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './eip';
-export * from './complexity'; 
+export * from './complexity';
+export * from './devnet-spec';


### PR DESCRIPTION

<img width="1138" height="1273" alt="Screenshot 2026-02-09 at 14 41 35" src="https://github.com/user-attachments/assets/eb17b470-0013-457e-bed9-bc6b4de9ba96" />
<img width="1092" height="1180" alt="Screenshot 2026-02-09 at 14 41 51" src="https://github.com/user-attachments/assets/c72420f5-e0a1-4883-ab33-abe73c3a4e15" />



feat(ci): add script and route to fetch PR statuses for devnet specs
chore(deps): add fetch-pr-statuses script to package.json
feat(navigation): add route for individual devnet spec sheets

feat(DevnetSpecPage): add DevnetSpecPage component to display EIP specs and implementation status

This adds a new page component dedicated to displaying the specification details for a given development network ('Devnet').

The component fetches spec data using `useDevnetSpec`, sets appropriate meta tags via `useMetaTags`, and renders:
1. General metadata (launch date, spec versions, upgrade name).
2. A matrix showing implementation status for Execution Layer (EL) and Consensus Layer (CL) clients based on their version or support status.
3. A tracker for related Pull Requests (PRs) merged/open for each EIP relevant to this devnet.

This provides users with a centralized view of what EIPs are targeted and which client implementations have achieved the required status. Utility components like `ChangeStatusBadge`, `ImplStatusCell`, and `PRStatusBadge` are introduced to format status indicators consistently.

feat(ui): display EIP status and implementation matrices

Introduce rendering logic for EIP status and implementation tracking for both Execution Layer (EL) and Consensus Layer (CL) clients.

This provides users with a clear, responsive view (desktop table and mobile cards) detailing:
1. Associated PRs for each EIP.
2. Client implementation status against each EIP, facilitating better tracking of Ethereum Upgrade progress.

refactor(ui): group and style tracked PRs in DevnetSpecPage for clarity

Organize the display of tracked Pull Requests (PRs) by grouping them according to their repository using predefined category order.

This change improves readability and scannability by:
1. Grouping PRs associated with 'ethereum/EIPs', 'execution-specs', 'consensus-specs', and 'execution-apis' together, with clear section headers.
2. Sorting the groups based on this predefined order.
3. Implementing consistent table layout for desktop views and card layout for mobile views, including status badges.

feat(devnet-specs): add bal-devnet-2 genesis specification file

Add the specification file for the fictional 'bal-devnet-2'. This file details the EIPs included, consensus/execution spec versions, and implementation statuses for a hypothetical devnet upgrade named "glamsterdam".

chore(deps): update EIP metadata to include recent PRs

This updates the cached data about related EIPs by incorporating recent pull requests from various Ethereum repositories (`execution-specs` and `execution-apis`). This is necessary to keep the tracking of EIP statuses and specifications up-to-date.

feat(hooks, types): introduce useDevnetSpec hook and DevnetSpec types

Introduce a new React hook `useDevnetSpec` to fetch and manage the data for a specific devnet specification located in a local JSON file.

This required creating new TypeScript types (`DevnetSpec`, `DevnetSpecEip`, etc.) in `src/types/devnet-spec.ts` to model the structure of the devnet specification data. The main types file is updated to re-export these new types.