### PR TITLE
fix PQI 038 lean client name typos

### DIFF
--- a/docs/skills/fix-call-typos/SKILL.md
+++ b/docs/skills/fix-call-typos/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: fix-call-typos
+description: Fix transcript/tldr typos for a published Forkcast call AND update the upstream ACDbot vocab so the same typo doesn't recur. Use when a call page on forkcast.org has wrong client/protocol/term names that the pipeline missed.
+---
+
+## Fix typos in a published call
+
+This skill walks the user through correcting typos in a call's artifacts on Forkcast (transcript, TLDR, key_decisions) and teaching the upstream ACDbot pipeline at `ethereum/pm` to catch those typos automatically next time.
+
+The "correct" approach would be to fix upstream and re-run the pipeline. In practice we patch the artifacts in both repos *and* update the vocab — that way published assets are right today, and future pipeline runs improve.
+
+See `docs/acdbot-forkcast-asset-pipeline.md` for the full asset pipeline overview.
+
+### Step 0: Prereqs
+
+The user must have both repos checked out locally. Defaults:
+- Forkcast: `/Users/lucy/fun/forkcast` (or a worktree under it)
+- PM: `/Users/lucy/fun/pm`
+
+If either is missing, ask the user where they live before proceeding.
+
+Open a worktree off `origin/main` for the forkcast side so the user's current branch isn't disturbed (`git fetch origin main && git worktree add …`). Work directly in `pm/` — that repo doesn't typically need a worktree, but pull `main` first.
+
+### Step 1: Identify the call
+
+Ask the user for:
+
+1. **Call slug + number** (e.g., `pqi/038`, `acdc/177`). This determines:
+   - Forkcast path: `public/artifacts/{slug}/{date}_{number_padded}/`
+   - PM path: `.github/ACDbot/artifacts/{pm_series}/{date}_{number_padded}/` — the PM series name often differs from the forkcast slug. Check `SERIES_TO_TYPE` in `forkcast/scripts/sync-call-assets.mjs` for the mapping (e.g., `pqi` ↔ `pqinterop`, `price` ↔ `glamsterdamrepricings`). Core series (`acdc`, `acde`, `acdt`) pass through unchanged.
+
+Resolve the absolute paths and confirm both directories exist before continuing.
+
+### Step 2: Gather corrections from the user
+
+Ask for two lists:
+
+1. **New vocabulary** — terms the LLM didn't know (client names, protocol names, EIP nicknames). Each term needs a canonical casing (e.g., `Ethlambda`, not `ETH Lambda` or `ETHLambda`).
+2. **Specific typo → correct mappings** — every variant the user has spotted, plus its target.
+
+Don't pre-read the transcript yet. Let the user tell you what's wrong first; their list anchors the work.
+
+### Step 3: Survey the transcript for related variants
+
+Once you have the user's list, grep the call's `transcript_corrected.vtt`, `tldr.json`, and (if present) `key_decisions.json` for:
+
+- The user's exact typos (to confirm hits and count occurrences)
+- Other plausible variants of the same words. Examples seen in the wild:
+  - Casing drift: `ETHLambda`, `ETH Lambda`, `ETH lambda`, `ETLambda` all → `Ethlambda`
+  - Vowel/letter drift: `Zeem`, `Zeeam`, `Zem`, `ZEM` all → `Zeam`; `Rheem`, `Reem`, `Dream` → `Ream`
+  - Speaker-attributed name confusion: a speaker labeled `| gean` referring to "Jim" almost certainly means `Gean`
+
+Surface the additional variants to the user with `AskUserQuestion`. For every variant ask: "is this the same word?" Don't assume.
+
+Also ask the user the **canonical casing** for any term that appears in multiple forms (e.g., `Ethlambda` vs `ETH Lambda`). Their answer goes into the vocab.
+
+### Step 4: Decide what's safe to add to the global vocab
+
+`ethereum_vocab.yaml` patterns are applied as **global find/replace** by the LLM on every future call. So an entry like `Jim: Gean` would garble any call where someone named Jim speaks. Same for common English words (`Dream → Ream`).
+
+Before adding to the vocab, ask: would this pattern, applied globally, ever break a different call's transcript? If yes, fix it only in the specific call — don't add it to the vocab. If no (the source token is rare and unambiguous), add it.
+
+Generally safe: invented-looking strings (`Zeem`, `QLEAN`, `Gein`, `ETHLambda`).
+Generally unsafe: real names (`Jim`), common English words (`Dream`), short ambiguous fragments.
+
+### Step 5: Update PM `ethereum_vocab.yaml`
+
+File: `pm/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml`.
+
+1. **New vocab terms** — add to the relevant section (`clients.execution`, `clients.consensus`, `clients.lean`, `acronyms`, `technical_terms`, etc.). If a new category is needed (e.g., a new ecosystem of clients), add a new subsection.
+2. **Safe error patterns** — append to `error_patterns:` as `- WrongForm: RightForm`.
+   - Order longer patterns before shorter ones with the same prefix (e.g., `Zeeam` before `Zem`) so substring matches don't misfire.
+   - Existing patterns are mixed-case; match the casing of the source token you want to catch.
+
+### Step 6: Fix the artifacts in Forkcast
+
+In the forkcast worktree, edit `public/artifacts/{slug}/{date}_{number}/`:
+
+1. **`transcript_corrected.vtt`** — apply every typo correction. For multi-token corruptions (e.g., `ReamZeem eats Lambda` for what was meant as "Ream, Zeam, Ethlambda"), do the long unique replacement *first*, then run the single-word substitutions. Use `Edit` with `replace_all: true` for safe global swaps; use scoped `Edit` for one-line fixes (like the `Jim → Gean` case).
+2. **`tldr.json`** — apply the same replacements where applicable.
+3. **`key_decisions.json`** (ACD calls only) — apply the same replacements. This file references EIP numbers; if a typo named an EIP, also verify the `eips:` array.
+4. **`transcript_changelog.tsv`** — this records what the LLM changed from the original. If a row's `corrected` value was wrong (e.g., `Zim → Zeem` when the right answer was `Zeam`), update the target column. Don't add new rows for manual corrections — the changelog is documentation of pipeline output, not of post-hoc edits. (Past examples: PM commit `f7f549b3` removed an over-correction row entirely.)
+
+After editing, grep the file again for any remaining instance of every typo string, including the ones the user gave you. Output should be empty.
+
+### Step 7: Mirror the fixes into PM
+
+The PM repo holds the upstream copy of these same artifacts at `.github/ACDbot/artifacts/{pm_series}/{date}_{number}/`. Before your edits these files were byte-identical to the forkcast copies (they're produced by the pipeline and the sync script just downloads them). The simplest correct move is to `cp` the four edited files (vtt, tldr, changelog, key_decisions if it exists) from forkcast to PM.
+
+Verify with `diff` afterwards — both copies should be identical.
+
+### Step 8: Commit and open PRs
+
+Two PRs, two commit-message styles (mirror prior commits — see PM `f7f549b3`, forkcast `37db68a3` for examples):
+
+**PM PR** — branch like `acdbot-fix-{slug}-{number}`. The commit covers:
+- The vocab additions (new terms + error patterns)
+- The corrected artifacts
+
+  Title: `acdbot: prevent {topic} transcript corruption` or `acdbot: fix {SLUG} {number} {topic} corruption`. Keep the title short; details go in the body.
+
+**Forkcast PR** — branch like `fix-{slug}-{number}-typos`. Single commit covering the artifact fixes only (no pipeline changes here).
+
+  Title: `fix {SLUG} {number} {topic} typos` or `fix: normalize {topic} in {SLUG} {number} summary`.
+
+For both, do NOT use `#N` for call numbers in PR title/body — GitHub treats it as an issue tag. Write `{SLUG} {number}` (e.g., `PQI 038`).
+
+### Step 9: Cleanup
+
+Once both PRs are open, remove the forkcast worktree (`git worktree remove --force`). Tell the user to merge both PRs (PM first is fine, order doesn't matter — the forkcast fix is a static patch, and the next pipeline run for *future* calls picks up the new vocab).
+
+### Step 10: Done
+
+Confirm to the user that the call page on forkcast.org will show the corrections after the forkcast PR's deploy completes, and that future calls will be auto-corrected by the pipeline using the new vocab entries.

--- a/public/artifacts/pqi/2026-05-06_038/tldr.json
+++ b/public/artifacts/pqi/2026-05-06_038/tldr.json
@@ -40,7 +40,7 @@
     "client_progress": [
       {
         "timestamp": "00:16:46",
-        "highlight": "Zeem optimizing aggregator performance and payload re-aggregation API"
+        "highlight": "Zeam optimizing aggregator performance and payload re-aggregation API"
       },
       {
         "timestamp": "00:18:25",
@@ -52,7 +52,7 @@
       },
       {
         "timestamp": "00:52:01",
-        "highlight": "ETH Lambda added LibP2P Identify Protocol support for Zeem interop"
+        "highlight": "Ethlambda added LibP2P Identify Protocol support for Zeam interop"
       }
     ],
     "devnet_5_scope": [

--- a/public/artifacts/pqi/2026-05-06_038/transcript_changelog.tsv
+++ b/public/artifacts/pqi/2026-05-06_038/transcript_changelog.tsv
@@ -1,6 +1,6 @@
 original	corrected	confidence
-Zim	Zeem	high
-NLEAN	QLEAN	high
+Zim	Zeam	high
+NLEAN	Qlean	high
 DevNet	devnet	high
 DevNets	devnets	high
 DevNet0	devnet0	high

--- a/public/artifacts/pqi/2026-05-06_038/transcript_corrected.vtt
+++ b/public/artifacts/pqi/2026-05-06_038/transcript_corrected.vtt
@@ -26,7 +26,7 @@ Thomas Coratger: So… Let's get started. Welcome to Post Quantum interrupt numb
 
 7
 00:16:10.550 --> 00:16:27.009
-Thomas Coratger: So, first, so we have different topics on the agenda. We will discuss, I think, mainly a devnet 5 proposal, but first, let us start with client updates. So, Zeem first.
+Thomas Coratger: So, first, so we have different topics on the agenda. We will discuss, I think, mainly a devnet 5 proposal, but first, let us start with client updates. So, Zeam first.
 
 8
 00:16:29.040 --> 00:16:30.030
@@ -214,7 +214,7 @@ Derek Sorken: it's a little bit difficult to say, okay, which client's doing wha
 
 54
 00:21:49.250 --> 00:21:55.569
-Derek Sorken: Okay, now we can see, okay, given client, okay, now it's Gein, or now it's Enlina, or whatnot.
+Derek Sorken: Okay, now we can see, okay, given client, okay, now it's Gean, or now it's Enlina, or whatnot.
 
 55
 00:21:55.890 --> 00:22:01.690
@@ -262,7 +262,7 @@ Derek Sorken: Or… If we want, we can see, of course.
 
 66
 00:22:53.950 --> 00:22:56.850
-Derek Sorken: In the case of, like, we have QLing here, I think it's just the,
+Derek Sorken: In the case of, like, we have Qlean here, I think it's just the,
 
 67
 00:22:57.140 --> 00:23:07.599
@@ -302,7 +302,7 @@ Derek Sorken: For client interop, it makes things way easier to see, you know, w
 
 76
 00:23:50.590 --> 00:24:03.709
-Derek Sorken: And so, I might add a little legend here, but, for example, we can see ETH lambda majority, and so two ETH lambda nodes, and say one key node works, and, like, one end lead node doesn't work, and if we want to go from the minority side instead, we can say, okay.
+Derek Sorken: And so, I might add a little legend here, but, for example, we can see Ethlambda majority, and so two Ethlambda nodes, and say one key node works, and, like, one end lead node doesn't work, and if we want to go from the minority side instead, we can say, okay.
 
 77
 00:24:03.860 --> 00:24:04.590
@@ -310,7 +310,7 @@ Derek Sorken: You know
 
 78
 00:24:04.980 --> 00:24:12.369
-Derek Sorken: when there's only one Zeeam node, but then there's two QLEAN nodes, things are failing, and of course, we can, again, navigate to see
+Derek Sorken: when there's only one Zeam node, but then there's two Qlean nodes, things are failing, and of course, we can, again, navigate to see
 
 79
 00:24:12.820 --> 00:24:16.219
@@ -838,15 +838,15 @@ Shariq Naiyer: let's just ensure that we don't have a lean start, lean start des
 
 210
 00:46:46.470 --> 00:47:03.400
-Shariq Naiyer: So you could also say, oh, I want one… one of Zeem, two of Zeem, so I could run two Zeem, I could run them in two subnets. So there's a lot of… there's a lot of, like, playing around, but let's just run Ream, Zeem, and ReamZeem eats Lambda, one subnet.
+Shariq Naiyer: So you could also say, oh, I want one… one of Zeam, two of Zeam, so I could run two Zeam, I could run them in two subnets. So there's a lot of… there's a lot of, like, playing around, but let's just run Ream, Zeam, and Ethlambda, one subnet.
 
 211
 00:47:03.760 --> 00:47:14.380
-Shariq Naiyer: So, this will now start a run with Reem, Zeem, and ETHLambda, and would save these logs in these timestamp format, as well as the latest logs will be in the latest folder.
+Shariq Naiyer: So, this will now start a run with Ream, Zeam, and Ethlambda, and would save these logs in these timestamp format, as well as the latest logs will be in the latest folder.
 
 212
 00:47:14.930 --> 00:47:30.970
-Shariq Naiyer: Now, I was trying to run all the clients at once, I was trying to run ETHLambda, Lantern, QLEAN, Dream, Zeem, as much as my, my, home piece, personal laptop would allow. But what I was finding is, like, it's hard to debug there, it's hard to figure out what's going wrong, and…
+Shariq Naiyer: Now, I was trying to run all the clients at once, I was trying to run Ethlambda, Lantern, Qlean, Ream, Zeam, as much as my, my, home piece, personal laptop would allow. But what I was finding is, like, it's hard to debug there, it's hard to figure out what's going wrong, and…
 
 213
 00:47:31.210 --> 00:47:36.959
@@ -854,11 +854,11 @@ Shariq Naiyer: So, here's what I started doing. I started running smaller subnet
 
 214
 00:47:37.430 --> 00:47:54.490
-Shariq Naiyer: One thing to note is, when running in one subnet, a lot of clients are pretty stable. However, when running in two subnets, like, clients start to break quite easily. So, what I've started with first is running Ream, Zeeam, and ETH Lambda. This tool is open source, and it's available on,
+Shariq Naiyer: One thing to note is, when running in one subnet, a lot of clients are pretty stable. However, when running in two subnets, like, clients start to break quite easily. So, what I've started with first is running Ream, Zeam, and Ethlambda. This tool is open source, and it's available on,
 
 215
 00:47:54.490 --> 00:48:19.279
-Shariq Naiyer: like, Ream Labs slash lean start, so anyone can run these devnets and start running them. You could also go to Clients, and you could change what Docker image you're using, so you could test with your local Docker image and stuff. So, what I've started doing is I'm running 3 clients right now, Rheem, Zeeam, and Ethlambda, figuring out what the issues are. If it's small enough, I'll just make it, test it on a local build, and push a PR to the client, and…
+Shariq Naiyer: like, Ream Labs slash lean start, so anyone can run these devnets and start running them. You could also go to Clients, and you could change what Docker image you're using, so you could test with your local Docker image and stuff. So, what I've started doing is I'm running 3 clients right now, Ream, Zeam, and Ethlambda, figuring out what the issues are. If it's small enough, I'll just make it, test it on a local build, and push a PR to the client, and…
 
 216
 00:48:19.280 --> 00:48:23.019
@@ -874,7 +874,7 @@ Shariq Naiyer: with 3 clients with, like, these less amount of logs, it's easier
 
 219
 00:48:44.350 --> 00:48:54.959
-Shariq Naiyer: So I'm starting with Rheem, Zem, ETHLambda. Once this is stable enough, stable, I'm gonna see… currently, what I'm finding is ETH Lambda does not reach finalization, while Rheem and Zeem
+Shariq Naiyer: So I'm starting with Ream, Zeam, Ethlambda. Once this is stable enough, stable, I'm gonna see… currently, what I'm finding is Ethlambda does not reach finalization, while Ream and Zeam
 
 220
 00:48:55.120 --> 00:49:03.639
@@ -882,11 +882,11 @@ Shariq Naiyer: comfortably reach finalization, but the issue might not be any…
 
 221
 00:49:07.180 --> 00:49:14.240
-Shariq Naiyer: So, yeah, so… Zem reached finalization, both ZEM, reached finalization, both,
+Shariq Naiyer: So, yeah, so… Zeam reached finalization, both Zeam, reached finalization, both,
 
 222
 00:49:14.410 --> 00:49:34.549
-Shariq Naiyer: lean reach finalization, but ETLambda did not, did not catch up. Now, one thing to note is this is likely not a problem in ETLambda. Like, this may be a problem in one of the three clients, but it's an interop problem. Clients are not interoping with each other. I'm going to figure out the problem here, and see the step forward. Then, I'm going to integrate Grandine.
+Shariq Naiyer: lean reach finalization, but Ethlambda did not, did not catch up. Now, one thing to note is this is likely not a problem in Ethlambda. Like, this may be a problem in one of the three clients, but it's an interop problem. Clients are not interoping with each other. I'm going to figure out the problem here, and see the step forward. Then, I'm going to integrate Grandine.
 
 223
 00:49:34.550 --> 00:49:57.059
@@ -1058,7 +1058,7 @@ Thomas Coratger: Great, Guin.
 
 265
 00:54:43.890 --> 00:54:56.759
-Shaaibu Suleiman | gean: Yeah, hello, hello. Yeah, so, on our site, we've been, running, devnet4, basically, Jim, with a couple of other clients, basically, doing some testing.
+Shaaibu Suleiman | gean: Yeah, hello, hello. Yeah, so, on our site, we've been, running, devnet4, basically, Gean, with a couple of other clients, basically, doing some testing.
 
 266
 00:54:56.910 --> 00:55:01.629


### PR DESCRIPTION
## Summary

- Normalize lean client names in PQI 038 artifacts: Zeem/Zeeam/Zem/ZEM → Zeam, Gein/Jim → Gean, QLing/QLEAN → Qlean, Rheem/Reem/Dream → Ream, ETHLambda/ETLambda/ETH Lambda → Ethlambda. Repaired the "ReamZeem eats Lambda" corruption to "Ethlambda".
- Updated `transcript_changelog.tsv` targets to reflect the corrected forms (Zim → Zeam, NLEAN → Qlean).
- Added a new `fix-call-typos` skill at `docs/skills/` documenting this workflow for future call cleanups.

Pairs with ethereum/pm PR which adds these clients/patterns to `ethereum_vocab.yaml` so future pipeline runs catch the same variants automatically.

## Test plan

- [ ] Verify https://forkcast.org/calls/pqi/038 shows the corrected client names after deploy
- [ ] Spot-check transcript playback for any remaining mistyped variants