### PR TITLE
Persist upgrade page layer/search filters in URL query params

### DIFF
--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../data/eips';
 import { getPendingProposalsForFork } from '../data/pending-proposals';
 import { Logo } from './ui/Logo';
@@ -70,12 +70,19 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   // Determine display mode for this upgrade page
   const pageMode = getUpgradePageMode(forkName);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const layerParam = searchParams.get('layer');
+  const initialLayerFilter: 'all' | 'EL' | 'CL' =
+    layerParam === 'EL' || layerParam === 'CL' ? layerParam : 'all';
+  const initialSearchQuery = searchParams.get('filter') ?? '';
+
   const [eips, setEips] = useState<EIP[]>([]);
   const [activeSection, setActiveSection] = useState<string>('overview');
   const [isDeclinedExpanded, setIsDeclinedExpanded] = useState(false);
   // In headlinerSelection mode, expand by default since it's the main content
   const [isHeadlinerProposalsExpanded, setIsHeadlinerProposalsExpanded] = useState(pageMode === 'headlinerSelection');
-  const [layerFilter, setLayerFilter] = useState<'all' | 'EL' | 'CL'>('all');
+  const [layerFilter, setLayerFilter] = useState<'all' | 'EL' | 'CL'>(initialLayerFilter);
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
 
   // Ensure headliner proposals are expanded when entering headlinerSelection mode
   useEffect(() => {
@@ -83,8 +90,37 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
       setIsHeadlinerProposalsExpanded(true);
     }
   }, [pageMode]);
-  const [searchQuery, setSearchQuery] = useState('');
   const location = useLocation();
+
+  const updateFilterParams = (nextLayer: 'all' | 'EL' | 'CL', nextQuery: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (nextLayer === 'all') {
+          next.delete('layer');
+        } else {
+          next.set('layer', nextLayer);
+        }
+        if (!nextQuery.trim()) {
+          next.delete('filter');
+        } else {
+          next.set('filter', nextQuery);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
+  const handleLayerFilterChange = (filter: 'all' | 'EL' | 'CL') => {
+    setLayerFilter(filter);
+    updateFilterParams(filter, searchQuery);
+  };
+
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query);
+    updateFilterParams(layerFilter, query);
+  };
   const { trackUpgradeView, trackLinkClick } = useAnalytics();
 
   // Update meta tags for SEO and social sharing
@@ -440,9 +476,9 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
             activeSection={activeSection}
             onSectionClick={scrollToSection}
             searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
+            onSearchChange={handleSearchChange}
             layerFilter={layerFilter}
-            onLayerFilterChange={setLayerFilter}
+            onLayerFilterChange={handleLayerFilterChange}
             showLayerFilter={pageMode === 'headlinerSelection' || forkName.toLowerCase() === 'glamsterdam' || forkName.toLowerCase() === 'hegota'}
           />
 

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../data/eips';
 import { getPendingProposalsForFork } from '../data/pending-proposals';
 import { Logo } from './ui/Logo';
@@ -46,6 +46,29 @@ const getUpgradePageMode = (forkName: string): UpgradePageMode => {
   return upgradePageModeByFork[forkName.toLowerCase()] ?? 'default';
 };
 
+const normalizeFilterParams = (
+  params: URLSearchParams,
+  showLayerFilter: boolean,
+  nextLayer: 'all' | 'EL' | 'CL',
+  nextQuery: string
+) => {
+  const next = new URLSearchParams(params);
+
+  if (!showLayerFilter || nextLayer === 'all') {
+    next.delete('layer');
+  } else {
+    next.set('layer', nextLayer);
+  }
+
+  if (!nextQuery.trim()) {
+    next.delete('filter');
+  } else {
+    next.set('filter', nextQuery);
+  }
+
+  return next;
+};
+
 interface PublicNetworkUpgradePageProps {
   forkName: string;
   displayName: string;
@@ -70,8 +93,9 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   // Determine display mode for this upgrade page
   const pageMode = getUpgradePageMode(forkName);
   const showLayerFilter = pageMode === 'headlinerSelection' || forkName.toLowerCase() === 'glamsterdam' || forkName.toLowerCase() === 'hegota';
-
-  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
   const layerParam = searchParams.get('layer');
   const layerFilter: 'all' | 'EL' | 'CL' =
     showLayerFilter && (layerParam === 'EL' || layerParam === 'CL') ? layerParam : 'all';
@@ -89,36 +113,17 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
       setIsHeadlinerProposalsExpanded(true);
     }
   }, [pageMode]);
-  const location = useLocation();
-
-  useEffect(() => {
-    if (showLayerFilter || !layerParam) return;
-
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete('layer');
-        return next;
-      },
-      { replace: true }
-    );
-  }, [layerParam, setSearchParams, showLayerFilter]);
+  const { trackUpgradeView, trackLinkClick } = useAnalytics();
 
   const updateFilterParams = (nextLayer: 'all' | 'EL' | 'CL', nextQuery: string) => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (!showLayerFilter || nextLayer === 'all') {
-          next.delete('layer');
-        } else {
-          next.set('layer', nextLayer);
-        }
-        if (!nextQuery.trim()) {
-          next.delete('filter');
-        } else {
-          next.set('filter', nextQuery);
-        }
-        return next;
+    const nextParams = normalizeFilterParams(searchParams, showLayerFilter, nextLayer, nextQuery);
+    const nextSearch = nextParams.toString();
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+        hash: location.hash,
       },
       { replace: true }
     );
@@ -131,7 +136,6 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   const handleSearchChange = (query: string) => {
     updateFilterParams(layerFilter, query);
   };
