### PR TITLE
Add noscript hint pointing LLM agents to /llms.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <noscript>This is a single-page app. Visit /llms.txt for guidance on how to traverse and access information from this website.</noscript>
     <script>
       try {
         const theme = localStorage.getItem('theme');

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <noscript>This is a single-page app. Visit /llms.txt for guidance on how to traverse and access information from this website.</noscript>
     <script>
       try {
         const theme = localStorage.getItem('theme');
@@ -68,6 +67,7 @@
     </script>
   </head>
   <body>
+    <noscript>This is a single-page app. Visit /llms.txt for guidance on how to traverse and access information from this website.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- Adds a `<noscript>` tag in `index.html` directing LLM agents to `/llms.txt`
- When agents fetch a SPA they get an empty JS shell with no navigable content — this gives them a breadcrumb to the structured site documentation
- `<noscript>` survives build minification, HTML-to-markdown conversion, and AI summarization, making it the most reliable approach over JS comments, `<meta>` tags, or HTML comments

## Test plan
- [x] Verify production build preserves the `<noscript>` tag
- [x] Fetch the deployed page with a non-JS client and confirm the hint is visible