### PR TITLE
sync: set video/transcript offsets for ACDT 75 and RPC 23

### DIFF
--- a/public/artifacts/acdt/2026-03-23_075/config.json
+++ b/public/artifacts/acdt/2026-03-23_075/config.json
@@ -2,7 +2,7 @@
   "issue": 1976,
   "videoUrl": "https://youtube.com/watch?v=Eq5S2q_fUGI",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:07:12",
+    "videoStartTime": "00:02:16"
   }
 }

--- a/public/artifacts/rpc/2026-03-23_023/config.json
+++ b/public/artifacts/rpc/2026-03-23_023/config.json
@@ -2,7 +2,7 @@
   "issue": 1974,
   "videoUrl": "https://www.youtube.com/watch?v=0UxYDNA80aY",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:05:46",
+    "videoStartTime": "00:05:46"
   }
 }


### PR DESCRIPTION
## Summary
- Set ACDT 75 offsets: video `00:02:16`, transcript `00:07:12`
- Set RPC 23 offsets: both `00:05:46`