-  const { trackUpgradeView, trackLinkClick } = useAnalytics();
 
   // Update meta tags for SEO and social sharing
   useMetaTags({

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -69,20 +69,19 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
 }) => {
   // Determine display mode for this upgrade page
   const pageMode = getUpgradePageMode(forkName);
+  const showLayerFilter = pageMode === 'headlinerSelection' || forkName.toLowerCase() === 'glamsterdam' || forkName.toLowerCase() === 'hegota';
 
   const [searchParams, setSearchParams] = useSearchParams();
   const layerParam = searchParams.get('layer');
-  const initialLayerFilter: 'all' | 'EL' | 'CL' =
-    layerParam === 'EL' || layerParam === 'CL' ? layerParam : 'all';
-  const initialSearchQuery = searchParams.get('filter') ?? '';
+  const layerFilter: 'all' | 'EL' | 'CL' =
+    showLayerFilter && (layerParam === 'EL' || layerParam === 'CL') ? layerParam : 'all';
+  const searchQuery = searchParams.get('filter') ?? '';
 
   const [eips, setEips] = useState<EIP[]>([]);
   const [activeSection, setActiveSection] = useState<string>('overview');
   const [isDeclinedExpanded, setIsDeclinedExpanded] = useState(false);
   // In headlinerSelection mode, expand by default since it's the main content
   const [isHeadlinerProposalsExpanded, setIsHeadlinerProposalsExpanded] = useState(pageMode === 'headlinerSelection');
-  const [layerFilter, setLayerFilter] = useState<'all' | 'EL' | 'CL'>(initialLayerFilter);
-  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
 
   // Ensure headliner proposals are expanded when entering headlinerSelection mode
   useEffect(() => {
@@ -92,11 +91,24 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   }, [pageMode]);
   const location = useLocation();
 
+  useEffect(() => {
+    if (showLayerFilter || !layerParam) return;
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('layer');
+        return next;
+      },
+      { replace: true }
+    );
+  }, [layerParam, setSearchParams, showLayerFilter]);
+
   const updateFilterParams = (nextLayer: 'all' | 'EL' | 'CL', nextQuery: string) => {
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        if (nextLayer === 'all') {
+        if (!showLayerFilter || nextLayer === 'all') {
           next.delete('layer');
         } else {
           next.set('layer', nextLayer);
@@ -113,12 +125,10 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
   };
 
   const handleLayerFilterChange = (filter: 'all' | 'EL' | 'CL') => {
-    setLayerFilter(filter);
     updateFilterParams(filter, searchQuery);
   };
 
   const handleSearchChange = (query: string) => {
-    setSearchQuery(query);
     updateFilterParams(layerFilter, query);
   };
   const { trackUpgradeView, trackLinkClick } = useAnalytics();
@@ -479,7 +489,7 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
             onSearchChange={handleSearchChange}
             layerFilter={layerFilter}
             onLayerFilterChange={handleLayerFilterChange}
-            showLayerFilter={pageMode === 'headlinerSelection' || forkName.toLowerCase() === 'glamsterdam' || forkName.toLowerCase() === 'hegota'}
+            showLayerFilter={showLayerFilter}
           />
 
           <div className="flex-1 min-w-0">

--- a/src/components/ui/CopyLinkButton.tsx
+++ b/src/components/ui/CopyLinkButton.tsx
@@ -15,7 +15,7 @@ export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({
   const [copiedSection, setCopiedSection] = useState<string | null>(null);
 
   const copyLinkToClipboard = (sectionId: string) => {
-    const url = `${window.location.origin}${window.location.pathname}#${sectionId}`;
+    const url = `${window.location.origin}${window.location.pathname}${window.location.search}#${sectionId}`;
     navigator.clipboard.writeText(url).then(() => {
       setCopiedSection(sectionId);
       // Clear the copied state after 2 seconds


### PR DESCRIPTION
## Summary

Make the **layer filter** (EL/CL/All) and **search text** on `/upgrade/:fork` pages shareable via URL so users can link directly to a filtered view.

- On mount, initialize `layerFilter` from `?layer=EL|CL` and `searchQuery` from `?filter=<query>`
- On change, sync back to the URL via `setSearchParams(..., { replace: true })` — no history spam, no reload
- `layer=all` and empty `filter` are stripped so clean URLs stay clean
- Follows the existing `useSearchParams` pattern from `StakeholderUpgradePage.tsx` (`?view=...`)

### Before
`https://forkcast.org/upgrade/glamsterdam` always loaded with "All" selected, even if the user had picked CL. Refreshing or sharing the tab lost the filter.

### After
`https://forkcast.org/upgrade/glamsterdam?layer=CL` lands directly on the CL-filtered view. Combined filters work too, e.g. `?layer=EL&filter=7702`.

## Test plan

Verified via Playwright against the Netlify deploy preview:

- [x] Visit `/upgrade/glamsterdam?layer=CL` — CL button active
- [x] Visit `/upgrade/glamsterdam?layer=EL&filter=7732` — EL active and input pre-filled with `7732`
- [x] Click CL button — URL updates to `?layer=CL`
- [x] Click All — `layer` param removed from URL
- [x] Type in "Filter EIPs…" — `?filter=...` updates live
- [x] Clear the search — `filter` param removed
- [x] Combined CL + text → both `?layer=CL&filter=proposer` present
- [x] Typing does not push browser history entries (replaceState)
- [x] `/upgrade/hegota?layer=EL` also honors the param (showLayerFilter for hegota)