### PR TITLE
Redirect /calls/&lt;type&gt; to filtered calls index

### DIFF
--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -88,11 +88,9 @@ const LAYOUT_EXPANDED = {
 const isIssueRedirectPath = (path: string | undefined): path is string =>
   Boolean(path && !path.includes('/') && /^\d+$/.test(path));
 
-const CALL_TYPE_FILTER_ALIASES = new Set(['acd', 'breakouts']);
-
 const isCallTypeFilterPath = (path: string | undefined): path is string => {
   if (!path || path.includes('/') || /^\d+$/.test(path)) return false;
-  return CALL_TYPE_FILTER_ALIASES.has(path) || protocolCalls.some(c => c.type === path);
+  return protocolCalls.some(c => c.type === path);
 };
 
 const timestampToSeconds = (timestamp: string | null | undefined): number => {

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -88,6 +88,13 @@ const LAYOUT_EXPANDED = {
 const isIssueRedirectPath = (path: string | undefined): path is string =>
   Boolean(path && !path.includes('/') && /^\d+$/.test(path));
 
+const CALL_TYPE_FILTER_ALIASES = new Set(['acd', 'breakouts']);
+
+const isCallTypeFilterPath = (path: string | undefined): path is string => {
+  if (!path || path.includes('/') || /^\d+$/.test(path)) return false;
+  return CALL_TYPE_FILTER_ALIASES.has(path) || protocolCalls.some(c => c.type === path);
+};
+
 const timestampToSeconds = (timestamp: string | null | undefined): number => {
   if (!timestamp) return 0;
   const parts = timestamp.split(':');
@@ -260,7 +267,8 @@ const CallPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // Redirect issue-number URLs (e.g., /calls/1954) to the canonical path
+  // Redirect issue-number URLs (e.g., /calls/1954) to the canonical path,
+  // and call-type-only URLs (e.g., /calls/acde) to the filtered index.
   const normalizedPath = callPath?.replace(/\/+$/, '');
   useEffect(() => {
     if (isIssueRedirectPath(normalizedPath)) {
@@ -276,6 +284,15 @@ const CallPage: React.FC = () => {
           { replace: true },
         );
       }
+    } else if (isCallTypeFilterPath(normalizedPath)) {
+      navigate(
+        {
+          pathname: '/calls',
+          search: `?filter=${normalizedPath}`,
+          hash: location.hash,
+        },
+        { replace: true },
+      );
     }
   }, [location.hash, location.search, normalizedPath, navigate]);
 
@@ -474,8 +491,8 @@ const CallPage: React.FC = () => {
   }, [callConfig]);
 
   useEffect(() => {
-    // Issue-number URLs are handled by the redirect effect — leave loading set.
-    if (isIssueRedirectPath(normalizedPath)) return;
+    // Issue-number and call-type URLs are handled by the redirect effect — leave loading set.
+    if (isIssueRedirectPath(normalizedPath) || isCallTypeFilterPath(normalizedPath)) return;
 
     let cancelled = false;
     setLoading(true);


### PR DESCRIPTION
## Summary
- When a user trims the call number off a call URL (e.g. `/calls/acde/229` → `/calls/acde`), redirect to `/calls?filter=acde` instead of falling through to the "Call not found" state.
- Also covers the meta filter aliases (`acd`, `breakouts`).
- Implemented as a sibling to the existing issue-number redirect in `CallPage`, with a matching guard in the data-loading effect so we don't briefly try to fetch a phantom call.

## Test plan
- [ ] `/calls/acde` → replaces with `/calls?filter=acde`
- [ ] `/calls/acdc`, `/calls/acdt`, `/calls/epbs`, `/calls/bal`, `/calls/focil` → replace with the corresponding `?filter=` URL
- [ ] `/calls/acd` → replaces with `/calls?filter=acd`
- [ ] `/calls/breakouts` → replaces with `/calls?filter=breakouts`
- [ ] `/calls/acde/229` still loads the call page as before
- [ ] `/calls/1954` (issue-number redirect) still resolves to its canonical path
- [ ] `/calls/somethinginvalid` still shows "Call not found"

https://claude.ai/code/session_016tCNZ37Yjy4vL4rC4ZgoF6

---
_Generated by [Claude Code](https://claude.ai/code/session_016tCNZ37Yjy4vL4rC4ZgoF6)_