### PR TITLE
fix: correct ACDC 177 BAL artifacts

### DIFF
--- a/public/artifacts/acdc/2026-04-16_177/key_decisions.json
+++ b/public/artifacts/acdc/2026-04-16_177/key_decisions.json
@@ -9,14 +9,14 @@
       "context": "defer optimization"
     },
     {
-      "original_text": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+FOCIL",
+      "original_text": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+BAL",
       "timestamp": "00:48:30",
       "type": "other",
       "eips": [
         7732,
-        7805
+        7928
       ],
-      "context": "merged ePBS+FOCIL workstreams"
+      "context": "merged ePBS+BAL workstreams"
     },
     {
       "original_text": "Add EIP 8136 (partial slashings) to Glamsterdam meta EIP as optional",

--- a/public/artifacts/acdc/2026-04-16_177/tldr.json
+++ b/public/artifacts/acdc/2026-04-16_177/tldr.json
@@ -8,7 +8,7 @@
       },
       {
         "timestamp": "00:47:00",
-        "highlight": "ePBS DevNet 2 cancelled; merging ePBS and FOCIL for DevNet 0"
+        "highlight": "ePBS DevNet 2 cancelled; merging ePBS and BAL for DevNet 0"
       },
       {
         "timestamp": "01:06:40",
@@ -70,7 +70,7 @@
     },
     {
       "timestamp": "00:48:30",
-      "decision": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+FOCIL"
+      "decision": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+BAL"
     },
     {
       "timestamp": "00:53:50",

--- a/public/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
+++ b/public/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
@@ -3,5 +3,4 @@ Glenster Dam	Glamsterdam	high
 DevNets	devnets	high
 Hagoda	Hegota	high
 EPBS	ePBS	high
-BAL	FOCIL	medium
 Nethermine	Nethermind	high

--- a/public/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
+++ b/public/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
@@ -38,7 +38,7 @@ stokes: You know, in the short term, looking at Glamsterdam and moving forward w
 
 10
 00:11:28.580 --> 00:11:35.449
-stokes: And if there's time, we'll have an update on some of the FOCIL work.
+stokes: And if there's time, we'll have an update on some of the BAL work.
 
 11
 00:11:35.950 --> 00:11:38.300
@@ -754,7 +754,7 @@ stokes: I forget what these comments are. Yeah, okay. So I think from here, I mi
 
 189
 00:36:25.120 --> 00:36:32.469
-stokes: There's FOCIL DevNet 4, eBPS DevNet 2, that's gonna reflect some of the changes we were just discussing.
+stokes: There's BAL DevNet 4, eBPS DevNet 2, that's gonna reflect some of the changes we were just discussing.
 
 190
 00:36:32.760 --> 00:36:36.760
@@ -998,7 +998,7 @@ terence: are minimally touched by 5094.
 
 250
 00:42:57.480 --> 00:43:05.029
-stokes: Yeah, and so we're not worried about, like, some FOCIL bug on the EL causing issues with the EPPS state transition, and…
+stokes: Yeah, and so we're not worried about, like, some BAL bug on the EL causing issues with the EPPS state transition, and…
 
 251
 00:43:05.180 --> 00:43:06.380
@@ -1662,7 +1662,7 @@ stokes: Yup.
 
 416
 00:59:40.570 --> 00:59:47.610
-stokes: Okay, cool. And then, yeah, circling back to BOTUS, I'm assuming you might have a question about the FOCIL stuff?
+stokes: Okay, cool. And then, yeah, circling back to BOTUS, I'm assuming you might have a question about the BAL stuff?
 
 417
 00:59:48.010 --> 00:59:56.029
@@ -2443,4 +2443,3 @@ Potuz: Bye-bye.
 611
 01:27:48.450 --> 01:27:49.140
 Justin Traglia: Hi, everyone.
-

--- a/scripts/extract-key-decisions.mjs
+++ b/scripts/extract-key-decisions.mjs
@@ -50,7 +50,7 @@ You receive the full TLDR (highlights, action items, decisions, targets). Classi
 
 - Multiple EIPs with the SAME action → one entry, all EIP numbers in \`eips\` array.
 - DIFFERENT actions in one decision string → separate entries per action.
-- Extract EIP numbers as integers from "EIP-1234", "EIP1234", or contextual references. Resolve well-known proposal names to their EIP numbers (e.g., FOCIL = 7805, ePBS = 7732, PeerDAS = 7594). Resolve ETH/XX aliases using the "Known Aliases" section if provided.
+- Extract EIP numbers as integers from "EIP-1234", "EIP1234", or contextual references. Resolve well-known proposal names to their EIP numbers (e.g., BAL = 7928, FOCIL = 7805, ePBS = 7732, PeerDAS = 7594). Resolve ETH/XX aliases using the "Known Aliases" section if provided.
 - \`original_text\` and \`timestamp\` must be copied verbatim from input.
 - If no EIP numbers can be identified, set \`eips\` to \`[]\`.
 - Rejecting a technical change *to* an EIP (not the EIP itself) → \`other\`.


### PR DESCRIPTION
## Summary
The synced ACDC 177 assets inherited a bad PM transcript correction that rewrote `BAL` to `FOCIL`.

kudos to @abcoathup for the fix! we also fixed the root cause in the pm repo here: https://github.com/ethereum/pm/pull/2025

## Fix
- update the synced ACDC 177 transcript, TLDR, and key decisions to use `BAL`
- map `BAL` to `EIP-7928` in key-decision extraction so future regenerations classify it correctly