### PR TITLE
add netlify.toml with build config and Node 24

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "24"


### PR DESCRIPTION
## Summary
- Adds `netlify.toml` so build config is version-controlled instead of living only in the Netlify dashboard
- Sets publish directory to `dist` (was incorrectly set to `public` in dashboard, which caused deploy previews to serve raw static files without the built app)
- Pins Node 24 to match our `engines` requirement

## Test plan
- [ ] Deploy preview on this PR builds and loads correctly
- [ ] PR 177 deploy preview works after this lands