### PR TITLE
Fix upgrade page scrollbars

### DIFF
--- a/src/components/GlamsterdamUpgradePage.tsx
+++ b/src/components/GlamsterdamUpgradePage.tsx
@@ -86,7 +86,7 @@ const GlamsterdamUpgradePage: React.FC = () => {
           </div>
 
           <div className="-mx-6 mt-4">
-            <div className="overflow-x-auto px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <div className="overflow-x-auto px-6 pb-3">
               <div className="flex gap-6 border-b border-slate-200 dark:border-slate-700 min-w-max">
                 {tabs.map((tab) => {
                   const active = isTabActive(pathname, tab.path);

--- a/src/components/network-upgrade/TableOfContents.tsx
+++ b/src/components/network-upgrade/TableOfContents.tsx
@@ -82,7 +82,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
 
   return (
     <div className="hidden lg:block w-64 flex-shrink-0">
-      <div className="sticky top-20 overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)]">
+      <div className="sticky top-20 max-h-[calc(100vh-6rem)] flex flex-col">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100 uppercase tracking-wide">Contents</h3>
           <Tooltip text="Scroll to top" position="bottom">
@@ -108,7 +108,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
           totalEipCount={totalEipCount}
         />
 
-        <nav className="space-y-1">
+        <nav className="min-h-0 flex-1 space-y-1 overflow-y-auto overflow-x-hidden pr-2 [scrollbar-gutter:stable]">
           {filteredItems.map((item) => {
             const button = (
               <button

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,7 @@
   }
 
   html {
+    color-scheme: light;
     scrollbar-gutter: stable;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
@@ -133,6 +134,7 @@
   }
 
   .dark {
+    color-scheme: dark;
     --background: 240 100% 0.8%;
     --foreground: 210 40% 98%;
 


### PR DESCRIPTION
## Summary

Fixes the Glamsterdam upgrade page scrollbar regression by keeping scroll behavior native and local to the part of the UI that actually scrolls.

## What changed

- Let browser scrollbars follow the active light/dark theme via `color-scheme`.
- Removed the hidden custom scrollbar treatment from the Glamsterdam tab strip.
- Changed the desktop upgrade contents sidebar so the heading and filters stay fixed while only the contents list scrolls.

## Why

The previous inner scrollbar applied to the full contents rail, so scrolling moved the heading and filters out of the rail and made hover behavior feel jumpy. Keeping the scroll container on the list itself makes the sidebar behave like a normal app sidebar and avoids scrollbar overlap with list labels.

## Validation

- Verified `/upgrade/glamsterdam` in the browser in dark and light mode.
- Verified the contents rail scroll behavior after separating the fixed controls from the scrollable list.
- `npm run lint`
- `npm run build`