### PR TITLE
sync: set video/transcript offsets for PQTS 006

### DIFF
--- a/public/artifacts/pqts/2026-04-15_006/config.json
+++ b/public/artifacts/pqts/2026-04-15_006/config.json
@@ -2,7 +2,7 @@
   "issue": 2011,
   "videoUrl": "https://www.youtube.com/watch?v=yAmLfnlnKtw",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:02:53",
+    "videoStartTime": "00:02:53"
   }
 }


### PR DESCRIPTION
## Summary
- Set video/transcript sync offsets for PQTS 006 to `00:02:53` (dead air at start)