### PR TITLE
update EIP statuses from ACDC 177

### DIFF
--- a/src/data/eips/7716.json
+++ b/src/data/eips/7716.json
@@ -8,6 +8,26 @@
   "category": "Core",
   "createdDate": "2024-05-25",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7716-anti-correlation-attestation-penalties/20137",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acdc/177",
+          "date": "2026-04-16",
+          "timestamp": 3532
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acdc/177",
+          "date": "2026-04-16",
+          "timestamp": 3532
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }

--- a/src/data/eips/8136.json
+++ b/src/data/eips/8136.json
@@ -16,7 +16,7 @@
           "status": "Considered",
           "call": "acdc/177",
           "date": "2026-04-16",
-          "timestamp": 2738
+          "timestamp": 2729
         }
       ]
     }

--- a/src/data/eips/8136.json
+++ b/src/data/eips/8136.json
@@ -8,6 +8,18 @@
   "category": "Networking",
   "createdDate": "2025-01-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8136-cell-level-deltas-for-data-column-broadcast/27675",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Glamsterdam",
+      "statusHistory": [
+        {
+          "status": "Considered",
+          "call": "acdc/177",
+          "date": "2026-04-16",
+          "timestamp": 2738
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }

--- a/src/data/eips/8205.json
+++ b/src/data/eips/8205.json
@@ -8,6 +8,26 @@
   "category": "Core",
   "createdDate": "2026-03-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8205-withdrawal-credentials-preregistration/28084",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acdc/177",
+          "date": "2026-04-16",
+          "timestamp": 3853
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acdc/177",
+          "date": "2026-04-16",
+          "timestamp": 3853
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }


### PR DESCRIPTION
## Summary

Status updates derived from ACDC #177 (April 16, 2026).

- **EIP-8136** (Cell-Level Deltas for Data Column Broadcast): added Glamsterdam fork relationship → `Considered`. Decision in call: "Add EIP 8136 to Glamsterdam meta EIP as optional" (~00:53:50). Confirmed against [EIP-7773](https://eips.ethereum.org/EIPS/eip-7773) — 8136 is in the CFI section, not SFI.
- **EIP-7716** (Anti-correlation attestation penalties): added Hegota fork relationship → `Proposed` + `presentation` entry. Oisin (Obol) presented as a non-headliner Hegota proposal (~01:07:04).
- **EIP-8205** (Withdrawal credentials preregistration): added Hegota fork relationship → `Proposed` + `presentation` entry. Dima (Lido) presented as a non-headliner Hegota proposal (~01:12:25).

## Related

- Transcript correction ("nod" → "non" headliner) split into #224.
- Hegotá meta EIP (EIP-8081) update PR opened in personal fork: dionysuzx/EIPs#7 — adds 7716, 8205 to PFI section and 8141 to CFI section.

## Notes for review

7716 and 8205 are not currently in EIP-8081's PFI section. Per EIP-7723, PFI requires a PR to the meta EIP. This repo has historically used `Proposed` more loosely (cf. EIP-8045's initial Glamsterdam entry), but for cleanest alignment, the upstream meta EIP PR should land before this merges.

Separately: **EIP-8141 (Frame Transaction)** is `Considered` for Hegota in this repo (acde/233) but is not in EIP-8081's CFI section. Being addressed in dionysuzx/EIPs#7.

## Test plan

- [ ] Visual check on /upgrade/glamsterdam shows 8136 under Considered
- [ ] Visual check on /upgrade/hegota shows 7716 and 8205 under Proposed
- [ ] Type-check passes (verified locally)