### PR TITLE
sync: set video/transcript offsets for PQI 33

### DIFF
--- a/public/artifacts/pqi/2026-03-25_033/config.json
+++ b/public/artifacts/pqi/2026-03-25_033/config.json
@@ -2,7 +2,7 @@
   "issue": 1983,
   "videoUrl": "https://www.youtube.com/watch?v=DVoenb4w7sI",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:18:13",
+    "videoStartTime": "00:18:13"
   }
 }


### PR DESCRIPTION
## Summary
- Set video/transcript offsets for PQI 33 to `00:18:13` (dead air before speech begins)

## Test plan
- [x] Verified sync on local dev server