### PR TITLE
sync: set pqts 4 video/transcript offset to skip dead air

### DIFF
--- a/public/artifacts/pqts/2026-03-18_004/config.json
+++ b/public/artifacts/pqts/2026-03-18_004/config.json
@@ -2,7 +2,7 @@
   "issue": 1968,
   "videoUrl": "https://www.youtube.com/watch?v=0PJUhBAiUXo",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:12:39",
+    "videoStartTime": "00:12:39"
   }
 }


### PR DESCRIPTION
## Summary
- Sets transcript/video sync offset to `00:12:39` for PQTS 4 (2026-03-18) to skip ~12 minutes of dead air (audio checks, pre-meeting chat)

## Test plan
- [ ] Verify transcript playback aligns with video on the [call page](https://wolovim.github.io/forkcast)