### PR TITLE
fix ACDC 177 transcript: nod → non headliner

### DIFF
--- a/public/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
+++ b/public/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
@@ -4,3 +4,4 @@ DevNets	devnets	high
 Hagoda	Hegota	high
 EPBS	ePBS	high
 Nethermine	Nethermind	high
+nod headliner	non headliner	high

--- a/public/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
+++ b/public/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
@@ -1878,7 +1878,7 @@ stokes: Okay, then let's move to Hagota.
 
 470
 01:06:00.740 --> 01:06:08.809
-stokes: And yeah, just a quick reminder, so we've opened the nod headliner proposal process, or window, I should say.
+stokes: And yeah, just a quick reminder, so we've opened the non headliner proposal process, or window, I should say.
 
 471
 01:06:09.130 --> 01:06:12.119


### PR DESCRIPTION
## Summary

Single-character ASR fix in the ACDC 177 transcript.

At ~01:06:00, stokes opened the **non**-headliner proposal window for Hegota; the corrected transcript had garbled this as "nod headliner". This matters because it determines whether EIPs floated in that segment (e.g., 7716, 8205) are tracked as headliner candidates or non-headliner proposals.

Adds the correction to `transcript_changelog.tsv` so it's traceable.

## Test plan

- [ ] Visual check on /calls/acdc/177 transcript at 01:06:00 shows "non headliner"
- [ ] `transcript_changelog.tsv` lists the correction