### PR TITLE
Add global navigation bar and improve feature discoverability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { getUpgradeById } from './data/upgrades';
 import { useAnalytics } from './hooks/useAnalytics';
 import { ThemeProvider } from './contexts/ThemeContext';
 import ExternalRedirect from './components/ExternalRedirect';
+import GlobalNav from './components/ui/GlobalNav';
 
 const stripTrailingSlashes = (p: string): string =>
   p === '/' ? '/' : p.replace(/\/+$/, '');
@@ -101,6 +102,7 @@ function App() {
         <AnalyticsTracker />
         <ScrollToTop />
         <div className="scanlines" aria-hidden="true" />
+        <GlobalNav />
         <main>
           <Routes>
             <Route path="/" element={<HomePage />} />

--- a/src/components/CallsIndexPage.tsx
+++ b/src/components/CallsIndexPage.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { Logo } from './ui/Logo';
-import ThemeToggle from './ui/ThemeToggle';
 import { protocolCalls, callTypeNames, isOneOffCall, type Call, type CallType } from '../data/calls';
 import { timelineEvents, type TimelineEvent } from '../data/events';
 import { fetchUpcomingCalls, type UpcomingCall } from '../utils/github';
@@ -151,7 +149,6 @@ const CallsIndexPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <div className="max-w-3xl mx-auto px-6 py-8">
         <div className="mb-6">
-          <Logo size="md" className="mb-4" />
           <div className="flex items-start justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Protocol Calendar</h1>
@@ -164,14 +161,11 @@ const CallsIndexPage: React.FC = () => {
                 Full calendar ↗
               </a>
             </div>
-            <div className="flex items-center gap-3">
-              <SearchTriggerButton
-                onOpen={() => setSearchOpen(true)}
-                placeholder="Search calls..."
-                ariaLabel="Search calls"
-              />
-              <ThemeToggle />
-            </div>
+            <SearchTriggerButton
+              onOpen={() => setSearchOpen(true)}
+              placeholder="Search calls..."
+              ariaLabel="Search calls"
+            />
           </div>
 
           {/* Filter buttons and events toggle */}

--- a/src/components/ComplexityPage.tsx
+++ b/src/components/ComplexityPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Logo } from './ui/Logo';
 import { eipsData } from '../data/eips';
 import { useComplexityData, getComplexityForEip } from '../hooks/useComplexityData';
 import { getComplexityTierColor, getComplexityTierEmoji } from '../utils/complexity';
@@ -8,7 +7,6 @@ import { getInclusionStage, getLaymanTitle, getProposalPrefix, getSpecificationU
 import { getInclusionStageColor } from '../utils/colors';
 import { InclusionStage } from '../types';
 import { useMetaTags } from '../hooks/useMetaTags';
-import ThemeToggle from './ui/ThemeToggle';
 import AnalysisNav from './ui/AnalysisNav';
 import { ComplexityTier } from '../types';
 
@@ -206,11 +204,7 @@ const ComplexityPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-8" />
+        <div className="mb-6">
           <div className="flex items-center gap-3 mb-2">
             <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               Test Complexity Analysis

--- a/src/components/DecisionsPage.tsx
+++ b/src/components/DecisionsPage.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { Logo } from './ui/Logo';
-import ThemeToggle from './ui/ThemeToggle';
 import { protocolCalls, Call } from '../data/calls';
 import { KeyDecision, EIP } from '../types/eip';
 import { eipsData } from '../data/eips';
@@ -101,11 +99,7 @@ const DecisionsPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-4" />
+        <div className="mb-6">
           <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-2">
             Key Decisions
           </h1>

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useCallback, type ReactNode } from 'react';
 import { useParams, Navigate, Link, useNavigate } from 'react-router-dom';
-import { Logo } from './ui/Logo';
-import ThemeToggle from './ui/ThemeToggle';
 import { useMetaTags } from '../hooks/useMetaTags';
 import { getDevnetSpec, getDevnetSeriesSiblings } from '../data/devnet-specs';
 import { useDevnetNetworks, getNetworkEntry, getNetworkMetadata } from '../hooks/useDevnetNetworks';
@@ -271,50 +269,44 @@ function DevnetPageLayout({
   return (
     <div className="min-h-screen bg-white dark:bg-slate-900">
       <header className="border-b border-slate-200 dark:border-slate-700">
-        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Logo size="sm" />
-            <Link
-              to="/devnets"
-              className="text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
-            >
-              &larr; Back to Devnets
-            </Link>
-          </div>
-          <div className="flex items-center gap-3">
-            {(prev || next) && (
-              <nav className="flex items-center gap-1 text-sm">
-                {prev ? (
-                  <Link
-                    to={`/devnets/${prev}`}
-                    className="px-2 py-1 rounded text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800 transition-colors"
-                    title={prev}
-                  >
-                    &larr; Prev
-                  </Link>
-                ) : (
-                  <span className="px-2 py-1 text-slate-300 dark:text-slate-600">
-                    &larr; Prev
-                  </span>
-                )}
-                <span className="text-slate-300 dark:text-slate-600">|</span>
-                {next ? (
-                  <Link
-                    to={`/devnets/${next}`}
-                    className="px-2 py-1 rounded text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800 transition-colors"
-                    title={next}
-                  >
-                    Next &rarr;
-                  </Link>
-                ) : (
-                  <span className="px-2 py-1 text-slate-300 dark:text-slate-600">
-                    Next &rarr;
-                  </span>
-                )}
-              </nav>
-            )}
-            <ThemeToggle />
-          </div>
+        <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link
+            to="/devnets"
+            className="text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+          >
+            &larr; Back to Devnets
+          </Link>
+          {(prev || next) && (
+            <nav className="flex items-center gap-1 text-sm">
+              {prev ? (
+                <Link
+                  to={`/devnets/${prev}`}
+                  className="px-2 py-1 rounded text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  title={prev}
+                >
+                  &larr; Prev
+                </Link>
+              ) : (
+                <span className="px-2 py-1 text-slate-300 dark:text-slate-600">
+                  &larr; Prev
+                </span>
+              )}
+              <span className="text-slate-300 dark:text-slate-600">|</span>
+              {next ? (
+                <Link
+                  to={`/devnets/${next}`}
+                  className="px-2 py-1 rounded text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  title={next}
+                >
+                  Next &rarr;
+                </Link>
+              ) : (
+                <span className="px-2 py-1 text-slate-300 dark:text-slate-600">
+                  Next &rarr;
+                </span>
+              )}
+            </nav>
+          )}
         </div>
       </header>
       <div className="max-w-4xl mx-auto px-4 py-8">

--- a/src/components/DevnetsIndexPage.tsx
+++ b/src/components/DevnetsIndexPage.tsx
@@ -1,7 +1,5 @@
 import React, { useState, lazy, Suspense } from 'react';
 import { Link } from 'react-router-dom';
-import { Logo } from './ui/Logo';
-import ThemeToggle from './ui/ThemeToggle';
 import AnalysisNav from './ui/AnalysisNav';
 import { useMetaTags } from '../hooks/useMetaTags';
 import { useDevnetNetworks } from '../hooks/useDevnetNetworks';
@@ -217,11 +215,7 @@ const DevnetsIndexPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-8" />
+        <div className="mb-6">
           <div className="flex items-center gap-3 mb-2">
             <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               Devnet Tracker

--- a/src/components/EipsIndexPage.tsx
+++ b/src/components/EipsIndexPage.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Logo } from './ui/Logo';
-import ThemeToggle from './ui/ThemeToggle';
 import { eipsData } from '../data/eips';
 import { getProposalPrefix, getLaymanTitle, getInclusionStage, isHeadlinerInAnyFork, wasHeadlinerCandidateInAnyFork, getEipLayer } from '../utils/eip';
 import { EipSearch } from './eip/EipSearch';
@@ -366,11 +364,7 @@ const EipsIndexPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-8" />
+        <div className="mb-6">
           <div className="flex items-center justify-between gap-3">
             <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               EIP Directory

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,9 +4,7 @@ import { getRecentCalls, isOneOffCall, callTypeNames, type CallType } from '../d
 import { eipsData } from '../data/eips';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { getProposalPrefix, getLaymanTitle, getInclusionStage } from '../utils/eip';
-import ThemeToggle from './ui/ThemeToggle';
 import UpgradeCarousel from './ui/UpgradeCarousel';
-import { Logo } from './ui/Logo';
 
 const HomePage = () => {
   const upgrades = networkUpgrades;
@@ -112,11 +110,7 @@ const HomePage = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="mb-12 text-center relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="2xl" className="mb-4" />
+        <div className="mb-8 text-center">
           <h2 className="text-xl font-light text-slate-700 dark:text-slate-300 tracking-tight">
             Ethereum Upgrade Tracker
           </h2>
@@ -250,13 +244,71 @@ const HomePage = () => {
           </div>
         </div>
 
-        {/* Planning Tools Section */}
+        {/* Glamsterdam Analysis Section */}
         <div className="mt-12">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-medium text-slate-900 dark:text-slate-100">
-              Planning Tools
-            </h2>
+          <div className="border border-purple-200 dark:border-purple-800/50 rounded-xl p-5 bg-purple-50/30 dark:bg-purple-950/10">
+            <div className="flex items-center gap-2 mb-4">
+              <h2 className="text-lg font-medium text-slate-900 dark:text-slate-100">
+                Glamsterdam Analysis
+              </h2>
+              <span className="px-2 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded">
+                Upcoming
+              </span>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Link
+                to="/priority"
+                className="group flex items-start gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/20 hover:border-purple-300 dark:hover:border-purple-600"
+              >
+                <div className="flex-shrink-0 w-9 h-9 bg-purple-100 dark:bg-purple-900/40 rounded-lg flex items-center justify-center text-purple-600 dark:text-purple-400">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
+                    Client Priority
+                  </h3>
+                  <p className="text-xs text-slate-600 dark:text-slate-400">
+                    How do Besu, Geth, Nethermind, Erigon, Reth, and other teams rank Glamsterdam EIPs?
+                  </p>
+                </div>
+                <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+
+              <Link
+                to="/complexity"
+                className="group flex items-start gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/20 hover:border-purple-300 dark:hover:border-purple-600"
+              >
+                <div className="flex-shrink-0 w-9 h-9 bg-amber-100 dark:bg-amber-900/40 rounded-lg flex items-center justify-center text-amber-600 dark:text-amber-400">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
+                    Test Complexity
+                  </h3>
+                  <p className="text-xs text-slate-600 dark:text-slate-400">
+                    STEEL team complexity assessments for each Glamsterdam EIP. Low/Medium/High effort tiers.
+                  </p>
+                </div>
+                <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            </div>
           </div>
+        </div>
+
+        {/* Protocol-Wide Tools Section */}
+        <div className="mt-8">
+          <h2 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-4">
+            Protocol-Wide Tools
+          </h2>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Link
@@ -270,54 +322,10 @@ const HomePage = () => {
               </div>
               <div className="flex-1 min-w-0">
                 <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
-                  Schedule
+                  ACD Planning Sandbox
                 </h3>
                 <p className="text-xs text-slate-600 dark:text-slate-400">
-                  Plan fork timelines with adjustable milestones
-                </p>
-              </div>
-              <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-
-            <Link
-              to="/priority"
-              className="group flex items-start gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/20 hover:border-purple-300 dark:hover:border-purple-600"
-            >
-              <div className="flex-shrink-0 w-9 h-9 bg-purple-100 dark:bg-purple-900/40 rounded-lg flex items-center justify-center text-purple-600 dark:text-purple-400">
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                </svg>
-              </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
-                  Client Priority
-                </h3>
-                <p className="text-xs text-slate-600 dark:text-slate-400">
-                  Aggregated client team stances on EIPs
-                </p>
-              </div>
-              <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-
-            <Link
-              to="/complexity"
-              className="group flex items-start gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/20 hover:border-purple-300 dark:hover:border-purple-600"
-            >
-              <div className="flex-shrink-0 w-9 h-9 bg-amber-100 dark:bg-amber-900/40 rounded-lg flex items-center justify-center text-amber-600 dark:text-amber-400">
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                </svg>
-              </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
-                  Test Complexity
-                </h3>
-                <p className="text-xs text-slate-600 dark:text-slate-400">
-                  STEEL team complexity assessments per EIP
+                  Model fork timelines for Glamsterdam and Hegota. Adjust phases and target dates.
                 </p>
               </div>
               <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -339,7 +347,29 @@ const HomePage = () => {
                   Devnet Tracker
                 </h3>
                 <p className="text-xs text-slate-600 dark:text-slate-400">
-                  Combined complexity, support, and inclusion status
+                  Active devnet series across Glamsterdam, Fusaka, and more. Specs and client support.
+                </p>
+              </div>
+              <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+
+            <Link
+              to="/decisions"
+              className="group flex items-start gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/20 hover:border-purple-300 dark:hover:border-purple-600 sm:col-span-2"
+            >
+              <div className="flex-shrink-0 w-9 h-9 bg-slate-100 dark:bg-slate-700 rounded-lg flex items-center justify-center text-slate-600 dark:text-slate-400">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
+                  Key Decisions
+                </h3>
+                <p className="text-xs text-slate-600 dark:text-slate-400">
+                  Key decisions from AllCoreDevs meetings, aggregated in reverse-chronological order.
                 </p>
               </div>
               <svg className="w-5 h-5 text-slate-400 group-hover:text-purple-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/PrioritizationPage.tsx
+++ b/src/components/PrioritizationPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Logo } from './ui/Logo';
 import { usePrioritizationData, getELClients, getCLClients } from '../hooks/usePrioritizationData';
 import {
   sortEipAggregates,
@@ -16,7 +15,6 @@ import { eipsData } from '../data/eips';
 import { InclusionStage } from '../types';
 import { EipAggregateStance, ClientStance } from '../types/prioritization';
 import { useMetaTags } from '../hooks/useMetaTags';
-import ThemeToggle from './ui/ThemeToggle';
 import AnalysisNav from './ui/AnalysisNav';
 
 type FilterLayer = 'all' | 'EL' | 'CL';
@@ -165,11 +163,7 @@ const PrioritizationPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-8" />
+        <div className="mb-6">
           <div className="flex items-center gap-3 mb-2">
             <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               Client Prioritization

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { eipsData } from '../data/eips';
 import { getPendingProposalsForFork } from '../data/pending-proposals';
-import { Logo } from './ui/Logo';
 import { useMetaTags } from '../hooks/useMetaTags';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { EIP, ClientTeamPerspective, InclusionStage } from '../types';
@@ -23,7 +22,6 @@ import {
 } from '../utils/colors';
 import { ActivationDetails } from '../data/upgrades';
 import { Tooltip, CopyLinkButton } from './ui';
-import ThemeToggle from './ui/ThemeToggle';
 import {
   NetworkUpgradeTimeline,
   FusakaTimeline,
@@ -372,10 +370,6 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <div className="mb-12 flex justify-between items-start">
-            <Logo size="lg" />
-            <ThemeToggle />
-          </div>
           <Link to="/" className="text-slate-600 hover:text-slate-800 dark:text-slate-300 dark:hover:text-slate-100 mb-6 inline-block text-sm font-medium">
             ← All Network Upgrades
           </Link>

--- a/src/components/RankPage.tsx
+++ b/src/components/RankPage.tsx
@@ -10,7 +10,6 @@ import {
 import { useAnalytics } from "../hooks/useAnalytics";
 import { eipsData } from "../data/eips";
 import { getPendingProposalsForFork, PendingProposal } from "../data/pending-proposals";
-import ThemeToggle from "./ui/ThemeToggle";
 
 const ChampionDisplay: React.FC<{ champions?: Champion[] }> = ({ champions }) => {
   if (!champions || champions.length === 0 || !champions.some(c => c.name)) return null;
@@ -688,9 +687,6 @@ const RankPage: React.FC = () => {
             <h1 className="font-semibold text-slate-900 dark:text-slate-100 text-center truncate max-w-full overflow-hidden text-base sm:text-xl">
               Hegota Headliner Tier Maker
             </h1>
-            <div className="sm:absolute sm:right-0 sm:top-1/2 sm:-translate-y-1/2">
-              <ThemeToggle />
-            </div>
           </div>
         </div>
       </div>

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -4,8 +4,6 @@ import YouTube, { YouTubeProps } from 'react-youtube';
 import ChatLog from './ChatLog';
 import TldrSummary from './TldrSummary';
 import CallSearch from './CallSearch';
-import ThemeToggle from '../ui/ThemeToggle';
-import { Logo } from '../ui/Logo';
 import { protocolCalls, callTypeNames, isOneOffCall, type CallType } from '../../data/calls';
 import { fetchUpcomingCalls } from '../../utils/github';
 import { useMetaTags } from '../../hooks/useMetaTags';
@@ -917,15 +915,7 @@ const CallPage: React.FC = () => {
   if (!callData) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100">
-        {/* Header */}
-        <div className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-10">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 py-2">
-            <div className="flex items-center justify-between">
-              <Logo size="sm" />
-              <ThemeToggle />
-            </div>
-          </div>
-        </div>
+        {/* Header spacer - GlobalNav handles navigation */}
 
         {/* Content */}
         <div className="max-w-4xl mx-auto px-6 py-16">
@@ -1341,38 +1331,30 @@ const CallPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100">
       {/* Compact Header */}
-      <div className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-10">
+      <div className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-12 z-10">
         <div className={layout.header}>
           {/* Mobile Layout */}
           <div className="sm:hidden flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Logo size="xs" />
               <span className="text-xs text-slate-600 dark:text-slate-400">
                 {getCallTypeLabel()}{oneOff ? '' : ` #${callData.number}`}
               </span>
             </div>
-            <div className="flex items-center gap-2">
-              <Link
-                to="/calls"
-                className="text-xs text-slate-600 dark:text-slate-400"
-              >
-                ← Back
-              </Link>
-              <ThemeToggle />
-            </div>
+            <Link
+              to="/calls"
+              className="text-xs text-slate-600 dark:text-slate-400"
+            >
+              ← Back
+            </Link>
           </div>
 
           {/* Desktop Layout */}
           <div className="hidden sm:flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Logo size="sm" />
-              <div className="text-slate-300 dark:text-slate-600">|</div>
-              <div className="flex items-center gap-2">
-                <h1 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                  {getCallTypeLabel()}{oneOff ? '' : ` #${callData.number}`}
-                </h1>
-                <span className="text-sm text-slate-500 dark:text-slate-400">• {callData.date}</span>
-              </div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {getCallTypeLabel()}{oneOff ? '' : ` #${callData.number}`}
+              </h1>
+              <span className="text-sm text-slate-500 dark:text-slate-400">• {callData.date}</span>
             </div>
             <div className="flex items-center gap-3">
               <Link
@@ -1394,7 +1376,6 @@ const CallPage: React.FC = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>
               </button>
-              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/src/components/call/CallPlanPage.tsx
+++ b/src/components/call/CallPlanPage.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { Logo } from '../ui/Logo';
-import ThemeToggle from '../ui/ThemeToggle';
 import { protocolCalls, callTypeNames, Call, type CallType } from '../../data/calls';
 import { useMetaTags } from '../../hooks/useMetaTags';
 import { KeyDecision, EIP } from '../../types/eip';
@@ -410,11 +408,7 @@ const CallPlanPage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="mb-8 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-4" />
+        <div className="mb-8">
           <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-2">
             <span className="font-normal opacity-80">Agenda Planner for</span>{' '}
             <div className="inline-block relative" ref={dropdownRef}>

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -13,8 +13,6 @@ import {
   getPrimaryEipLayer,
 } from '../../utils';
 import { Tooltip } from '../ui';
-import ThemeToggle from '../ui/ThemeToggle';
-import { Logo } from '../ui/Logo';
 import { EipTimeline } from './EipTimeline';
 import { EipSearch } from './EipSearch';
 import EipSearchModal from './EipSearchModal';
@@ -162,20 +160,16 @@ export const EipPage: React.FC = () => {
       <div className="max-w-3xl mx-auto">
         {/* Site Header */}
         <div className="mb-6 flex items-center justify-between">
-          <Logo size="md" />
-          <div className="flex items-center gap-3">
-            <Link
-              to="/eips"
-              className="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
-              <span>All EIPs</span>
-            </Link>
-            <EipSearch onOpen={() => setSearchModalOpen(true)} />
-            <ThemeToggle />
-          </div>
+          <Link
+            to="/eips"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            <span>All EIPs</span>
+          </Link>
+          <EipSearch onOpen={() => setSearchModalOpen(true)} />
         </div>
 
         {/* Main Card */}

--- a/src/components/schedule/SchedulePage.tsx
+++ b/src/components/schedule/SchedulePage.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Logo } from '../ui/Logo';
 import { FUSAKA_PROGRESS, GLAMSTERDAM_PROGRESS, HEGOTA_PROGRESS, UPGRADE_PROCESS_PHASES } from '../../constants/timeline-phases';
 import { useMetaTags } from '../../hooks/useMetaTags';
-import ThemeToggle from '../ui/ThemeToggle';
 import AnalysisNav from '../ui/AnalysisNav';
 import { generateForkProgress, parseLocalDate, parseShortDate, daysBetween, DEFAULT_PHASE_DURATIONS, PhaseDurations, calculateSoonestMainnetDate, formatDateISO } from './forkDateCalculator';
 import ForkGanttChart from './ForkGanttChart';
@@ -309,11 +307,7 @@ const SchedulePage: React.FC = () => {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="mb-6 relative">
-          <div className="absolute top-0 right-0">
-            <ThemeToggle />
-          </div>
-          <Logo size="md" className="mb-8" />
+        <div className="mb-6">
           <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-2">
             ACD Planning Sandbox
           </h1>

--- a/src/components/stakeholder/StakeholderUpgradePage.tsx
+++ b/src/components/stakeholder/StakeholderUpgradePage.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../../data/eips';
-import { Logo } from '../ui/Logo';
 import { useMetaTags } from '../../hooks/useMetaTags';
 import { useAnalytics } from '../../hooks/useAnalytics';
 import { EIP } from '../../types';
-import ThemeToggle from '../ui/ThemeToggle';
 import { StakeholderEipCard } from './StakeholderEipCard';
 import { filterEipsForStakeholder, groupByInclusionStage } from '../../utils/stakeholder';
 
@@ -111,10 +109,6 @@ export const StakeholderUpgradePage: React.FC<StakeholderUpgradePageProps> = ({ 
       <div className="max-w-2xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <div className="mb-12 flex justify-between items-start">
-            <Logo size="lg" />
-            <ThemeToggle />
-          </div>
           <Link
             to={`/upgrade/${forkName.toLowerCase()}`}
             className="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 mb-4 inline-block text-sm"

--- a/src/components/ui/AnalysisNav.tsx
+++ b/src/components/ui/AnalysisNav.tsx
@@ -4,19 +4,18 @@ import { Link, useLocation } from 'react-router-dom';
 interface NavItem {
   path: string;
   label: string;
-  description: string;
+  glamsterdam?: boolean;
 }
 
 const navItems: NavItem[] = [
-  { path: '/schedule', label: 'Schedule', description: 'ACD planning' },
-  { path: '/priority', label: 'Client Priority', description: 'Team stances' },
-  { path: '/complexity', label: 'Test Complexity', description: 'STEEL scores' },
-  { path: '/devnets', label: 'Devnet Tracker', description: 'Combined view' },
+  { path: '/schedule', label: 'Schedule' },
+  { path: '/devnets', label: 'Devnet Tracker' },
+  { path: '/priority', label: 'Client Priority', glamsterdam: true },
+  { path: '/complexity', label: 'Test Complexity', glamsterdam: true },
 ];
 
 const AnalysisNav: React.FC = () => {
   const location = useLocation();
-  // Normalize pathname by removing trailing slash
   const pathname = location.pathname.replace(/\/$/, '') || '/';
 
   return (
@@ -27,13 +26,18 @@ const AnalysisNav: React.FC = () => {
           <Link
             key={item.path}
             to={item.path}
-            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors inline-flex items-center gap-1.5 ${
               isActive
                 ? 'bg-white dark:bg-slate-700 text-purple-700 dark:text-purple-300 shadow-sm'
                 : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200'
             }`}
           >
             {item.label}
+            {item.glamsterdam && (
+              <span className="px-1 py-0.5 text-[9px] font-semibold leading-none rounded bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400">
+                Glamsterdam
+              </span>
+            )}
           </Link>
         );
       })}

--- a/src/components/ui/GlobalNav.tsx
+++ b/src/components/ui/GlobalNav.tsx
@@ -1,0 +1,349 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Logo } from './Logo';
+import ThemeToggle from './ThemeToggle';
+import { networkUpgrades } from '../../data/upgrades';
+
+const activeUpgrades = networkUpgrades.filter(u => !u.disabled).reverse();
+
+const STATUS_COLORS: Record<string, string> = {
+  Live: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  Upcoming: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  Planning: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  Research: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400',
+};
+
+interface PlanningItem {
+  path: string;
+  label: string;
+  title: string;
+  glamsterdam?: boolean;
+}
+
+const planningItems: PlanningItem[] = [
+  { path: '/schedule', label: 'Schedule', title: 'ACD Planning Sandbox' },
+  { path: '/priority', label: 'Client Priority', title: 'Client team stances on EIPs', glamsterdam: true },
+  { path: '/complexity', label: 'Test Complexity', title: 'STEEL testing effort scores', glamsterdam: true },
+];
+
+interface MeetingsItem {
+  path: string;
+  label: string;
+  title: string;
+}
+
+const meetingsItems: MeetingsItem[] = [
+  { path: '/calls', label: 'Calls', title: 'Protocol Calendar' },
+  { path: '/decisions', label: 'Decisions', title: 'Key decisions from ACD meetings' },
+];
+
+const btnClass = (active: boolean) =>
+  `px-2.5 py-1.5 rounded-md text-sm font-medium transition-colors inline-flex items-center gap-1 ${
+    active
+      ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+      : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+  }`;
+
+const directLinkClass = (active: boolean) =>
+  `px-2.5 py-1.5 rounded-md text-sm font-medium transition-colors ${
+    active
+      ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+      : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+  }`;
+
+const dropdownItemClass = (active: boolean) =>
+  `flex items-center justify-between px-3 py-2 text-sm transition-colors ${
+    active
+      ? 'bg-slate-50 dark:bg-slate-700/50 text-purple-700 dark:text-purple-300'
+      : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50'
+  }`;
+
+const chevron = (open: boolean) => (
+  <svg className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+);
+
+function useDropdown() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return { open, setOpen, ref };
+}
+
+const GlobalNav: React.FC = () => {
+  const location = useLocation();
+  const pathname = location.pathname.replace(/\/$/, '') || '/';
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const upgrades = useDropdown();
+  const meetings = useDropdown();
+  const planning = useDropdown();
+
+  // Close everything on navigation
+  useEffect(() => {
+    setMobileMenuOpen(false);
+    upgrades.setOpen(false);
+    meetings.setOpen(false);
+    planning.setOpen(false);
+  }, [pathname]);
+
+  const isActive = (path: string) => {
+    if (path === '/') return pathname === '/';
+    return pathname === path || pathname.startsWith(path + '/');
+  };
+
+  const isUpgradePage = pathname.startsWith('/upgrade/');
+  const isMeetingsPage = meetingsItems.some(i => isActive(i.path));
+  const isPlanningPage = planningItems.some(i => isActive(i.path));
+
+  const divider = <div className="w-px h-4 bg-slate-200 dark:bg-slate-700 mx-1" />;
+
+  return (
+    <nav className="sticky top-0 z-40 bg-white/95 dark:bg-slate-900/95 backdrop-blur-sm border-b border-slate-200 dark:border-slate-700/80">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6">
+        <div className="flex items-center justify-between h-12">
+          <Logo size="sm" className="flex-shrink-0" />
+
+          {/* Desktop nav */}
+          <div className="hidden md:flex items-center gap-0.5 ml-6 flex-1">
+            {/* Upgrades dropdown */}
+            <div className="relative" ref={upgrades.ref}>
+              <button
+                onClick={() => upgrades.setOpen(!upgrades.open)}
+                className={btnClass(isUpgradePage)}
+                type="button"
+              >
+                Upgrades
+                {chevron(upgrades.open)}
+              </button>
+              {upgrades.open && (
+                <div className="absolute top-full left-0 mt-1 w-56 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
+                  {activeUpgrades.map((u) => (
+                    <Link key={u.id} to={u.path} className={dropdownItemClass(pathname === u.path)}>
+                      <span className="font-medium">{u.name.replace(' Upgrade', '')}</span>
+                      <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${STATUS_COLORS[u.status] || ''}`}>
+                        {u.status}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {divider}
+
+            {/* EIPs - direct link */}
+            <Link to="/eips" title="EIP Directory" className={directLinkClass(isActive('/eips'))}>
+              EIPs
+            </Link>
+
+            {divider}
+
+            {/* Meetings dropdown */}
+            <div className="relative" ref={meetings.ref}>
+              <button
+                onClick={() => meetings.setOpen(!meetings.open)}
+                className={btnClass(isMeetingsPage)}
+                type="button"
+              >
+                Meetings
+                {chevron(meetings.open)}
+              </button>
+              {meetings.open && (
+                <div className="absolute top-full left-0 mt-1 w-60 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
+                  {meetingsItems.map((item) => (
+                    <Link key={item.path} to={item.path} className={dropdownItemClass(isActive(item.path))}>
+                      <div>
+                        <div className="font-medium">{item.label}</div>
+                        <div className="text-xs text-slate-400 dark:text-slate-500">{item.title}</div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {divider}
+
+            {/* ACD Planning dropdown */}
+            <div className="relative" ref={planning.ref}>
+              <button
+                onClick={() => planning.setOpen(!planning.open)}
+                className={btnClass(isPlanningPage)}
+                type="button"
+              >
+                ACD Planning
+                {chevron(planning.open)}
+              </button>
+              {planning.open && (
+                <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
+                  {planningItems.map((item) => (
+                    <Link key={item.path} to={item.path} className={dropdownItemClass(isActive(item.path))}>
+                      <div>
+                        <div className="font-medium inline-flex items-center gap-1.5">
+                          {item.label}
+                          {item.glamsterdam && (
+                            <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400">
+                              Glamsterdam
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-slate-400 dark:text-slate-500">{item.title}</div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {divider}
+
+            {/* Devnets - direct link */}
+            <Link to="/devnets" title="Devnet Tracker" className={directLinkClass(isActive('/devnets'))}>
+              Devnets
+            </Link>
+          </div>
+
+          {/* Right: Theme + Mobile menu */}
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+
+            <button
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              className="md:hidden p-1.5 rounded-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              aria-label="Toggle navigation menu"
+              type="button"
+            >
+              {mobileMenuOpen ? (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      {mobileMenuOpen && (
+        <div className="md:hidden border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+          <div className="max-w-5xl mx-auto px-4 py-3 space-y-1">
+            {/* Upgrades */}
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 px-2.5 pt-1 pb-1">
+              Upgrades
+            </div>
+            {activeUpgrades.map((u) => (
+              <Link
+                key={u.id}
+                to={u.path}
+                className={`flex items-center justify-between px-2.5 py-2 rounded-md transition-colors ${
+                  pathname === u.path
+                    ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+                    : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+                }`}
+              >
+                <span className="text-sm font-medium">{u.name.replace(' Upgrade', '')}</span>
+                <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${STATUS_COLORS[u.status] || ''}`}>
+                  {u.status}
+                </span>
+              </Link>
+            ))}
+
+            {/* EIPs */}
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 px-2.5 pt-3 pb-1">
+              EIPs
+            </div>
+            <Link
+              to="/eips"
+              className={`block px-2.5 py-2 rounded-md transition-colors ${
+                isActive('/eips')
+                  ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+                  : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+              }`}
+            >
+              <span className="text-sm font-medium">EIP Directory</span>
+              <span className="block text-xs text-slate-400 dark:text-slate-500 mt-0.5">Browse all Ethereum Improvement Proposals</span>
+            </Link>
+
+            {/* Meetings */}
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 px-2.5 pt-3 pb-1">
+              Meetings
+            </div>
+            {meetingsItems.map((item) => (
+              <Link
+                key={item.path}
+                to={item.path}
+                className={`block px-2.5 py-2 rounded-md transition-colors ${
+                  isActive(item.path)
+                    ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+                    : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+                }`}
+              >
+                <span className="text-sm font-medium">{item.label}</span>
+                <span className="block text-xs text-slate-400 dark:text-slate-500 mt-0.5">{item.title}</span>
+              </Link>
+            ))}
+
+            {/* ACD Planning */}
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 px-2.5 pt-3 pb-1">
+              ACD Planning
+            </div>
+            {planningItems.map((item) => (
+              <Link
+                key={item.path}
+                to={item.path}
+                className={`block px-2.5 py-2 rounded-md transition-colors ${
+                  isActive(item.path)
+                    ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+                    : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+                }`}
+              >
+                <span className="text-sm font-medium inline-flex items-center gap-1.5">
+                  {item.label}
+                  {item.glamsterdam && (
+                    <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400">
+                      Glamsterdam
+                    </span>
+                  )}
+                </span>
+                <span className="block text-xs text-slate-400 dark:text-slate-500 mt-0.5">{item.title}</span>
+              </Link>
+            ))}
+
+            {/* Devnets */}
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 px-2.5 pt-3 pb-1">
+              Devnets
+            </div>
+            <Link
+              to="/devnets"
+              className={`block px-2.5 py-2 rounded-md transition-colors ${
+                isActive('/devnets')
+                  ? 'bg-slate-100 dark:bg-slate-800 text-purple-700 dark:text-purple-300'
+                  : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+              }`}
+            >
+              <span className="text-sm font-medium">Devnet Tracker</span>
+              <span className="block text-xs text-slate-400 dark:text-slate-500 mt-0.5">Active devnet series, specs, and client support</span>
+            </Link>
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default GlobalNav;


### PR DESCRIPTION
## Summary

- **Global navigation bar** — persistent sticky nav on every page replacing per-page Logo/ThemeToggle headers. Categorized dropdowns: Upgrades (with status badges), Meetings (Calls + Decisions), ACD Planning (Schedule + fork-scoped Priority/Complexity). EIPs and Devnets as direct links. Responsive mobile menu with subtitles.
- **Homepage restructured** — split generic "Planning Tools" into a Glamsterdam Analysis section (purple container with Client Priority + Test Complexity) and Protocol-Wide Tools (Schedule, Devnet Tracker, Key Decisions). Enriched descriptions naming specific forks and data sources.
- **Decisions page now discoverable** — previously had zero entry points; now in nav dropdown and homepage.
- **Upgrade pages accessible from anywhere** — Upgrades dropdown lists Hegota, Glamsterdam, Fusaka, Pectra from any page.
- **AnalysisNav updated** — inline Glamsterdam badges on fork-scoped items.

## What was NOT changed

- Color palette, theme, and visual branding — untouched
- All existing page content and functionality — preserved
- UpgradeCarousel on homepage — kept as-is

## Test plan

- [ ] Verify all nav links work on desktop and mobile
- [ ] Check dropdowns open/close correctly, including outside-click dismiss
- [ ] Confirm active states highlight correctly on each page
- [ ] Test mobile hamburger menu shows all items with subtitles
- [ ] Verify no duplicate Logo/ThemeToggle on any page
- [ ] Check CallPage sticky sub-header stacks below GlobalNav
- [ ] Test upgrade page navigation via dropdown from inner pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)