### PR TITLE
add EIPs-7975 & -8159 (eth/70 & eth/71)

### DIFF
--- a/src/data/eips/7975.json
+++ b/src/data/eips/7975.json
@@ -2,7 +2,7 @@
   "id": 7975,
   "title": "EIP-7975: eth/70 - partial block receipt lists",
   "status": "Draft",
-  "description": "Modifies the eth p2p protocol to allow requesting partial block receipt lists. As block gas limits increase, receipt lists may exceed the 10MiB message size limit, causing sync failures. This EIP introduces pagination via a lastBlockIncomplete flag and firstBlockReceiptIndex field.",
+  "description": "Adds a facility for paginating block receipts in the p2p protocol",
   "author": "Felix Lange <fjl@ethereum.org>, Jochem Brouwer (@jochem-brouwer), Giulio Rebuffo (@Giulio2002)",
   "type": "Standards Track",
   "category": "Networking",

--- a/src/data/eips/8159.json
+++ b/src/data/eips/8159.json
@@ -2,7 +2,7 @@
   "id": 8159,
   "title": "EIP-8159: eth/71 - Block Access List Exchange",
   "status": "Draft",
-  "description": "Adds peer-to-peer exchange of block-level access lists to the eth protocol. Introduces GetBlockAccessLists and BlockAccessLists messages, enabling peers to request and serve BALs for synchronization and parallel execution. Requires EIP-7928 (Block-Level Access Lists).",
+  "description": "Adds peer-to-peer exchange of block-level access lists to the eth protocol",
   "author": "Toni Wahrstätter (@nerolation)",
   "type": "Standards Track",
   "category": "Networking",


### PR DESCRIPTION
adding EIP-7975 and EIP-8159 as CFI, decision made on [ACDE #230](https://forkcast.org/calls/acde/230) using opus 4.5 and EIP content, original PRs (#[9906](https://github.com/ethereum/EIPs/pull/9906), #[11307](https://github.com/ethereum/EIPs/pull/11307)), ACDE chat logs, and client roster lookups to fill template