### PR TITLE
Add min-release-age to npmrc for supply chain protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=7


### PR DESCRIPTION
**note: contributors may need to update local npm version**

## Summary
- Adds `min-release-age=7` to `.npmrc`, requiring packages to be published for at least 7 days before they can be installed
- Protects against supply chain attacks — most malicious packages are flagged and removed within hours to days
- Can be overridden per-install with `npm install --min-release-age=0` when an urgent patch is needed

## Test plan
- [x] Verify `npm install` still works with existing dependencies
- [x] Confirm newly published packages (<7 days) are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)