### PR TITLE
sync: set video/transcript offsets for ACDT 78

### DIFF
--- a/public/artifacts/acdt/2026-04-20_078/config.json
+++ b/public/artifacts/acdt/2026-04-20_078/config.json
@@ -2,7 +2,7 @@
   "issue": 2019,
   "videoUrl": "https://youtube.com/watch?v=ZvG3OkEt8_o",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:06:16",
+    "videoStartTime": "00:03:33"
   }
 }


### PR DESCRIPTION
## Summary
- Set sync offsets for ACDT 78 (livestreamed call)
- video: 00:03:33, transcript: 00:06:16

## Test plan
- [x] Verified sync looks good on local dev server