### PR TITLE
sync: set video/transcript offsets for PQI 38

### DIFF
--- a/public/artifacts/pqi/2026-05-06_038/config.json
+++ b/public/artifacts/pqi/2026-05-06_038/config.json
@@ -2,7 +2,7 @@
   "issue": 2040,
   "videoUrl": "https://www.youtube.com/watch?v=RWmlIA4Gu4I",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:15:58",
+    "videoStartTime": "00:15:58"
   }
 }


### PR DESCRIPTION
## Summary
- Set `transcriptStartTime` and `videoStartTime` to `00:15:58` for PQI 38

## Test plan
- [x] Verified sync looks correct on local dev server at /calls/pqi/038