### PR TITLE
sync: set video/transcript offsets for one-off-1985 2

### DIFF
--- a/public/artifacts/one-off-1985/2026-03-25_002/config.json
+++ b/public/artifacts/one-off-1985/2026-03-25_002/config.json
@@ -2,7 +2,7 @@
   "issue": 1985,
   "videoUrl": "https://www.youtube.com/watch?v=IJrBJpbnkpg",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:10:44",
+    "videoStartTime": "00:10:44"
   }
 }


### PR DESCRIPTION
## Summary
- Set video/transcript sync offsets to `00:10:44` for one-off-1985 2 (Frame TX call) to skip dead air at the start

## Test plan
- [x] Verified sync on local dev server