### PR TITLE
Remove show/hide events toggle from calls page

### DIFF
--- a/src/components/CallsIndexPage.tsx
+++ b/src/components/CallsIndexPage.tsx
@@ -25,7 +25,6 @@ const CallsIndexPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedFilter = searchParams.get('filter') || 'all';
   const selectedBreakoutType = searchParams.get('breakoutType') || '';
-  const showEvents = searchParams.get('events') !== 'false';
   const [upcomingCalls, setUpcomingCalls] = useState<UpcomingCall[]>([]);
   const [upcomingCallsLoading, setUpcomingCallsLoading] = useState(true);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -112,9 +111,9 @@ const CallsIndexPage: React.FC = () => {
     return [
       ...filteredCalls,
       ...filteredUpcomingCalls,
-      ...(showEvents ? timelineEvents : [])
+      ...timelineEvents
     ];
-  }, [filteredCalls, filteredUpcomingCalls, showEvents]);
+  }, [filteredCalls, filteredUpcomingCalls]);
 
   const viewerTimeZone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
   const todayDateString = getTodayDateString(new Date(), viewerTimeZone);
@@ -159,7 +158,6 @@ const CallsIndexPage: React.FC = () => {
           <CallsIndexFilters
             selectedFilter={selectedFilter}
             selectedBreakoutType={selectedBreakoutType}
-            showEvents={showEvents}
             breakoutDropdownOpen={breakoutDropdownOpen}
             breakoutDropdownRef={breakoutDropdownRef}
             breakoutLabel={breakoutLabel}
@@ -185,12 +183,6 @@ const CallsIndexPage: React.FC = () => {
                 else next.delete('breakoutType');
               });
               setBreakoutDropdownOpen(false);
-            }}
-            onToggleEvents={() => {
-              updateSearchParams((next) => {
-                if (showEvents) next.set('events', 'false');
-                else next.delete('events');
-              });
             }}
           />
         </div>

--- a/src/components/calls-index/CallsIndexFilters.tsx
+++ b/src/components/calls-index/CallsIndexFilters.tsx
@@ -31,7 +31,6 @@ const FILTER_INACTIVE_COLORS: Record<string, string> = {
 interface CallsIndexFiltersProps {
   selectedFilter: string;
   selectedBreakoutType: string;
-  showEvents: boolean;
   breakoutDropdownOpen: boolean;
   breakoutDropdownRef: RefObject<HTMLDivElement | null>;
   breakoutLabel: string;
@@ -41,13 +40,11 @@ interface CallsIndexFiltersProps {
   onBackToAllFilters: () => void;
   onToggleBreakoutDropdown: () => void;
   onSelectBreakoutType: (breakoutType: string | null) => void;
-  onToggleEvents: () => void;
 }
 
 export const CallsIndexFilters = ({
   selectedFilter,
   selectedBreakoutType,
-  showEvents,
   breakoutDropdownOpen,
   breakoutDropdownRef,
   breakoutLabel,
@@ -57,12 +54,11 @@ export const CallsIndexFilters = ({
   onBackToAllFilters,
   onToggleBreakoutDropdown,
   onSelectBreakoutType,
-  onToggleEvents
 }: CallsIndexFiltersProps) => {
   const isBreakoutsExpanded = selectedFilter === 'breakouts';
 
   return (
-    <div className="mt-4 flex items-center justify-between gap-2">
+    <div className="mt-4">
       <div className={`flex items-center gap-1.5 flex-nowrap sm:flex-wrap ${isBreakoutsExpanded ? '' : 'overflow-x-auto scrollbar-hide'}`}>
         {isBreakoutsExpanded ? (
           <>
@@ -147,18 +143,6 @@ export const CallsIndexFilters = ({
           </>
         )}
       </div>
-
-      <button
-        onClick={onToggleEvents}
-        className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
-          showEvents
-            ? 'bg-slate-600 text-white dark:bg-slate-400 dark:text-slate-900'
-            : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700'
-        }`}
-      >
-        <div className={`h-1.5 w-1.5 rounded-full ${showEvents ? 'bg-white dark:bg-slate-900' : 'bg-slate-500 dark:bg-slate-400'}`}></div>
-        <span>{showEvents ? 'Hide Events' : 'Show Events'}</span>
-      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removes the "Show Events / Hide Events" toggle button from the Protocol Calendar page
- Events are now always displayed in the timeline — simplifies the UI and removes the `events` URL search param and related state/props

## Test plan
- [x] Visit `/calls` and confirm events appear in the timeline
- [x] Confirm the toggle button is gone from the filter bar
- [x] Confirm existing filters (All, ACD, Breakouts, etc.) still work
- [x] Confirm `?events=false` URL param no longer hides events