### PR TITLE
sync: set video/transcript offsets for FOCIL 31

### DIFF
--- a/public/artifacts/focil/2026-03-24_031/config.json
+++ b/public/artifacts/focil/2026-03-24_031/config.json
@@ -2,7 +2,7 @@
   "issue": 1978,
   "videoUrl": "https://www.youtube.com/watch?v=eM1LKIUJbEc",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:11:23",
+    "videoStartTime": "00:11:23"
   }
 }


### PR DESCRIPTION
## Summary
- Set video and transcript start time offsets to `00:11:23` for FOCIL 31