### PR TITLE
upgrade page mobile optimizations

### DIFF
--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -520,8 +520,6 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
                 status={status}
                 activationDate={activationDate}
                 onStageClick={scrollToSection}
-                clientTeamPerspectives={clientTeamPerspectives}
-                onExternalLinkClick={handleExternalLinkClick}
                 activationDetails={activationDetails}
               />
 

--- a/src/components/PublicNetworkUpgradePage.tsx
+++ b/src/components/PublicNetworkUpgradePage.tsx
@@ -32,6 +32,7 @@ import {
   HegotaTimeline,
   PectraTimeline,
   TableOfContents,
+  EipFilterBar,
   OverviewSection,
   ClientPerspectives,
   EipCard
@@ -484,6 +485,19 @@ const PublicNetworkUpgradePage: React.FC<PublicNetworkUpgradePageProps> = ({
         </div>
 
         <NetworkUpgradeTimeline currentForkName={forkName} />
+
+        {/* Mobile-only filter bar — the desktop sidebar (lg+) handles this */}
+        <div className="lg:hidden mb-4">
+          <EipFilterBar
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+            layerFilter={layerFilter}
+            onLayerFilterChange={handleLayerFilterChange}
+            showLayerFilter={showLayerFilter}
+            matchCount={filterEips(eips).length}
+            totalEipCount={filterEipsByLayer(eips).length}
+          />
+        </div>
 
         <div className="flex gap-8">
           <TableOfContents

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -269,7 +269,7 @@ export const EipPage: React.FC = () => {
 
             {/* Description */}
             <p className="mt-4 text-slate-700 dark:text-slate-300 leading-relaxed">
-              {parseMarkdownLinks(eip.laymanDescription || eip.description)}
+              {parseMarkdownLinks(eip.description)}
             </p>
 
             {/* Breakout Call */}

--- a/src/components/network-upgrade/EipCard.tsx
+++ b/src/components/network-upgrade/EipCard.tsx
@@ -13,8 +13,9 @@ import {
   getEipLayer,
 } from '../../utils';
 import { Tooltip, CopyLinkButton } from '../ui';
-import { useButterflyData } from '../../hooks/useButterflyData';
-import { ClientTestingProgress } from './ClientTestingProgress';
+// Butterfly view disabled — data is stale. Uncomment to re-enable.
+// import { useButterflyData } from '../../hooks/useButterflyData';
+// import { ClientTestingProgress } from './ClientTestingProgress';
 
 interface EipCardProps {
   eip: EIP;
@@ -28,8 +29,8 @@ export const EipCard: React.FC<EipCardProps> = ({ eip, forkName, handleExternalL
   const [showChampionDetails, setShowChampionDetails] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Fetch butterfly data for EIP 7928
-  const { data: butterflyData, loading: butterflyLoading, error: butterflyError } = useButterflyData(eip.id, forkName);
+  // Butterfly view disabled — data is stale. Uncomment to re-enable.
+  // const { data: butterflyData, loading: butterflyLoading, error: butterflyError } = useButterflyData(eip.id, forkName);
 
   const hasMissingTradeoffs = !eip.tradeoffs || eip.tradeoffs.length === 0;
 
@@ -371,7 +372,7 @@ export const EipCard: React.FC<EipCardProps> = ({ eip, forkName, handleExternalL
           );
         })()}
 
-        {/* Client Testing Progress (EIP 7928) */}
+        {/* Butterfly view disabled — data is stale. Uncomment to re-enable.
         {eip.id === 7928 && !butterflyLoading && (
           <>
             {butterflyData && <ClientTestingProgress data={butterflyData} />}
@@ -389,6 +390,7 @@ export const EipCard: React.FC<EipCardProps> = ({ eip, forkName, handleExternalL
             )}
           </>
         )}
+        */}
 
         {/* Benefits - Always visible */}
         {eip.benefits && eip.benefits.length > 0 && (

--- a/src/components/network-upgrade/EipFilterBar.tsx
+++ b/src/components/network-upgrade/EipFilterBar.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Tooltip } from '../ui';
+
+type LayerFilter = 'all' | 'EL' | 'CL';
+
+interface EipFilterBarProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  layerFilter?: LayerFilter;
+  onLayerFilterChange?: (filter: LayerFilter) => void;
+  showLayerFilter?: boolean;
+  matchCount: number;
+  totalEipCount: number;
+}
+
+export const EipFilterBar: React.FC<EipFilterBarProps> = ({
+  searchQuery,
+  onSearchChange,
+  layerFilter = 'all',
+  onLayerFilterChange,
+  showLayerFilter = false,
+  matchCount,
+  totalEipCount,
+}) => {
+  return (
+    <>
+      {/* Search input */}
+      <div className="relative mb-3 px-0.5">
+        <input
+          type="text"
+          placeholder="Filter EIPs..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange('')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+            aria-label="Clear search"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Layer filter */}
+      {showLayerFilter && onLayerFilterChange && (
+        <div className="flex gap-1 mb-3 px-0.5">
+          <Tooltip text="Show all EIPs" position="bottom" className="flex-1">
+            <button
+              onClick={() => onLayerFilterChange('all')}
+              className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
+                layerFilter === 'all'
+                  ? 'border-slate-400 text-slate-700 bg-white dark:border-slate-400 dark:text-slate-200 dark:bg-slate-700'
+                  : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
+              }`}
+            >
+              All
+            </button>
+          </Tooltip>
+          <Tooltip text="Execution Layer" position="bottom" className="flex-1">
+            <button
+              onClick={() => onLayerFilterChange('EL')}
+              className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
+                layerFilter === 'EL'
+                  ? 'bg-indigo-100 text-indigo-700 border-indigo-200 dark:bg-indigo-900/20 dark:text-indigo-300 dark:border-indigo-600'
+                  : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
+              }`}
+            >
+              EL
+            </button>
+          </Tooltip>
+          <Tooltip text="Consensus Layer" position="bottom" className="flex-1">
+            <button
+              onClick={() => onLayerFilterChange('CL')}
+              className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
+                layerFilter === 'CL'
+                  ? 'bg-teal-100 text-teal-700 border-teal-200 dark:bg-teal-900/20 dark:text-teal-300 dark:border-teal-600'
+                  : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
+              }`}
+            >
+              CL
+            </button>
+          </Tooltip>
+        </div>
+      )}
+
+      {/* Search results count */}
+      {searchQuery && (
+        <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 px-1">
+          {matchCount === 0 ? 'No matches' : `${matchCount} of ${totalEipCount} EIPs`}
+        </p>
+      )}
+    </>
+  );
+};

--- a/src/components/network-upgrade/FusakaTimeline.tsx
+++ b/src/components/network-upgrade/FusakaTimeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FUSAKA_TIMELINE_PHASES } from '../../constants/timeline-phases';
 import { getPhaseStatusIcon } from '../../utils/timeline';
 import { getPhaseStatusColor } from '../../utils/colors';
@@ -6,7 +6,10 @@ import { useAnalytics } from '../../hooks/useAnalytics';
 
 export const FusakaTimeline: React.FC = () => {
   const phases = FUSAKA_TIMELINE_PHASES;
+  const [isExpanded, setIsExpanded] = useState(false);
   const { trackLinkClick } = useAnalytics();
+  const activeIndex = phases.findIndex(p => p.status === 'in-progress');
+  const highlightIndex = activeIndex >= 0 ? activeIndex : phases.length - 1;
 
   const handleExternalLinkClick = (linkType: string, url: string) => {
     trackLinkClick(linkType, url);
@@ -18,47 +21,104 @@ export const FusakaTimeline: React.FC = () => {
         <div className="relative">
           {/* Vertical line */}
           {phases.length > 1 && (
-            <div className="absolute left-5 top-5 bottom-12 w-0.5 bg-slate-200 dark:bg-slate-600" />
+            <div className={`absolute left-5 top-5 bottom-5 w-0.5 bg-slate-200 dark:bg-slate-600 ${!isExpanded ? 'hidden lg:block' : ''}`} />
           )}
 
-          <div className="space-y-8">
-            {phases.map((phase) => (
-              <div key={phase.id} className="flex items-start gap-4">
-                {/* Status icon */}
-                <div
-                  className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${
-                    getPhaseStatusColor(phase.status)
-                  }`}
-                >
-                  {/* Opaque base background (masks the timeline line) */}
-                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
-                  {/* Subtle colored background (restores the desired color) */}
-                  <div className={`absolute inset-0 rounded-full ${
-                    getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')
-                  }`} />
-                  <div className="relative">
-                    {getPhaseStatusIcon(phase.status)}
-                  </div>
+          {/* Before-highlight phases (collapsible on mobile) */}
+          {highlightIndex > 0 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pb-8">
+                  {phases.slice(0, highlightIndex).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
                 </div>
+              </div>
+            </div>
+          )}
 
-                {/* Content */}
+          {/* Active/highlight phase (always visible) */}
+          {phases[highlightIndex] && (() => {
+            const phase = phases[highlightIndex];
+            return (
+              <div className="flex items-start gap-4">
+                <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                  <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                  <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                </div>
                 <div className="flex-1 flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
                     <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
                   </div>
-
-                  {/* Date on the right */}
                   <div className="flex-shrink-0">
-                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">
-                      {phase.dateRange}
-                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
                   </div>
                 </div>
               </div>
-            ))}
-          </div>
+            );
+          })()}
+
+          {/* After-highlight phases (collapsible on mobile) */}
+          {highlightIndex < phases.length - 1 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pt-8">
+                  {phases.slice(highlightIndex + 1).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
+
+        {/* Mobile expand/collapse toggle */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="lg:hidden mt-2 flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+        >
+          {isExpanded ? 'Show less' : 'Expand timeline'}
+          <svg
+            className={`w-3.5 h-3.5 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
         {/* Source link and dates disclaimer */}
         <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-600">

--- a/src/components/network-upgrade/GlamsterdamTimeline.tsx
+++ b/src/components/network-upgrade/GlamsterdamTimeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GLAMSTERDAM_TIMELINE_PHASES } from '../../constants/timeline-phases';
 import { getPhaseStatusIcon } from '../../utils/timeline';
 import { getPhaseStatusColor } from '../../utils/colors';
@@ -6,7 +6,10 @@ import { useAnalytics } from '../../hooks/useAnalytics';
 
 export const GlamsterdamTimeline: React.FC = () => {
   const phases = GLAMSTERDAM_TIMELINE_PHASES;
+  const [isExpanded, setIsExpanded] = useState(false);
   const { trackLinkClick } = useAnalytics();
+  const activeIndex = phases.findIndex(p => p.status === 'in-progress');
+  const highlightIndex = activeIndex >= 0 ? activeIndex : phases.length - 1;
 
   const handleExternalLinkClick = (linkType: string, url: string) => {
     trackLinkClick(linkType, url);
@@ -18,38 +21,89 @@ export const GlamsterdamTimeline: React.FC = () => {
         <div className="relative">
           {/* Vertical line */}
           {phases.length > 1 && (
-            <div className="absolute left-5 top-5 bottom-12 w-0.5 bg-slate-200 dark:bg-slate-600" />
+            <div className={`absolute left-5 top-5 bottom-5 w-0.5 bg-slate-200 dark:bg-slate-600 ${!isExpanded ? 'hidden lg:block' : ''}`} />
           )}
 
-          <div className="space-y-8">
-            {phases.map((phase) => (
-              <div key={phase.id} className="flex items-start gap-4">
-                {/* Status icon */}
-                <div
-                  className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${
-                    getPhaseStatusColor(phase.status)
-                  }`}
-                >
-                  {/* Opaque base background (masks the timeline line) */}
-                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
-                  {/* Subtle colored background (restores the desired color) */}
-                  <div className={`absolute inset-0 rounded-full ${
-                    getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')
-                  }`} />
-                  <div className="relative">
-                    {getPhaseStatusIcon(phase.status)}
-                  </div>
+          {/* Before-highlight phases (collapsible on mobile) */}
+          {highlightIndex > 0 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pb-8">
+                  {phases.slice(0, highlightIndex).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1">
+                        <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                        <p className="text-xs text-slate-600 dark:text-slate-300 mb-2">{phase.description}</p>
+                      </div>
+                    </div>
+                  ))}
                 </div>
+              </div>
+            </div>
+          )}
 
-                {/* Content */}
+          {/* Active/highlight phase (always visible) */}
+          {phases[highlightIndex] && (() => {
+            const phase = phases[highlightIndex];
+            return (
+              <div className="flex items-start gap-4">
+                <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                  <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                  <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                </div>
                 <div className="flex-1">
                   <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
                   <p className="text-xs text-slate-600 dark:text-slate-300 mb-2">{phase.description}</p>
                 </div>
               </div>
-            ))}
-          </div>
+            );
+          })()}
+
+          {/* After-highlight phases (collapsible on mobile) */}
+          {highlightIndex < phases.length - 1 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pt-8">
+                  {phases.slice(highlightIndex + 1).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1">
+                        <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                        <p className="text-xs text-slate-600 dark:text-slate-300 mb-2">{phase.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
+
+        {/* Mobile expand/collapse toggle */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="lg:hidden mt-2 flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+        >
+          {isExpanded ? 'Show less' : 'Expand timeline'}
+          <svg
+            className={`w-3.5 h-3.5 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
         {/* Source link */}
         <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-600">

--- a/src/components/network-upgrade/HegotaTimeline.tsx
+++ b/src/components/network-upgrade/HegotaTimeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { HEGOTA_TIMELINE_PHASES } from '../../constants/timeline-phases';
 import { getPhaseStatusIcon } from '../../utils/timeline';
 import { getPhaseStatusColor } from '../../utils/colors';
@@ -6,7 +6,10 @@ import { useAnalytics } from '../../hooks/useAnalytics';
 
 export const HegotaTimeline: React.FC = () => {
   const phases = HEGOTA_TIMELINE_PHASES;
+  const [isExpanded, setIsExpanded] = useState(false);
   const { trackLinkClick } = useAnalytics();
+  const activeIndex = phases.findIndex(p => p.status === 'in-progress');
+  const highlightIndex = activeIndex >= 0 ? activeIndex : phases.length - 1;
 
   const handleExternalLinkClick = (linkType: string, url: string) => {
     trackLinkClick(linkType, url);
@@ -18,47 +21,104 @@ export const HegotaTimeline: React.FC = () => {
         <div className="relative">
           {/* Vertical line */}
           {phases.length > 1 && (
-            <div className="absolute left-5 top-5 bottom-12 w-0.5 bg-slate-200 dark:bg-slate-600" />
+            <div className={`absolute left-5 top-5 bottom-5 w-0.5 bg-slate-200 dark:bg-slate-600 ${!isExpanded ? 'hidden lg:block' : ''}`} />
           )}
 
-          <div className="space-y-8">
-            {phases.map((phase) => (
-              <div key={phase.id} className="flex items-start gap-4">
-                {/* Status icon */}
-                <div
-                  className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${
-                    getPhaseStatusColor(phase.status)
-                  }`}
-                >
-                  {/* Opaque base background (masks the timeline line) */}
-                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
-                  {/* Subtle colored background (restores the desired color) */}
-                  <div className={`absolute inset-0 rounded-full ${
-                    getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')
-                  }`} />
-                  <div className="relative">
-                    {getPhaseStatusIcon(phase.status)}
-                  </div>
+          {/* Before-highlight phases (collapsible on mobile) */}
+          {highlightIndex > 0 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pb-8">
+                  {phases.slice(0, highlightIndex).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
                 </div>
+              </div>
+            </div>
+          )}
 
-                {/* Content */}
+          {/* Active/highlight phase (always visible) */}
+          {phases[highlightIndex] && (() => {
+            const phase = phases[highlightIndex];
+            return (
+              <div className="flex items-start gap-4">
+                <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                  <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                  <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                </div>
                 <div className="flex-1 flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
                     <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
                   </div>
-
-                  {/* Date on the right */}
                   <div className="flex-shrink-0">
-                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">
-                      {phase.dateRange}
-                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
                   </div>
                 </div>
               </div>
-            ))}
-          </div>
+            );
+          })()}
+
+          {/* After-highlight phases (collapsible on mobile) */}
+          {highlightIndex < phases.length - 1 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pt-8">
+                  {phases.slice(highlightIndex + 1).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
+
+        {/* Mobile expand/collapse toggle */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="lg:hidden mt-2 flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+        >
+          {isExpanded ? 'Show less' : 'Expand timeline'}
+          <svg
+            className={`w-3.5 h-3.5 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
         {/* Footer */}
         <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-600">

--- a/src/components/network-upgrade/OverviewSection.tsx
+++ b/src/components/network-upgrade/OverviewSection.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { EIP, ClientTeamPerspective } from '../../types';
+import { EIP } from '../../types';
 import {
   getInclusionStage,
 } from '../../utils';
 import { ActivationDetails } from '../../data/upgrades';
 import { CopyLinkButton } from '../ui/CopyLinkButton';
-import { ClientPerspectives } from './ClientPerspectives';
 
 interface OverviewSectionProps {
   eips: EIP[];
@@ -13,8 +12,6 @@ interface OverviewSectionProps {
   status: string;
   activationDate?: string;
   onStageClick: (stageId: string) => void;
-  clientTeamPerspectives?: ClientTeamPerspective[];
-  onExternalLinkClick?: (linkType: string, url: string) => void;
   activationDetails?: ActivationDetails;
 }
 
@@ -24,9 +21,7 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({
   status,
   activationDate,
   onStageClick,
-  clientTeamPerspectives,
   activationDetails,
-  onExternalLinkClick,
 }) => {
   // For Live upgrades, only show Included (declined is replaced by activation details)
   const stageStats = status === 'Live'
@@ -106,22 +101,22 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({
         </div>
       )}
 
-      {/* Client Perspectives for candidate EIPs (Glamsterdam only) */}
-      {forkName.toLowerCase() === 'glamsterdam' && clientTeamPerspectives && (
-        <div className="mb-6">
-          <ClientPerspectives
-            perspectives={clientTeamPerspectives}
-            type="candidate"
-            onLinkClick={(url: string) => {
-              window.open(url, '_blank');
-              onExternalLinkClick?.('client_perspective_candidate', url);
-            }}
-          />
+      {/* Scoping notice for Glamsterdam */}
+      {forkName.toLowerCase() === 'glamsterdam' && (
+        <div className="p-4 mb-6 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded">
+          <div className="flex items-start gap-3">
+            <svg className="w-5 h-5 text-blue-500 dark:text-blue-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p className="text-blue-800 dark:text-blue-200 text-xs leading-relaxed">
+              Candidate EIPs are being fine-tuned, implemented, and tested on closed devnets. This process will determine which EIPs get Scheduled for Inclusion.
+            </p>
+          </div>
         </div>
       )}
 
       {/* Stage counts grid */}
-      <div className={status === 'Live' ? 'grid grid-cols-1 md:grid-cols-3 gap-4' : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4'}>
+      <div className={status === 'Live' ? 'grid grid-cols-1 md:grid-cols-3 gap-4' : 'grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4'}>
           {/* Live status info box - only for Live upgrades */}
           {status === 'Live' && (
             <div className="flex flex-col items-center justify-center p-4 rounded bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700">

--- a/src/components/network-upgrade/PectraTimeline.tsx
+++ b/src/components/network-upgrade/PectraTimeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PECTRA_TIMELINE_PHASES } from '../../constants/timeline-phases';
 import { getPhaseStatusIcon } from '../../utils/timeline';
 import { getPhaseStatusColor } from '../../utils/colors';
@@ -6,7 +6,10 @@ import { useAnalytics } from '../../hooks/useAnalytics';
 
 export const PectraTimeline: React.FC = () => {
   const phases = PECTRA_TIMELINE_PHASES;
+  const [isExpanded, setIsExpanded] = useState(false);
   const { trackLinkClick } = useAnalytics();
+  const activeIndex = phases.findIndex(p => p.status === 'in-progress');
+  const highlightIndex = activeIndex >= 0 ? activeIndex : phases.length - 1;
 
   const handleExternalLinkClick = (linkType: string, url: string) => {
     trackLinkClick(linkType, url);
@@ -18,47 +21,104 @@ export const PectraTimeline: React.FC = () => {
         <div className="relative">
           {/* Vertical line */}
           {phases.length > 1 && (
-            <div className="absolute left-5 top-5 bottom-12 w-0.5 bg-slate-200 dark:bg-slate-600" />
+            <div className={`absolute left-5 top-5 bottom-5 w-0.5 bg-slate-200 dark:bg-slate-600 ${!isExpanded ? 'hidden lg:block' : ''}`} />
           )}
 
-          <div className="space-y-8">
-            {phases.map((phase) => (
-              <div key={phase.id} className="flex items-start gap-4">
-                {/* Status icon */}
-                <div
-                  className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${
-                    getPhaseStatusColor(phase.status)
-                  }`}
-                >
-                  {/* Opaque base background (masks the timeline line) */}
-                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
-                  {/* Subtle colored background (restores the desired color) */}
-                  <div className={`absolute inset-0 rounded-full ${
-                    getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')
-                  }`} />
-                  <div className="relative">
-                    {getPhaseStatusIcon(phase.status)}
-                  </div>
+          {/* Before-highlight phases (collapsible on mobile) */}
+          {highlightIndex > 0 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pb-8">
+                  {phases.slice(0, highlightIndex).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
                 </div>
+              </div>
+            </div>
+          )}
 
-                {/* Content */}
+          {/* Active/highlight phase (always visible) */}
+          {phases[highlightIndex] && (() => {
+            const phase = phases[highlightIndex];
+            return (
+              <div className="flex items-start gap-4">
+                <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                  <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                  <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                  <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                </div>
                 <div className="flex-1 flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
                     <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
                   </div>
-
-                  {/* Date on the right */}
                   <div className="flex-shrink-0">
-                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">
-                      {phase.dateRange}
-                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
                   </div>
                 </div>
               </div>
-            ))}
-          </div>
+            );
+          })()}
+
+          {/* After-highlight phases (collapsible on mobile) */}
+          {highlightIndex < phases.length - 1 && (
+            <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] ${isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+              <div className="overflow-hidden">
+                <div className="space-y-8 pt-8">
+                  {phases.slice(highlightIndex + 1).map(phase => (
+                    <div key={phase.id} className="flex items-start gap-4">
+                      <div className={`relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center ${getPhaseStatusColor(phase.status)}`}>
+                        <div className="absolute inset-0 rounded-full bg-white dark:bg-slate-800" />
+                        <div className={`absolute inset-0 rounded-full ${getPhaseStatusColor(phase.status).match(/(bg-\S+)|(dark:bg-\S+)/g)?.join(' ')}`} />
+                        <div className="relative">{getPhaseStatusIcon(phase.status)}</div>
+                      </div>
+                      <div className="flex-1 flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-medium text-slate-900 dark:text-slate-100 text-sm mb-1">{phase.title}</h4>
+                          <p className="text-xs text-slate-600 dark:text-slate-300 mb-2 leading-relaxed">{phase.description}</p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">{phase.dateRange}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
+
+        {/* Mobile expand/collapse toggle */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="lg:hidden mt-2 flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+        >
+          {isExpanded ? 'Show less' : 'Expand timeline'}
+          <svg
+            className={`w-3.5 h-3.5 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
         {/* Source link and dates disclaimer */}
         <div className="mt-4 pt-4 border-t border-slate-200 dark:border-slate-600">

--- a/src/components/network-upgrade/TableOfContents.tsx
+++ b/src/components/network-upgrade/TableOfContents.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Tooltip } from '../ui';
+import { EipFilterBar } from './EipFilterBar';
 
 interface TOCItem {
   id: string;
@@ -97,76 +98,15 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
           </Tooltip>
         </div>
 
-        {/* Search input */}
-        <div className="relative mb-3 px-0.5">
-          <input
-            type="text"
-            placeholder="Filter EIPs..."
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-          />
-          {searchQuery && (
-            <button
-              onClick={() => onSearchChange('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-              aria-label="Clear search"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          )}
-        </div>
-
-        {/* Layer filter */}
-        {showLayerFilter && onLayerFilterChange && (
-          <div className="flex gap-1 mb-3 px-0.5">
-            <Tooltip text="Show all EIPs" position="bottom" className="flex-1">
-              <button
-                onClick={() => onLayerFilterChange('all')}
-                className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
-                  layerFilter === 'all'
-                    ? 'border-slate-400 text-slate-700 bg-white dark:border-slate-400 dark:text-slate-200 dark:bg-slate-700'
-                    : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
-                }`}
-              >
-                All
-              </button>
-            </Tooltip>
-            <Tooltip text="Execution Layer" position="bottom" className="flex-1">
-              <button
-                onClick={() => onLayerFilterChange('EL')}
-                className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
-                  layerFilter === 'EL'
-                    ? 'bg-indigo-100 text-indigo-700 border-indigo-200 dark:bg-indigo-900/20 dark:text-indigo-300 dark:border-indigo-600'
-                    : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
-                }`}
-              >
-                EL
-              </button>
-            </Tooltip>
-            <Tooltip text="Consensus Layer" position="bottom" className="flex-1">
-              <button
-                onClick={() => onLayerFilterChange('CL')}
-                className={`w-full px-2 py-1 text-xs font-medium rounded border transition-colors cursor-pointer ${
-                  layerFilter === 'CL'
-                    ? 'bg-teal-100 text-teal-700 border-teal-200 dark:bg-teal-900/20 dark:text-teal-300 dark:border-teal-600'
-                    : 'border-slate-200 text-slate-500 bg-white hover:border-slate-300 dark:border-slate-600 dark:text-slate-400 dark:bg-slate-800 dark:hover:border-slate-500'
-                }`}
-              >
-                CL
-              </button>
-            </Tooltip>
-          </div>
-        )}
-
-        {/* Search results count */}
-        {searchQuery && (
-          <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 px-1">
-            {matchCount === 0 ? 'No matches' : `${matchCount} of ${totalEipCount} EIPs`}
-          </p>
-        )}
+        <EipFilterBar
+          searchQuery={searchQuery}
+          onSearchChange={onSearchChange}
+          layerFilter={layerFilter}
+          onLayerFilterChange={onLayerFilterChange}
+          showLayerFilter={showLayerFilter}
+          matchCount={matchCount}
+          totalEipCount={totalEipCount}
+        />
 
         <nav className="space-y-1">
           {filteredItems.map((item) => {

--- a/src/components/network-upgrade/index.ts
+++ b/src/components/network-upgrade/index.ts
@@ -1,4 +1,5 @@
 export * from './ClientPerspectives';
+export * from './EipFilterBar';
 export * from './ClientTeamPerspectives';
 export * from './ClientTestingProgress';
 export * from './EipCard';

--- a/src/utils/eip.test.ts
+++ b/src/utils/eip.test.ts
@@ -15,21 +15,12 @@ const makeEip = (overrides: Partial<EIP> = {}): EIP => ({
 });
 
 describe('getSummaryDescription', () => {
-  it('uses laymanDescription when present', () => {
+  it('returns the EIP description', () => {
     const eip = makeEip({
-      description: 'Technical fallback',
+      description: 'The EIP description',
       laymanDescription: 'Reader-friendly summary',
     });
 
-    expect(getSummaryDescription(eip)).toBe('Reader-friendly summary');
-  });
-
-  it('falls back to description when laymanDescription is missing', () => {
-    const eip = makeEip({
-      description: 'Technical fallback',
-      laymanDescription: undefined,
-    });
-
-    expect(getSummaryDescription(eip)).toBe('Technical fallback');
+    expect(getSummaryDescription(eip)).toBe('The EIP description');
   });
 });

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -89,7 +89,7 @@ export const getProposalPrefix = (eip: EIP): ProposalType => {
 };
 
 export const getSummaryDescription = (eip: EIP): string =>
-  eip.laymanDescription || eip.description;
+  eip.description;
 
 /**
  * Get the specification URL for an EIP


### PR DESCRIPTION
- upgrade page, mobile:
   - add eip search and layer filtering
   - reduce real estate usage in overview and timeline components
- sub stale glamsterdam client prios for an updated stage description
- comment out BAL butterfly data; todo: diagnose stale data issue this week
- display eip descriptions instead of layman; todo: fresh pass of data quality/accessibility and shortening them to a standard length