### PR TITLE
ACDE 236: sync offsets, typo fixes, key decision updates

### DIFF
--- a/public/artifacts/acde/2026-05-07_236/config.json
+++ b/public/artifacts/acde/2026-05-07_236/config.json
@@ -2,7 +2,7 @@
   "issue": 2033,
   "videoUrl": "https://youtube.com/watch?v=19Hi3SbT6tc",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:07:15",
+    "videoStartTime": "00:03:24"
   }
 }

--- a/public/artifacts/acde/2026-05-07_236/key_decisions.json
+++ b/public/artifacts/acde/2026-05-07_236/key_decisions.json
@@ -29,20 +29,8 @@
       "context": "pending deposit limit fix"
     },
     {
-      "original_text": "EIP-8246 (remove SELFDESTRUCT burn) considered for Glamsterdam to enable EIP-7708",
-      "timestamp": "01:13:47",
-      "type": "stage_change",
-      "eips": [
-        8246
-      ],
-      "stage_change": {
-        "to": "Considered"
-      },
-      "fork": "Glamsterdam"
-    },
-    {
-      "original_text": "EIP-8254 (cap deposit requests per block) proposed for Glamsterdam",
-      "timestamp": "00:17:15",
+      "original_text": "EIP-8254 (cap deposit requests per block) PFI'd for Glamsterdam",
+      "timestamp": "01:00:06",
       "type": "stage_change",
       "eips": [
         8254
@@ -50,7 +38,21 @@
       "stage_change": {
         "to": "Proposed"
       },
-      "fork": "Glamsterdam"
+      "fork": "Glamsterdam",
+      "context": "open questions remain"
+    },
+    {
+      "original_text": "EIP-8246 (remove SELFDESTRUCT burn) goes straight to CFI for Glamsterdam",
+      "timestamp": "01:15:50",
+      "type": "stage_change",
+      "eips": [
+        8246
+      ],
+      "stage_change": {
+        "to": "Considered"
+      },
+      "fork": "Glamsterdam",
+      "context": "full SELFDESTRUCT removal can't fit Glamsterdam"
     },
     {
       "original_text": "EIP-7709 (BLOCKHASH from storage) proposed for Hegota by Ignacio",

--- a/public/artifacts/acde/2026-05-07_236/key_decisions.json
+++ b/public/artifacts/acde/2026-05-07_236/key_decisions.json
@@ -2,24 +2,23 @@
   "meeting": "ACDE #236 - May 7, 2026",
   "key_decisions": [
     {
-      "original_text": "SFI definition approved; EIPs moved to SFI status (excluding 8038)",
+      "original_text": "EIPs moved from CFI to SFI status for Glamsterdam",
       "timestamp": "00:17:15",
       "type": "stage_change",
       "eips": [
-        7928,
-        8037,
-        8070,
-        7709,
-        8254,
-        7805,
-        8061,
-        8080,
-        8246
+        7708,
+        7778,
+        7843,
+        7954,
+        7976,
+        7981,
+        8024,
+        8037
       ],
       "stage_change": {
         "to": "Scheduled"
       },
-      "context": "excluding 8038"
+      "fork": "Glamsterdam"
     },
     {
       "original_text": "Target 200M gas floor for Glamsterdam (pending deposit limit fix)",
@@ -30,7 +29,7 @@
       "context": "pending deposit limit fix"
     },
     {
-      "original_text": "Remove selfdestruct burn feature (8246); defer full removal to Hegota",
+      "original_text": "EIP-8246 (remove SELFDESTRUCT burn) considered for Glamsterdam to enable EIP-7708",
       "timestamp": "01:13:47",
       "type": "stage_change",
       "eips": [
@@ -39,8 +38,43 @@
       "stage_change": {
         "to": "Considered"
       },
-      "fork": "Glamsterdam",
-      "context": "full removal deferred to Hegota"
+      "fork": "Glamsterdam"
+    },
+    {
+      "original_text": "EIP-8254 (cap deposit requests per block) proposed for Glamsterdam",
+      "timestamp": "00:17:15",
+      "type": "stage_change",
+      "eips": [
+        8254
+      ],
+      "stage_change": {
+        "to": "Proposed"
+      },
+      "fork": "Glamsterdam"
+    },
+    {
+      "original_text": "EIP-7709 (BLOCKHASH from storage) proposed for Hegota by Ignacio",
+      "timestamp": "01:16:50",
+      "type": "stage_change",
+      "eips": [
+        7709
+      ],
+      "stage_change": {
+        "to": "Proposed"
+      },
+      "fork": "Hegota"
+    },
+    {
+      "original_text": "EIP-8253 (remove pre-Spurious-Dragon accounts) presented and proposed for Hegota by Jochem",
+      "timestamp": "01:25:10",
+      "type": "stage_change",
+      "eips": [
+        8253
+      ],
+      "stage_change": {
+        "to": "Proposed"
+      },
+      "fork": "Hegota"
     }
   ]
 }

--- a/public/artifacts/acde/2026-05-07_236/tldr.json
+++ b/public/artifacts/acde/2026-05-07_236/tldr.json
@@ -4,7 +4,7 @@
     "fork_status_and_schedule": [
       {
         "timestamp": "00:07:15",
-        "highlight": "Glamsterdam devnets 0-3 launched; devnet 2 added EIP-8061"
+        "highlight": "Glamsterdam devnets 0-3 launched; glamsterdam-devnet-2 added EIP-8061"
       },
       {
         "timestamp": "00:09:24",
@@ -14,15 +14,15 @@
     "testing_progress": [
       {
         "timestamp": "00:11:00",
-        "highlight": "Ball devnet 6 stable with Lighthouse/Lodestar; Glamsterdam devnet 3 running"
+        "highlight": "bal-devnet-6 stable with Lighthouse/Lodestar; glamsterdam-devnet-3 running"
       },
       {
         "timestamp": "00:11:38",
-        "highlight": "Ball devnet 7 planned for next week with 8037 fixes"
+        "highlight": "bal-devnet-7 planned for next week with 8037 fixes"
       },
       {
         "timestamp": "00:14:27",
-        "highlight": "Optimization merges needed to Ball devnet 3 until devnet 7 stable"
+        "highlight": "Optimization merges needed to bal-devnet-3 until bal-devnet-7 stable"
       }
     ],
     "eip_proposals": [
@@ -110,7 +110,7 @@
   "targets": [
     {
       "timestamp": "00:11:48",
-      "target": "Ball devnet 7 launch - next week"
+      "target": "bal-devnet-7 launch - next week"
     }
   ]
 }

--- a/public/artifacts/acde/2026-05-07_236/transcript_corrected.vtt
+++ b/public/artifacts/acde/2026-05-07_236/transcript_corrected.vtt
@@ -78,7 +78,7 @@ nixo: Yep.
 
 20
 00:08:09.540 --> 00:08:24.099
-Barnabas: Yeah, so we started out, with answering devnet 0, on the second day of in the interop. We basically included, all the, Ball devnet 5 changes and, ePBS.
+Barnabas: Yeah, so we started out, with answering devnet 0, on the second day of in the interop. We basically included, all the, bal-devnet-5 changes and, ePBS.
 
 21
 00:08:24.450 --> 00:08:29.280
@@ -138,7 +138,7 @@ Barnabas: We have, currently, Docker Access, Ball.net 6 up and running, with the
 
 35
 00:10:22.150 --> 00:10:29.270
-Barnabas: That has been quite stable, and we have Glamsterdam devnet 3, which is basically the same spec as Glamsterdam devnet 2.
+Barnabas: That has been quite stable, and we have glamsterdam-devnet-3, which is basically the same spec as glamsterdam-devnet-2.
 
 36
 00:10:30.880 --> 00:10:43.010
@@ -266,15 +266,15 @@ Maria Silva: working on Vol devnet 7 for next week, but at this point, we still 
 
 67
 00:14:45.440 --> 00:14:57.869
-Maria Silva: So, we are working on Ball devnet 7, with the fixes from 8037, and that should then, at some point next week, become our EL stable branch, but until then, for the clients that are
+Maria Silva: So, we are working on bal-devnet-7, with the fixes from 8037, and that should then, at some point next week, become our EL stable branch, but until then, for the clients that are
 
 68
 00:14:57.870 --> 00:15:08.150
-Maria Silva: working on the optimization still from last week, please merge them to Ball devnet3 so we can see the results on Benchmarker.
+Maria Silva: working on the optimization still from last week, please merge them to bal-devnet-3 so we can see the results on Benchmarker.
 
 69
 00:15:12.700 --> 00:15:21.950
-Maria Silva: Sorry, I think I'm… I may have missed some of the numbers there, but essentially, it's, like, merge optimizations to Paul devnet 3 until we have
+Maria Silva: Sorry, I think I'm… I may have missed some of the numbers there, but essentially, it's, like, merge optimizations to bal-devnet-3 until we have
 
 70
 00:15:22.270 --> 00:15:24.049

--- a/src/data/eips/7708.json
+++ b/src/data/eips/7708.json
@@ -23,6 +23,12 @@
           "status": "Considered",
           "call": "acde/225",
           "date": "2025-12-04"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [
@@ -33,7 +39,7 @@
       ]
     }
   ],
-  "laymanDescription": "Make every ETH transfer—including from contracts and SELFDESTRUCT—emit an event log. Apps and explorers can track ETH movements uniformly, similar to ERC-20 transfers, improving deposit detection and reducing ad-hoc tracing.",
+  "laymanDescription": "Make every ETH transfer\u2014including from contracts and SELFDESTRUCT\u2014emit an event log. Apps and explorers can track ETH movements uniformly, similar to ERC-20 transfers, improving deposit detection and reducing ad-hoc tracing.",
   "stakeholderImpacts": {
     "endUsers": {
       "description": "Deposits and withdrawals are detected more reliably across apps and exchanges; no change to how users send or receive ETH."

--- a/src/data/eips/7708.json
+++ b/src/data/eips/7708.json
@@ -39,7 +39,7 @@
       ]
     }
   ],
-  "laymanDescription": "Make every ETH transfer\u2014including from contracts and SELFDESTRUCT\u2014emit an event log. Apps and explorers can track ETH movements uniformly, similar to ERC-20 transfers, improving deposit detection and reducing ad-hoc tracing.",
+  "laymanDescription": "Make every ETH transfer—including from contracts and SELFDESTRUCT—emit an event log. Apps and explorers can track ETH movements uniformly, similar to ERC-20 transfers, improving deposit detection and reducing ad-hoc tracing.",
   "stakeholderImpacts": {
     "endUsers": {
       "description": "Deposits and withdrawals are detected more reliably across apps and exchanges; no change to how users send or receive ETH."

--- a/src/data/eips/7709.json
+++ b/src/data/eips/7709.json
@@ -8,6 +8,26 @@
   "category": "Core",
   "createdDate": "2024-05-18",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7709-read-blockhash-opcode-from-storage-and-adjust-gas-cost/20052",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 4379
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 4356
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }

--- a/src/data/eips/7778.json
+++ b/src/data/eips/7778.json
@@ -3,7 +3,7 @@
   "title": "EIP-7778: Block Gas Accounting without Refunds",
   "status": "Draft",
   "description": "Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting",
-  "author": "Ben Adams (@benaadams), Toni Wahrst\u00e4tter (@nerolation)",
+  "author": "Ben Adams (@benaadams), Toni Wahrstätter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2024-10-01",
@@ -33,7 +33,7 @@
       ],
       "champions": [
         {
-          "name": "Toni Wahrst\u00e4tter",
+          "name": "Toni Wahrstätter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/7778.json
+++ b/src/data/eips/7778.json
@@ -3,7 +3,7 @@
   "title": "EIP-7778: Block Gas Accounting without Refunds",
   "status": "Draft",
   "description": "Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting",
-  "author": "Ben Adams (@benaadams), Toni Wahrstätter (@nerolation)",
+  "author": "Ben Adams (@benaadams), Toni Wahrst\u00e4tter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2024-10-01",
@@ -23,11 +23,17 @@
           "status": "Considered",
           "call": "acde/225",
           "date": "2025-12-04"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [
         {
-          "name": "Toni Wahrstätter",
+          "name": "Toni Wahrst\u00e4tter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/7843.json
+++ b/src/data/eips/7843.json
@@ -33,6 +33,12 @@
           "status": "Considered",
           "call": "acde/225",
           "date": "2025-12-04"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [

--- a/src/data/eips/7954.json
+++ b/src/data/eips/7954.json
@@ -49,7 +49,7 @@
       "description": "Explorers, indexers, verifiers, and RPC tooling should handle larger contract bytecode and initcode in deployment flows."
     },
     "layer2s": {
-      "description": "Systems mirroring Ethereum\u2019s limits may need updates to contract-size checks to remain compatible with L1 rules."
+      "description": "Systems mirroring Ethereum’s limits may need updates to contract-size checks to remain compatible with L1 rules."
     },
     "stakersNodes": {
       "description": "Operators need upgraded clients at fork; larger contracts can slightly increase storage and processing per deployment."

--- a/src/data/eips/7954.json
+++ b/src/data/eips/7954.json
@@ -18,6 +18,12 @@
           "status": "Considered",
           "call": "acde/228",
           "date": "2026-01-15"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [
@@ -43,7 +49,7 @@
       "description": "Explorers, indexers, verifiers, and RPC tooling should handle larger contract bytecode and initcode in deployment flows."
     },
     "layer2s": {
-      "description": "Systems mirroring Ethereum’s limits may need updates to contract-size checks to remain compatible with L1 rules."
+      "description": "Systems mirroring Ethereum\u2019s limits may need updates to contract-size checks to remain compatible with L1 rules."
     },
     "stakersNodes": {
       "description": "Operators need upgraded clients at fork; larger contracts can slightly increase storage and processing per deployment."

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -3,7 +3,7 @@
   "title": "EIP-7976: Increase Calldata Floor Cost",
   "status": "Draft",
   "description": "Increase the calldata floor cost to 64/64 gas per byte to reduce maximum block size",
-  "author": "Toni Wahrst\u00e4tter (@nerolation)",
+  "author": "Toni Wahrstätter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2025-06-18",
@@ -33,7 +33,7 @@
       ],
       "champions": [
         {
-          "name": "Toni Wahrst\u00e4tter",
+          "name": "Toni Wahrstätter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -3,7 +3,7 @@
   "title": "EIP-7976: Increase Calldata Floor Cost",
   "status": "Draft",
   "description": "Increase the calldata floor cost to 64/64 gas per byte to reduce maximum block size",
-  "author": "Toni Wahrstätter (@nerolation)",
+  "author": "Toni Wahrst\u00e4tter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2025-06-18",
@@ -23,11 +23,17 @@
           "status": "Considered",
           "call": "acde/226",
           "date": "2025-12-18"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [
         {
-          "name": "Toni Wahrstätter",
+          "name": "Toni Wahrst\u00e4tter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -3,7 +3,7 @@
   "title": "EIP-7981: Increase Access List Cost",
   "status": "Draft",
   "description": "Price access lists for data to reduce maximum block size",
-  "author": "Toni Wahrst\u00e4tter (@nerolation)",
+  "author": "Toni Wahrstätter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2024-12-27",
@@ -33,7 +33,7 @@
       ],
       "champions": [
         {
-          "name": "Toni Wahrst\u00e4tter",
+          "name": "Toni Wahrstätter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -3,7 +3,7 @@
   "title": "EIP-7981: Increase Access List Cost",
   "status": "Draft",
   "description": "Price access lists for data to reduce maximum block size",
-  "author": "Toni Wahrstätter (@nerolation)",
+  "author": "Toni Wahrst\u00e4tter (@nerolation)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2024-12-27",
@@ -23,11 +23,17 @@
           "status": "Considered",
           "call": "acde/226",
           "date": "2025-12-18"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [
         {
-          "name": "Toni Wahrstätter",
+          "name": "Toni Wahrst\u00e4tter",
           "discord": "nero_eth"
         }
       ]

--- a/src/data/eips/8024.json
+++ b/src/data/eips/8024.json
@@ -3,7 +3,7 @@
   "title": "EIP-8024: Backward compatible SWAPN, DUPN, EXCHANGE",
   "status": "Review",
   "description": "Introduce additional instructions for manipulating the stack which allow accessing the stack at higher depths",
-  "author": "Francisco Giordano (@frangio), Charles Cooper (@charles-cooper), Alex Beregszaszi (@axic), Pawe\u0142 Bylica (@chfast)",
+  "author": "Francisco Giordano (@frangio), Charles Cooper (@charles-cooper), Alex Beregszaszi (@axic), Paweł Bylica (@chfast)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2025-08-16",

--- a/src/data/eips/8024.json
+++ b/src/data/eips/8024.json
@@ -3,7 +3,7 @@
   "title": "EIP-8024: Backward compatible SWAPN, DUPN, EXCHANGE",
   "status": "Review",
   "description": "Introduce additional instructions for manipulating the stack which allow accessing the stack at higher depths",
-  "author": "Francisco Giordano (@frangio), Charles Cooper (@charles-cooper), Alex Beregszaszi (@axic), Paweł Bylica (@chfast)",
+  "author": "Francisco Giordano (@frangio), Charles Cooper (@charles-cooper), Alex Beregszaszi (@axic), Pawe\u0142 Bylica (@chfast)",
   "type": "Standards Track",
   "category": "Core",
   "createdDate": "2025-08-16",
@@ -23,6 +23,12 @@
           "status": "Considered",
           "call": "acde/225",
           "date": "2025-12-04"
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [

--- a/src/data/eips/8037.json
+++ b/src/data/eips/8037.json
@@ -24,6 +24,12 @@
           "call": "acdt/66",
           "date": "2026-01-19",
           "timestamp": 3188
+        },
+        {
+          "status": "Scheduled",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
         }
       ],
       "champions": [

--- a/src/data/eips/8246.json
+++ b/src/data/eips/8246.json
@@ -16,7 +16,7 @@
           "status": "Considered",
           "call": "acde/236",
           "date": "2026-05-07",
-          "timestamp": 4196
+          "timestamp": 4319
         }
       ]
     }

--- a/src/data/eips/8246.json
+++ b/src/data/eips/8246.json
@@ -8,6 +8,18 @@
   "category": "Core",
   "createdDate": "2026-05-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8246-remove-selfdestruct-burn/28416",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Glamsterdam",
+      "statusHistory": [
+        {
+          "status": "Considered",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 4196
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }

--- a/src/data/eips/8253.json
+++ b/src/data/eips/8253.json
@@ -1,0 +1,32 @@
+{
+  "id": 8253,
+  "title": "EIP-8253: Remove pre-Spurious-Dragon accounts",
+  "status": "Draft",
+  "description": "Sets nonce to 1 for accounts meeting specific criteria (empty code, zero nonce, non-empty storage) through an irregular state transition, preventing future contract creation collisions.",
+  "author": "Jochem Brouwer (@jochem-brouwer)",
+  "type": "Standards Track",
+  "category": "Core",
+  "createdDate": "2026-05-05",
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 4879
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 4879
+        }
+      ]
+    }
+  ],
+  "tradeoffs": null
+}

--- a/src/data/eips/8254.json
+++ b/src/data/eips/8254.json
@@ -16,7 +16,7 @@
           "status": "Proposed",
           "call": "acde/236",
           "date": "2026-05-07",
-          "timestamp": 804
+          "timestamp": 3375
         }
       ]
     }

--- a/src/data/eips/8254.json
+++ b/src/data/eips/8254.json
@@ -1,0 +1,25 @@
+{
+  "id": 8254,
+  "title": "EIP-8254: Cap deposit requests per block",
+  "status": "Draft",
+  "description": "Limits the number of deposit requests in an Execution Layer block to 8192.",
+  "author": "pk910 (@pk910), Barnabas Busa (@barnabasbusa)",
+  "type": "Standards Track",
+  "category": "Core",
+  "createdDate": "2026-05-06",
+  "discussionLink": "https://ethereum-magicians.org/t/eip-8254-cap-deposit-requests-per-block/28453",
+  "forkRelationships": [
+    {
+      "forkName": "Glamsterdam",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acde/236",
+          "date": "2026-05-07",
+          "timestamp": 804
+        }
+      ]
+    }
+  ],
+  "tradeoffs": null
+}

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -89,7 +89,7 @@ export interface KeyDecision {
   type: KeyDecisionType;
   eips: number[];
   stage_change?: {
-    to: 'Considered' | 'Scheduled' | 'Included' | 'Declined' | 'Withdrawn';
+    to: 'Proposed' | 'Considered' | 'Scheduled' | 'Included' | 'Declined' | 'Withdrawn';
   };
   devnet?: string;
   fork?: string;


### PR DESCRIPTION
## Summary
- Set video/transcript sync offsets for ACDE 236
- Normalize devnet name typos in transcript and tldr (`Ball devnet N` / `Paul devnet 3` → `bal-devnet-N`; `Glamsterdam devnet N` → `glamsterdam-devnet-N`)
- Rewrite `key_decisions.json` after cross-checking with the call agenda (ethereum/pm#2033) and the Glamsterdam SFI PR (ethereum/EIPs#11399). The LLM extractor had grouped unrelated EIPs into the SFI batch — fixed.
- Update `statusHistory` for every EIP touched in this call (SFI batch, 8246, 8254, 7709, 8253)
- Stub EIP files for 8253 and 8254 (not yet merged into ethereum/EIPs)
- Add `'Proposed'` to the `KeyDecision.stage_change.to` union (the extractor prompt already permits it; the type was stale)

### Decisions captured (per agenda 2033 + transcript)
- **SFI for Glamsterdam** (`acde/236` @ 00:17:15): EIP-7708, 7778, 7843, 7954, 7976, 7981, 8024, 8037
- **CFI for Glamsterdam** (@ 01:15:50): EIP-8246 (selfdestruct burn removal); full SELFDESTRUCT removal can't fit Glamsterdam
- **PFI for Glamsterdam** (@ 01:00:06): EIP-8254 (cap deposit requests per block); open questions remain
- **PFI for Hegota** (@ 01:16:50): EIP-7709 (BLOCKHASH from storage), proposed by Ignacio
- **PFI for Hegota + presentation** (@ 01:25:10): EIP-8253 (remove pre-Spurious-Dragon accounts), presented by Jochem

### Companion PR
PM-side typo vocab additions + mirrored artifacts: ethereum/pm#2042

## Test plan
- [ ] Reload `/calls/acde/236` — sync offsets align video and transcript
- [ ] Key decisions panel shows the 6 corrected decisions with right EIPs and stages
- [ ] EIP pages for 7708, 7778, 7843, 7954, 7976, 7981, 8024, 8037 show Glamsterdam status as Scheduled
- [ ] EIP pages for 7709 and 8253 show Hegota status as Proposed
- [ ] EIP page for 8246 shows Glamsterdam as Considered
- [ ] EIP page for 8254 shows Glamsterdam as Proposed
- [ ] No remaining `Ball devnet` / `Paul devnet` / `Glamsterdam devnet N` references in transcript or tldr