### PR TITLE
Improve llms.txt for LLM agent discoverability

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,20 +1,50 @@
-Forkcast is a static Ethereum upgrade tracker focused on EIPs, protocol calls, devnets, and upgrade planning.
-It exposes public route pages plus machine-readable JSON and transcript artifacts for calls and status tracking.
+# Forkcast: Ethereum Upgrade Tracker
 
-# Key entry points
+> Source: https://github.com/ethereum/forkcast
 
-- [EIP directory](https://forkcast.org/eips)
-- [Protocol calls](https://forkcast.org/calls)
-- [Devnet tracker](https://forkcast.org/devnets)
-- [Key decisions](https://forkcast.org/decisions)
-- [Agenda planner](https://forkcast.org/agenda)
-- [Recent EIP stage changes JSON](https://forkcast.org/api/eip-stage-changes.json)
+Forkcast tracks EIPs, protocol calls, devnets, and upgrade planning for Ethereum network upgrades.
 
-# Call artifacts
+## Important: This is a Single Page Application
 
-Call pages live under `/calls/{type}/{number}`.
-Public call assets are served under `/artifacts/{series}/{date}_{number}/` and may include `transcript_corrected.vtt`, `transcript.vtt`, `chat.txt`, `tldr.json`, `key_decisions.json`, and `config.json`.
+Forkcast is a client-side rendered SPA. Route URLs like `/eips`, `/calls`, `/devnets`, `/decisions`, and `/agenda` return an empty HTML shell with no content. Do not fetch these routes expecting data.
 
-# EIP data
+## Static files you CAN fetch
 
-EIP spec markdown is served at `/eips/{number}.md` (e.g., `/eips/1153.md`).
+### EIP specs (Markdown)
+Individual EIP documents are served as static markdown:
+- Pattern: `/eips/{number}.md`
+- Example: /eips/1153.md
+
+### Call artifacts
+Call artifacts are served as static files organized by series and call number:
+- Pattern: `/artifacts/{series}/{date}_{number}/{file}`
+- Example: /artifacts/acde/2025-05-22_212/transcript.vtt
+
+Available files per call vary but may include: `transcript.vtt`, `transcript_corrected.vtt`, `chat.txt`, `config.json`, `tldr.json`, `key_decisions.json`, `agenda_suggestions.json`, `eip_threads.json`, `open_action_items.json`, `deferred_decisions.json`.
+
+Series include: acdc, acde, acdt, awd, bal, epbs, etm, fcr, focil, pqi, pqts, price, rpc, tli, zkevm.
+
+## Structured data (GitHub source)
+
+The full structured dataset lives in the source repo under `src/data/`:
+
+- `upgrades.ts` - All network upgrades with statuses, dates, and client team perspectives
+- `events.ts` - Timeline of devnets, testnets, and mainnet activations
+- `pending-proposals.ts` - Proposals not yet assigned EIP numbers
+- `eips.ts` / `eips/` - EIP metadata as JSON (one file per EIP)
+- `calls.ts` - Protocol call series definitions
+- `protocol-calls.generated.json` - Full index of all protocol calls
+
+Access these via the GitHub API: `gh api repos/ethereum/forkcast/contents/src/data/upgrades.ts`
+
+## Quick reference
+
+| Want                     | How                                                         |
+| ------------------------ | ----------------------------------------------------------- |
+| Single EIP spec          | `GET /eips/{number}.md`                                     |
+| Call transcript          | `GET /artifacts/{series}/{date}_{number}/transcript.vtt`    |
+| Call summary/decisions   | `GET /artifacts/{series}/{date}_{number}/key_decisions.json` |
+| All upgrades + statuses  | GitHub: `src/data/upgrades.ts`                              |
+| Full EIP index           | GitHub: `src/data/eips/`                                    |
+| Event timeline           | GitHub: `src/data/events.ts`                                |
+| Pending proposals        | GitHub: `src/data/pending-proposals.ts`                     |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,11 +18,31 @@ Individual EIP documents are served as static markdown:
 ### Call artifacts
 Call artifacts are served as static files organized by series and call number:
 - Pattern: `/artifacts/{series}/{date}_{number}/{file}`
-- Example: /artifacts/acde/2025-05-22_212/transcript.vtt
+- Example: /artifacts/acde/2026-04-09_234/tldr.json
 
-Available files per call vary but may include: `transcript.vtt`, `transcript_corrected.vtt`, `chat.txt`, `config.json`, `tldr.json`, `key_decisions.json`, `agenda_suggestions.json`, `eip_threads.json`, `open_action_items.json`, `deferred_decisions.json`.
+Available files per call vary but may include:
+- `tldr.json` - Structured highlights grouped by topic, with timestamps
+- `key_decisions.json` - Decisions made during the call, with EIP references
+- `transcript.vtt` / `transcript_corrected.vtt` - Full call transcript
+- `chat.txt` - Chat log
+- `config.json` - Call metadata
 
-Series include: acdc, acde, acdt, awd, bal, epbs, etm, fcr, focil, pqi, pqts, price, rpc, tli, zkevm.
+Recent ACDE and ACDC calls (from ~Oct 2025 onward) include `tldr.json` and `key_decisions.json`. Older calls only have transcripts and chat logs.
+
+### Call planning artifacts
+Each series has a `plan/` directory with upcoming agenda context:
+- Pattern: `/artifacts/{series}/plan/{file}`
+- Example: /artifacts/acde/plan/open_action_items.json
+- Files: `agenda_suggestions.json`, `deferred_decisions.json`, `eip_threads.json`, `open_action_items.json`
+
+### Finding recent calls
+The call index (`protocol-calls.generated.json`) is only in the source repo, not served as a static file. To discover recent calls, either:
+1. Fetch from GitHub: `gh api repos/ethereum/forkcast/contents/src/data/protocol-calls.generated.json`
+2. Or construct artifact paths directly — the two main series are:
+   - **acde** (All Core Devs - Execution): biweekly, numbered 208+, e.g. `/artifacts/acde/2026-04-09_234/`
+   - **acdc** (All Core Devs - Consensus): biweekly, numbered 154+, e.g. `/artifacts/acdc/2026-03-19_176/`
+
+Other series: acdt, awd, bal, epbs, etm, fcr, focil, pqi, pqts, price, rpc, tli, zkevm.
 
 ## Structured data (GitHub source)
 
@@ -39,12 +59,15 @@ Access these via the GitHub API: `gh api repos/ethereum/forkcast/contents/src/da
 
 ## Quick reference
 
-| Want                     | How                                                         |
-| ------------------------ | ----------------------------------------------------------- |
-| Single EIP spec          | `GET /eips/{number}.md`                                     |
-| Call transcript          | `GET /artifacts/{series}/{date}_{number}/transcript.vtt`    |
-| Call summary/decisions   | `GET /artifacts/{series}/{date}_{number}/key_decisions.json` |
-| All upgrades + statuses  | GitHub: `src/data/upgrades.ts`                              |
-| Full EIP index           | GitHub: `src/data/eips/`                                    |
-| Event timeline           | GitHub: `src/data/events.ts`                                |
-| Pending proposals        | GitHub: `src/data/pending-proposals.ts`                     |
+| Want                     | How                                                          |
+| ------------------------ | ------------------------------------------------------------ |
+| Single EIP spec          | `GET /eips/{number}.md`                                      |
+| Recent call TLDR         | `GET /artifacts/acde/{date}_{number}/tldr.json`              |
+| Recent call decisions    | `GET /artifacts/acde/{date}_{number}/key_decisions.json`     |
+| Call transcript          | `GET /artifacts/{series}/{date}_{number}/transcript.vtt`     |
+| Upcoming agenda context  | `GET /artifacts/{series}/plan/open_action_items.json`        |
+| All upgrades + statuses  | GitHub: `src/data/upgrades.ts`                               |
+| Full call index          | GitHub: `src/data/protocol-calls.generated.json`             |
+| Full EIP index           | GitHub: `src/data/eips/`                                     |
+| Event timeline           | GitHub: `src/data/events.ts`                                 |
+| Pending proposals        | GitHub: `src/data/pending-proposals.ts`                      |


### PR DESCRIPTION
## Summary

- Warns upfront that Forkcast is an SPA and route URLs (`/eips`, `/calls`, etc.) are not fetchable
- Separates static files (EIP markdown, call artifacts) from client-side routes with concrete patterns and examples
- Lists all artifact series and file types available per call
- Points to `src/data/` in the GitHub source for structured data (upgrades, events, EIP index)
- Adds a quick-reference table mapping common queries to their data sources

## Context

When an LLM agent encounters the current llms.txt, it sees routes like `/eips` and `/calls` listed as "key entry points" and tries to fetch them — getting back empty SPA shells. It also sees "machine-readable EIP stage changes JSON" without an actual URL, leading to guessed paths that 404. This rewrite makes it unambiguous what's fetchable and what isn't.

## Test plan

- [ ] Verify `/eips/1153.md` still serves correctly
- [ ] Verify an artifact path like `/artifacts/acde/2025-05-22_212/transcript.vtt` serves correctly
- [ ] Have an LLM agent fetch the new `llms.txt` and confirm it can navigate the site without 404s