### PR TITLE
sync: set video/transcript offsets for ACDT 77

### DIFF
--- a/public/artifacts/acdt/2026-04-13_077/config.json
+++ b/public/artifacts/acdt/2026-04-13_077/config.json
@@ -2,7 +2,7 @@
   "issue": 2008,
   "videoUrl": "https://youtube.com/watch?v=JcoG0oqmDNg",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:08:18",
+    "videoStartTime": "00:01:05"
   }
 }


### PR DESCRIPTION
## Summary
- Set video/transcript sync offsets for ACDT 77 (video: 00:01:05, transcript: 00:08:18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)