### PR TITLE
sync: set video/transcript offsets for FCR 006

### DIFF
--- a/public/artifacts/fcr/2026-04-14_006/config.json
+++ b/public/artifacts/fcr/2026-04-14_006/config.json
@@ -2,7 +2,7 @@
   "issue": 1982,
   "videoUrl": "https://www.youtube.com/watch?v=3U_Vm78QKLM",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:06:49",
+    "videoStartTime": "00:06:49"
   }
 }


### PR DESCRIPTION
## Summary
- Set video and transcript start time offsets to `00:06:49` for FCR 006 to skip dead air at the beginning of the recording