### PR TITLE
fix: normalize devnet naming in ACDT 77 summary

### DIFF
--- a/public/artifacts/acdt/2026-04-13_077/key_decisions.json
+++ b/public/artifacts/acdt/2026-04-13_077/key_decisions.json
@@ -2,7 +2,7 @@
   "meeting": "ACDT #77 - April 13, 2026",
   "key_decisions": [
     {
-      "original_text": "Prefer stability over adding EIP-2780 to BalDevNet 4 before interop",
+      "original_text": "Prefer stability over adding EIP-2780 to bal-devnet-4 before interop",
       "timestamp": "00:19:47",
       "type": "other",
       "eips": [
@@ -11,7 +11,7 @@
       "context": "deferred to maintain stability before interop"
     },
     {
-      "original_text": "Include EIP-7976 and EIP-7981 in BalDevNet 4 (simple data EIPs)",
+      "original_text": "Include EIP-7976 and EIP-7981 in bal-devnet-4 (simple data EIPs)",
       "timestamp": "00:21:28",
       "type": "devnet_inclusion",
       "eips": [

--- a/public/artifacts/acdt/2026-04-13_077/tldr.json
+++ b/public/artifacts/acdt/2026-04-13_077/tldr.json
@@ -4,11 +4,11 @@
     "devnet_status": [
       {
         "timestamp": "00:08:31",
-        "highlight": "ePBS DevNet 1 broken since launch; DevNet 2 planned after beacon state changes"
+        "highlight": "epbs-devnet-1 broken since launch; devnet 2 planned after beacon state changes"
       },
       {
         "timestamp": "00:09:12",
-        "highlight": "BalDevNet 3 launched Wednesday; Geth/Nethermind forked on gas accounting disagreement"
+        "highlight": "bal-devnet-3 launched Wednesday; Geth/Nethermind forked on gas accounting disagreement"
       },
       {
         "timestamp": "00:09:53",
@@ -18,7 +18,7 @@
     "bal_devnet_planning": [
       {
         "timestamp": "00:11:17",
-        "highlight": "BalDevNet 4 spec created; 2-3 issues for DevNet 3, remainder require DevNet 4"
+        "highlight": "bal-devnet-4 spec created; 2-3 issues for devnet 3, remainder require devnet 4"
       },
       {
         "timestamp": "00:13:27",
@@ -26,7 +26,7 @@
       },
       {
         "timestamp": "00:14:24",
-        "highlight": "EIP-7976 and EIP-7981 proposed for BalDevNet 4"
+        "highlight": "EIP-7976 and EIP-7981 proposed for bal-devnet-4"
       },
       {
         "timestamp": "00:14:50",
@@ -72,11 +72,11 @@
   "decisions": [
     {
       "timestamp": "00:19:47",
-      "decision": "Prefer stability over adding EIP-2780 to BalDevNet 4 before interop"
+      "decision": "Prefer stability over adding EIP-2780 to bal-devnet-4 before interop"
     },
     {
       "timestamp": "00:21:28",
-      "decision": "Include EIP-7976 and EIP-7981 in BalDevNet 4 (simple data EIPs)"
+      "decision": "Include EIP-7976 and EIP-7981 in bal-devnet-4 (simple data EIPs)"
     },
     {
       "timestamp": "00:19:32",
@@ -86,7 +86,7 @@
   "targets": [
     {
       "timestamp": "00:15:21",
-      "target": "April 29th - Latest BalDevNet 4 launch (prefer before interop)"
+      "target": "April 29th - Latest bal-devnet-4 launch (prefer before interop)"
     }
   ]
 }

--- a/public/artifacts/acdt/2026-04-13_077/tldr.json
+++ b/public/artifacts/acdt/2026-04-13_077/tldr.json
@@ -36,7 +36,7 @@
     "epbs_technical": [
       {
         "timestamp": "00:22:54",
-        "highlight": "Proposed: EPBS range sync without requesting payloads for finalized sections"
+        "highlight": "Proposed: ePBS range sync without requesting payloads for finalized sections"
       },
       {
         "timestamp": "00:24:40",
@@ -60,7 +60,7 @@
     },
     {
       "timestamp": "00:34:30",
-      "action": "Write up EPBS range sync proposal for EL team review",
+      "action": "Write up ePBS range sync proposal for EL team review",
       "owner": "Potuz"
     },
     {


### PR DESCRIPTION
## Summary
- Patch ACDT 77 tldr.json and key_decisions.json: BalDevNet → bal-devnet-N, ePBS DevNet → epbs-devnet-N, DevNet → devnet
- Root cause addressed upstream in ethereum/pm (changelog prompt fix)

## Test plan
- [ ] Verify summary renders correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)