### PR TITLE
sync: set video/transcript offsets for PRICE 5 and PQTS 5

### DIFF
--- a/public/artifacts/pqts/2026-04-01_005/config.json
+++ b/public/artifacts/pqts/2026-04-01_005/config.json
@@ -2,7 +2,7 @@
   "issue": 1981,
   "videoUrl": "https://www.youtube.com/watch?v=V59OkKfATng",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:04:22",
+    "videoStartTime": "00:04:22"
   }
 }

--- a/public/artifacts/price/2026-04-01_005/config.json
+++ b/public/artifacts/price/2026-04-01_005/config.json
@@ -2,7 +2,7 @@
   "issue": 2000,
   "videoUrl": "https://www.youtube.com/watch?v=40w2GkOLTfI",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:07:59",
+    "videoStartTime": "00:07:59"
   }
 }


### PR DESCRIPTION
## Summary
- Set sync offsets for PRICE 5 (00:07:59) and PQTS 5 (00:04:22) to skip dead air at start of recordings