### PR TITLE
devnets: harden notes parsing, probe in series

### DIFF
--- a/scripts/scrape-all-devnet-specs.mjs
+++ b/scripts/scrape-all-devnet-specs.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Re-scrape all known devnet specs from HackMD.
- * Reads existing JSON files in src/data/devnets/ to determine which IDs to scrape.
+ * Reads existing JSON files in src/data/devnets/ to determine which IDs to scrape,
+ * then probes for new devnets beyond the highest known number in each series.
  * Tolerates 404s (not all devnets have HackMD specs).
  */
 
@@ -14,17 +15,37 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEVNETS_DIR = join(__dirname, '..', 'src/data/devnets');
 const SCRAPER = join(__dirname, 'scrape-devnet-spec.mjs');
 
-const files = readdirSync(DEVNETS_DIR).filter((f) => f.endsWith('.json'));
-const ids = files.map((f) => f.replace('.json', ''));
+function scrape(id, { quiet = false } = {}) {
+  execFileSync('node', [SCRAPER, id], {
+    stdio: quiet ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  });
+}
 
-console.log(`Scraping ${ids.length} devnet specs...\n`);
+const files = readdirSync(DEVNETS_DIR).filter((f) => f.endsWith('.json'));
+const ids = new Set(files.map((f) => f.replace('.json', '')));
+
+// Group by series prefix and find the max version in each.
+// e.g. "glamsterdam-devnet-3" → series "glamsterdam-devnet", version 3
+const seriesMax = new Map();
+for (const id of ids) {
+  const match = id.match(/^(.+-devnet)-(\d+)$/);
+  if (!match) continue;
+  const [, series, numStr] = match;
+  const num = parseInt(numStr, 10);
+  if (!seriesMax.has(series) || num > seriesMax.get(series)) {
+    seriesMax.set(series, num);
+  }
+}
+
+// --- Phase 1: scrape all known IDs ---
+console.log(`Scraping ${ids.size} known devnet specs...\n`);
 
 let succeeded = 0;
 let failed = 0;
 
 for (const id of ids) {
   try {
-    execFileSync('node', [SCRAPER, id], { stdio: 'inherit' });
+    scrape(id);
     succeeded++;
   } catch {
     console.warn(`  ⚠ Skipped ${id} (no HackMD spec found)\n`);
@@ -32,4 +53,26 @@ for (const id of ids) {
   }
 }
 
-console.log(`\nDone: ${succeeded} updated, ${failed} skipped`);
+// --- Phase 2: probe for new devnets beyond the highest known version ---
+let discovered = 0;
+
+for (const [series, max] of seriesMax) {
+  let next = max + 1;
+  while (true) {
+    const candidate = `${series}-${next}`;
+    console.log(`Probing for ${candidate}...`);
+    try {
+      scrape(candidate, { quiet: true });
+      console.log(`  ✓ Discovered ${candidate}`);
+      discovered++;
+      next++;
+    } catch {
+      console.log(`  — not found, stopping ${series} series`);
+      break;
+    }
+  }
+}
+
+console.log(
+  `\nDone: ${succeeded} updated, ${failed} skipped, ${discovered} newly discovered`,
+);

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -23,12 +23,27 @@ if (!/^[a-z0-9-]+$/.test(id)) {
 }
 
 const DOWNLOAD_URL = `https://notes.ethereum.org/@ethpandaops/${id}/download`;
+const NETWORKS_URL =
+  'https://ethpandaops-platform-production-cartographoor.ams3.digitaloceanspaces.com/networks.json';
 
 async function fetchMarkdown() {
   console.log(`Fetching ${DOWNLOAD_URL}`);
   const res = await fetch(DOWNLOAD_URL);
   if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${DOWNLOAD_URL}`);
   return res.text();
+}
+
+/** Fetch genesis time (unix seconds) from the cartographoor networks.json. */
+async function fetchGenesisTime() {
+  try {
+    const res = await fetch(NETWORKS_URL);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const entry = data.networks?.[id];
+    return entry?.genesisConfig?.genesisTime ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function parseTitle(md) {
@@ -216,7 +231,10 @@ function parseSameSpecAs(md) {
 }
 
 async function main() {
-  const md = await fetchMarkdown();
+  const [md, genesisTime] = await Promise.all([
+    fetchMarkdown(),
+    fetchGenesisTime(),
+  ]);
 
   const sameSpecAs = parseSameSpecAs(md);
 
@@ -240,12 +258,19 @@ async function main() {
     };
     console.log(`  (uses same spec as ${sameSpecAs})`);
   } else {
+    let announcements = parseAnnouncements(md);
+    // Drop "targets to launch" announcements when we know the actual genesis time
+    if (genesisTime) {
+      announcements = announcements.filter(
+        (a) => !/targets to launch/i.test(a),
+      );
+    }
     spec = {
       id,
       title: parseTitle(md),
       sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
       scrapedAt: new Date().toISOString(),
-      announcements: parseAnnouncements(md),
+      announcements,
       eips: parseEipTable(md),
       elClientSupport: parseClientMatrix(
         md,
@@ -257,6 +282,16 @@ async function main() {
       ),
       specReferences: parseSpecReferences(md),
     };
+  }
+
+  // Store genesis time if available (from cartographoor or previously scraped)
+  if (genesisTime) {
+    spec.genesisTime = genesisTime;
+    // Filter "targets to launch" announcements now that we have the real date
+    spec.announcements = spec.announcements.filter(
+      (a) => !/targets to launch/i.test(a),
+    );
+    console.log(`  genesis time: ${new Date(genesisTime * 1000).toISOString()}`);
   }
 
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -4,7 +4,7 @@
  * Usage: node scripts/scrape-devnet-spec.mjs bal-devnet-3
  */
 
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -199,26 +199,65 @@ function parseSpecReferences(md) {
   };
 }
 
+/**
+ * Detect pages that say "same spec as [other-devnet](url)".
+ * Returns the referenced devnet ID if found, otherwise null.
+ * Prefers the link text over the URL slug (pages sometimes have copy-paste URL errors).
+ */
+function parseSameSpecAs(md) {
+  const match = md.match(
+    /same spec as \[([^\]]+)\]\(https?:\/\/notes\.ethereum\.org\/@ethpandaops\/([a-z0-9-]+)\)/i,
+  );
+  if (!match) return null;
+  const linkText = match[1].trim();
+  const urlSlug = match[2];
+  // Use link text if it looks like a valid devnet ID, otherwise fall back to URL slug
+  return /^[a-z0-9-]+-devnet-\d+$/.test(linkText) ? linkText : urlSlug;
+}
+
 async function main() {
   const md = await fetchMarkdown();
 
-  const spec = {
-    id,
-    title: parseTitle(md),
-    sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
-    scrapedAt: new Date().toISOString(),
-    announcements: parseAnnouncements(md),
-    eips: parseEipTable(md),
-    elClientSupport: parseClientMatrix(
-      md,
-      /## Execution Layer Client Support|### Implementation tracker EL/,
-    ),
-    clClientSupport: parseClientMatrix(
-      md,
-      /## Consensus Layer Client Support|## Consensus Layer Support|### Implementation tracker CL/,
-    ),
-    specReferences: parseSpecReferences(md),
-  };
+  const sameSpecAs = parseSameSpecAs(md);
+
+  let spec;
+  if (sameSpecAs) {
+    // This page reuses another devnet's spec — copy its data
+    const refPath = join(OUTPUT_DIR, `${sameSpecAs}.json`);
+    if (!existsSync(refPath)) {
+      throw new Error(
+        `Referenced spec ${sameSpecAs} not found at ${refPath}. Scrape it first.`,
+      );
+    }
+    const refSpec = JSON.parse(readFileSync(refPath, 'utf-8'));
+    spec = {
+      ...refSpec,
+      id,
+      title: parseTitle(md),
+      sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
+      scrapedAt: new Date().toISOString(),
+      sameSpecAs,
+    };
+    console.log(`  (uses same spec as ${sameSpecAs})`);
+  } else {
+    spec = {
+      id,
+      title: parseTitle(md),
+      sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
+      scrapedAt: new Date().toISOString(),
+      announcements: parseAnnouncements(md),
+      eips: parseEipTable(md),
+      elClientSupport: parseClientMatrix(
+        md,
+        /## Execution Layer Client Support|### Implementation tracker EL/,
+      ),
+      clClientSupport: parseClientMatrix(
+        md,
+        /## Consensus Layer Client Support|## Consensus Layer Support|### Implementation tracker CL/,
+      ),
+      specReferences: parseSpecReferences(md),
+    };
+  }
 
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
 

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -247,7 +247,7 @@ async function main() {
         `Referenced spec ${sameSpecAs} not found at ${refPath}. Scrape it first.`,
       );
     }
-    const refSpec = JSON.parse(readFileSync(refPath, 'utf-8'));
+    const { genesisTime: _inherited, ...refSpec } = JSON.parse(readFileSync(refPath, 'utf-8'));
     spec = {
       ...refSpec,
       id,
@@ -258,19 +258,12 @@ async function main() {
     };
     console.log(`  (uses same spec as ${sameSpecAs})`);
   } else {
-    let announcements = parseAnnouncements(md);
-    // Drop "targets to launch" announcements when we know the actual genesis time
-    if (genesisTime) {
-      announcements = announcements.filter(
-        (a) => !/targets to launch/i.test(a),
-      );
-    }
     spec = {
       id,
       title: parseTitle(md),
       sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
       scrapedAt: new Date().toISOString(),
-      announcements,
+      announcements: parseAnnouncements(md),
       eips: parseEipTable(md),
       elClientSupport: parseClientMatrix(
         md,

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -247,14 +247,18 @@ async function main() {
         `Referenced spec ${sameSpecAs} not found at ${refPath}. Scrape it first.`,
       );
     }
-    const { genesisTime: _inherited, ...refSpec } = JSON.parse(readFileSync(refPath, 'utf-8'));
+    const refSpec = JSON.parse(readFileSync(refPath, 'utf-8'));
     spec = {
-      ...refSpec,
       id,
       title: parseTitle(md),
       sourceUrl: `https://notes.ethereum.org/@ethpandaops/${id}`,
       scrapedAt: new Date().toISOString(),
       sameSpecAs,
+      announcements: [],
+      eips: refSpec.eips,
+      elClientSupport: { clients: [], matrix: [] },
+      clClientSupport: { clients: [], matrix: [] },
+      specReferences: refSpec.specReferences,
     };
     console.log(`  (uses same spec as ${sameSpecAs})`);
   } else {

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -360,6 +360,19 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
               View Source
             </a>
             <span>&middot;</span>
+            {spec.genesisTime && (
+              <>
+                <span>
+                  Launched{' '}
+                  {new Date(spec.genesisTime * 1000).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+                <span>&middot;</span>
+              </>
+            )}
             <span>
               Scraped{' '}
               {new Date(spec.scrapedAt).toLocaleDateString('en-US', {

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -371,6 +371,19 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
           </div>
         </div>
 
+        {/* Same-spec notice */}
+        {spec.sameSpecAs && (
+          <div className="mb-8 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 px-4 py-3 text-sm text-slate-600 dark:text-slate-400">
+            This devnet used the same spec as{' '}
+            <Link
+              to={`/devnets/${spec.sameSpecAs}`}
+              className="text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 font-medium transition-colors"
+            >
+              {spec.sameSpecAs}
+            </Link>.
+          </div>
+        )}
+
         {/* Announcements */}
         {spec.announcements.length > 0 && (
           <section className="mb-8 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-sm text-blue-900 dark:text-blue-200 overflow-hidden divide-y divide-blue-200 dark:divide-blue-800">

--- a/src/data/devnets/bal-devnet-0.json
+++ b/src/data/devnets/bal-devnet-0.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-0",
   "title": "bal-devnet-0",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-0",
-  "scrapedAt": "2026-05-11T18:46:11.515Z",
+  "scrapedAt": "2026-05-11T18:52:17.154Z",
   "announcements": [
     "bal-devnet-0 targets to launch on end of Oct 2025.\n(launched [2025-Nov-04 05:02:44 PM UTC](https://github.com/ethpandaops/bal-devnets/blob/master/network-configs/devnet-0/metadata/config.yaml#L27C1-L27C30))"
   ],

--- a/src/data/devnets/bal-devnet-1.json
+++ b/src/data/devnets/bal-devnet-1.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-1",
   "title": "bal-devnet-1",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-1",
-  "scrapedAt": "2026-05-11T18:46:12.603Z",
+  "scrapedAt": "2026-05-11T18:52:18.194Z",
   "announcements": [
     "bal-devnet-1 targets to launch early Jan 2026.\n(launched [2025-Dec-18 01:00:00 PM UTC](https://github.com/ethpandaops/bal-devnets/blob/master/network-configs/devnet-1/metadata/config.yaml#L27))"
   ],

--- a/src/data/devnets/bal-devnet-2.json
+++ b/src/data/devnets/bal-devnet-2.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-2",
   "title": "bal-devnet-2",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-2",
-  "scrapedAt": "2026-05-11T18:46:13.470Z",
+  "scrapedAt": "2026-05-11T18:52:19.237Z",
   "announcements": [
     "bal-devnet-2 targets to launch 04 Feb 2026.\n([launched 2026-Feb-06 02:29:50 PM UTC](https://github.com/ethpandaops/bal-devnets/blob/master/network-configs/devnet-2/metadata/config.yaml#L27-L28))",
     "EL clients: please add flags to enable/disable BAL optimizations batch/parallel io and parallel execution."

--- a/src/data/devnets/bal-devnet-3.json
+++ b/src/data/devnets/bal-devnet-3.json
@@ -2,9 +2,8 @@
   "id": "bal-devnet-3",
   "title": "bal-devnet-3",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-3",
-  "scrapedAt": "2026-05-11T18:46:14.553Z",
+  "scrapedAt": "2026-05-11T18:52:20.287Z",
   "announcements": [
-    "bal-devnet-3 targets to launch 08 April 2026.",
     "EL clients: please add flags to enable/disable BAL optimizations batch/parallel io and parallel execution.",
     "EL clients: **EIP-8037** will be using a hardcoded value for the **cost per state byte of 1174**. This aligns with a block gas limit of 100M, the value being set for the devnet. The cost per state byte value of 1174 will be a treated as a fork constant for this devnet and not depend on the block gas limit. For the next devnet we will use the full EIP variant where the cpsb will depend on the block gas limit."
   ],
@@ -230,5 +229,6 @@
       "version": "bal@v5.6.0",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.0"
     }
-  }
+  },
+  "genesisTime": 1775658600
 }

--- a/src/data/devnets/bal-devnet-4.json
+++ b/src/data/devnets/bal-devnet-4.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-4",
   "title": "bal-devnet-4",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-4",
-  "scrapedAt": "2026-05-11T18:46:14.907Z",
+  "scrapedAt": "2026-05-11T18:52:21.337Z",
   "announcements": [
     "bal-devnet-4 target launch: **Wednesday 29.04**.",
     "BAL benchmark dashboard https://nerolation.github.io/bal-dashboard/. Based on data from https://benchmarkoor.core.ethpandaops.io. Requires benchmarkoor api key.",

--- a/src/data/devnets/bal-devnet-5.json
+++ b/src/data/devnets/bal-devnet-5.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-5",
   "title": "bal-devnet-5",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-5",
-  "scrapedAt": "2026-05-11T18:46:15.312Z",
+  "scrapedAt": "2026-05-11T18:52:22.404Z",
   "announcements": [
     "bal-devnet-5 will launch on wednesday **29.04**.",
     "BAL benchmark dashboard https://nerolation.github.io/bal-dashboard/. Based on data from https://benchmarkoor.core.ethpandaops.io. Requires benchmarkoor api key.",

--- a/src/data/devnets/bal-devnet-6.json
+++ b/src/data/devnets/bal-devnet-6.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-6",
   "title": "bal-devnet-6",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-6",
-  "scrapedAt": "2026-05-11T18:46:15.729Z",
+  "scrapedAt": "2026-05-11T18:52:23.432Z",
   "announcements": [
     "bal-devnet-6 target launch: **Friday 01.05**.",
     "BAL benchmark dashboard https://nerolation.github.io/bal-dashboard/. Based on data from https://benchmarkoor.core.ethpandaops.io. Requires benchmarkoor api key.",
@@ -271,5 +271,6 @@
       "version": "snøbal-devnet-6@v1.0.0",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/snøbal-devnet-6@v1.0.0"
     }
-  }
+  },
+  "genesisTime": 1777615200
 }

--- a/src/data/devnets/blob-devnet-0.json
+++ b/src/data/devnets/blob-devnet-0.json
@@ -2,7 +2,7 @@
   "id": "blob-devnet-0",
   "title": "blob-devnet-0",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/blob-devnet-0",
-  "scrapedAt": "2026-05-11T18:46:16.927Z",
+  "scrapedAt": "2026-05-11T18:52:24.496Z",
   "announcements": [
     "blob-devnet-0 launched on 21st of Jan 2026.",
     "Weekly [discussion](https://hackmd.io/BcJbP0D2TYue15rho9bvfA)"
@@ -134,5 +134,6 @@
       "url": "https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.1"
     },
     "executionSpecs": null
-  }
+  },
+  "genesisTime": 1769027294
 }

--- a/src/data/devnets/epbs-devnet-0.json
+++ b/src/data/devnets/epbs-devnet-0.json
@@ -2,7 +2,7 @@
   "id": "epbs-devnet-0",
   "title": "epbs-devnet-0",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/epbs-devnet-0",
-  "scrapedAt": "2026-05-11T18:46:18.033Z",
+  "scrapedAt": "2026-05-11T18:52:25.531Z",
   "announcements": [
     "epbs-devnet-0 targets to launch by 4th of March 2026",
     "On epbs-devnet-0, only self-built payloads will be tested."

--- a/src/data/devnets/epbs-devnet-1.json
+++ b/src/data/devnets/epbs-devnet-1.json
@@ -2,7 +2,7 @@
   "id": "epbs-devnet-1",
   "title": "epbs-devnet-1",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/epbs-devnet-1",
-  "scrapedAt": "2026-05-11T18:46:18.440Z",
+  "scrapedAt": "2026-05-11T18:52:26.422Z",
   "announcements": [
     "epbs-devnet-1 targets to launch by 31st of March 2026.",
     "On devnet 1 only local block building will be tested only."

--- a/src/data/devnets/epbs-devnet-2.json
+++ b/src/data/devnets/epbs-devnet-2.json
@@ -2,7 +2,7 @@
   "id": "epbs-devnet-2",
   "title": "epbs-devnet-2",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/epbs-devnet-2",
-  "scrapedAt": "2026-05-11T18:46:18.838Z",
+  "scrapedAt": "2026-05-11T18:52:27.302Z",
   "announcements": [
     "epbs-devnet-2 will no longer happen. For latest info please head over to https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-0",
     "Everything below is outdated!!"

--- a/src/data/devnets/glamsterdam-devnet-0.json
+++ b/src/data/devnets/glamsterdam-devnet-0.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-0",
   "title": "glamsterdam-devnet-0",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-0",
-  "scrapedAt": "2026-05-11T18:36:51.273Z",
+  "scrapedAt": "2026-05-11T18:59:57.831Z",
   "announcements": [
     "glamsterdam-devnet-0 targets to launch on the 24th of April 2026.",
     "EL clients: **EIP-8037** ~~will switch from hard coded **cost per state byte** to a variable cost based on the block gas limit. Similar to bal-devnet-3 or 4.~~ Will stay static."

--- a/src/data/devnets/glamsterdam-devnet-0.json
+++ b/src/data/devnets/glamsterdam-devnet-0.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-0",
   "title": "glamsterdam-devnet-0",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-0",
-  "scrapedAt": "2026-05-11T18:46:19.260Z",
+  "scrapedAt": "2026-05-11T18:36:51.273Z",
   "announcements": [
     "glamsterdam-devnet-0 targets to launch on the 24th of April 2026.",
     "EL clients: **EIP-8037** ~~will switch from hard coded **cost per state byte** to a variable cost based on the block gas limit. Similar to bal-devnet-3 or 4.~~ Will stay static."

--- a/src/data/devnets/glamsterdam-devnet-1.json
+++ b/src/data/devnets/glamsterdam-devnet-1.json
@@ -2,19 +2,249 @@
   "id": "glamsterdam-devnet-1",
   "title": "glamsterdam-devnet-1",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-1",
-  "scrapedAt": "2026-05-11T18:46:19.609Z",
-  "announcements": [],
-  "eips": [],
+  "scrapedAt": "2026-05-11T18:25:42.216Z",
+  "announcements": [
+    "glamsterdam-devnet-0 targets to launch on the 24th of April 2026.",
+    "EL clients: **EIP-8037** ~~will switch from hard coded **cost per state byte** to a variable cost based on the block gas limit. Similar to bal-devnet-3 or 4.~~ Will stay static."
+  ],
+  "eips": [
+    {
+      "number": 7708,
+      "title": "ETH transfers emit a log",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7708"
+    },
+    {
+      "number": 7732,
+      "title": "Enshrined Proposer-Builder Separation",
+      "status": "updated",
+      "url": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7732.md"
+    },
+    {
+      "number": 7778,
+      "title": "Block Gas Accounting without Refunds",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7778"
+    },
+    {
+      "number": 7843,
+      "title": "SLOTNUM opcode",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7843"
+    },
+    {
+      "number": 7928,
+      "title": "Block-Level Access Lists",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-7928"
+    },
+    {
+      "number": 7954,
+      "title": "Increase Maximum Contract Size",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7954"
+    },
+    {
+      "number": 7975,
+      "title": "eth/70 - partial block receipt lists",
+      "status": "optional",
+      "url": "https://eips.ethereum.org/EIPS/eip-7975"
+    },
+    {
+      "number": 7976,
+      "title": "Increase Calldata Floor Cost (64/64)",
+      "status": "new",
+      "url": "https://eips.ethereum.org/EIPS/eip-7976"
+    },
+    {
+      "number": 7981,
+      "title": "Increase Access List Cost",
+      "status": "new",
+      "url": "https://eips.ethereum.org/EIPS/eip-7981"
+    },
+    {
+      "number": 8024,
+      "title": "Backward compatible SWAPN, DUPN, EXCHANGE",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-8024"
+    },
+    {
+      "number": 8159,
+      "title": "eth/71 - Block Access List Exchange",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-8159"
+    }
+  ],
   "elClientSupport": {
-    "clients": [],
-    "matrix": []
+    "clients": [
+      "Geth",
+      "Besu",
+      "Reth",
+      "Nethermind",
+      "Erigon",
+      "Nimbus-EL",
+      "Ethrex"
+    ],
+    "matrix": [
+      {
+        "eipNumber": 7708,
+        "label": "7708 (ETH Logs)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "supported",
+          "Reth": "supported",
+          "Nethermind": "supported",
+          "Erigon": "supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 7778,
+        "label": "7778 (Gas Refunds)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "supported",
+          "Reth": "supported",
+          "Nethermind": "supported",
+          "Erigon": "supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 7843,
+        "label": "7843 (SLOTNUM)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "supported",
+          "Reth": "supported",
+          "Nethermind": "supported",
+          "Erigon": "supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 7928,
+        "label": "7928 (BAL)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "supported",
+          "Reth": "supported",
+          "Nethermind": "supported",
+          "Erigon": "supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 7954,
+        "label": "7954 (MContract)",
+        "support": {
+          "Geth": "not_supported",
+          "Besu": "not_supported",
+          "Reth": "not_supported",
+          "Nethermind": "not_supported",
+          "Erigon": "not_supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 7975,
+        "label": "7975 (eth/70)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "in_progress",
+          "Reth": "not_supported",
+          "Nethermind": "supported",
+          "Erigon": "not_supported",
+          "Nimbus-EL": "not_supported",
+          "Ethrex": "not_supported"
+        }
+      },
+      {
+        "eipNumber": 8024,
+        "label": "8024 (SWAPN/DUPN)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "supported",
+          "Reth": "supported",
+          "Nethermind": "supported",
+          "Erigon": "supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 8037,
+        "label": "8037 (stateIncr)",
+        "support": {
+          "Geth": "supported",
+          "Besu": "not_supported",
+          "Reth": "not_supported",
+          "Nethermind": "not_supported",
+          "Erigon": "not_supported",
+          "Nimbus-EL": "supported",
+          "Ethrex": "supported"
+        }
+      },
+      {
+        "eipNumber": 8159,
+        "label": "8159 (eth/71)",
+        "support": {
+          "Geth": "not_supported",
+          "Besu": "not_supported",
+          "Reth": "not_supported",
+          "Nethermind": "not_supported",
+          "Erigon": "not_supported",
+          "Nimbus-EL": "not_supported",
+          "Ethrex": "not_supported"
+        }
+      },
+      {
+        "eipNumber": 7732,
+        "label": "7732 ePBS",
+        "support": {
+          "Geth": "not_supported",
+          "Besu": "not_supported",
+          "Reth": "not_supported",
+          "Nethermind": "not_supported",
+          "Erigon": "not_supported",
+          "Nimbus-EL": "not_supported",
+          "Ethrex": "not_supported"
+        }
+      }
+    ]
   },
   "clClientSupport": {
-    "clients": [],
-    "matrix": []
+    "clients": [
+      "Lodestar",
+      "Lighthouse",
+      "Prysm"
+    ],
+    "matrix": [
+      {
+        "eipNumber": 7928,
+        "label": "EIP-7928",
+        "support": {
+          "Lodestar": "glamsterdam-devnet-0",
+          "Lighthouse": "unknown",
+          "Prysm": "unknown"
+        }
+      }
+    ]
   },
   "specReferences": {
-    "consensusSpecs": null,
-    "executionSpecs": null
-  }
+    "consensusSpecs": {
+      "version": "v1.7.0-alpha.5",
+      "url": "https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.5"
+    },
+    "executionSpecs": {
+      "version": "bal@v5.6.1",
+      "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
+    }
+  },
+  "sameSpecAs": "glamsterdam-devnet-0"
 }

--- a/src/data/devnets/glamsterdam-devnet-1.json
+++ b/src/data/devnets/glamsterdam-devnet-1.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-1",
   "title": "glamsterdam-devnet-1",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-1",
-  "scrapedAt": "2026-05-11T18:25:42.216Z",
+  "scrapedAt": "2026-05-11T18:52:29.162Z",
   "announcements": [
     "glamsterdam-devnet-0 targets to launch on the 24th of April 2026.",
     "EL clients: **EIP-8037** ~~will switch from hard coded **cost per state byte** to a variable cost based on the block gas limit. Similar to bal-devnet-3 or 4.~~ Will stay static."

--- a/src/data/devnets/glamsterdam-devnet-1.json
+++ b/src/data/devnets/glamsterdam-devnet-1.json
@@ -2,11 +2,9 @@
   "id": "glamsterdam-devnet-1",
   "title": "glamsterdam-devnet-1",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-1",
-  "scrapedAt": "2026-05-11T18:52:29.162Z",
-  "announcements": [
-    "glamsterdam-devnet-0 targets to launch on the 24th of April 2026.",
-    "EL clients: **EIP-8037** ~~will switch from hard coded **cost per state byte** to a variable cost based on the block gas limit. Similar to bal-devnet-3 or 4.~~ Will stay static."
-  ],
+  "scrapedAt": "2026-05-11T20:00:47.979Z",
+  "sameSpecAs": "glamsterdam-devnet-0",
+  "announcements": [],
   "eips": [
     {
       "number": 7708,
@@ -76,165 +74,12 @@
     }
   ],
   "elClientSupport": {
-    "clients": [
-      "Geth",
-      "Besu",
-      "Reth",
-      "Nethermind",
-      "Erigon",
-      "Nimbus-EL",
-      "Ethrex"
-    ],
-    "matrix": [
-      {
-        "eipNumber": 7708,
-        "label": "7708 (ETH Logs)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "supported",
-          "Reth": "supported",
-          "Nethermind": "supported",
-          "Erigon": "supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 7778,
-        "label": "7778 (Gas Refunds)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "supported",
-          "Reth": "supported",
-          "Nethermind": "supported",
-          "Erigon": "supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 7843,
-        "label": "7843 (SLOTNUM)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "supported",
-          "Reth": "supported",
-          "Nethermind": "supported",
-          "Erigon": "supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 7928,
-        "label": "7928 (BAL)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "supported",
-          "Reth": "supported",
-          "Nethermind": "supported",
-          "Erigon": "supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 7954,
-        "label": "7954 (MContract)",
-        "support": {
-          "Geth": "not_supported",
-          "Besu": "not_supported",
-          "Reth": "not_supported",
-          "Nethermind": "not_supported",
-          "Erigon": "not_supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 7975,
-        "label": "7975 (eth/70)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "in_progress",
-          "Reth": "not_supported",
-          "Nethermind": "supported",
-          "Erigon": "not_supported",
-          "Nimbus-EL": "not_supported",
-          "Ethrex": "not_supported"
-        }
-      },
-      {
-        "eipNumber": 8024,
-        "label": "8024 (SWAPN/DUPN)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "supported",
-          "Reth": "supported",
-          "Nethermind": "supported",
-          "Erigon": "supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 8037,
-        "label": "8037 (stateIncr)",
-        "support": {
-          "Geth": "supported",
-          "Besu": "not_supported",
-          "Reth": "not_supported",
-          "Nethermind": "not_supported",
-          "Erigon": "not_supported",
-          "Nimbus-EL": "supported",
-          "Ethrex": "supported"
-        }
-      },
-      {
-        "eipNumber": 8159,
-        "label": "8159 (eth/71)",
-        "support": {
-          "Geth": "not_supported",
-          "Besu": "not_supported",
-          "Reth": "not_supported",
-          "Nethermind": "not_supported",
-          "Erigon": "not_supported",
-          "Nimbus-EL": "not_supported",
-          "Ethrex": "not_supported"
-        }
-      },
-      {
-        "eipNumber": 7732,
-        "label": "7732 ePBS",
-        "support": {
-          "Geth": "not_supported",
-          "Besu": "not_supported",
-          "Reth": "not_supported",
-          "Nethermind": "not_supported",
-          "Erigon": "not_supported",
-          "Nimbus-EL": "not_supported",
-          "Ethrex": "not_supported"
-        }
-      }
-    ]
+    "clients": [],
+    "matrix": []
   },
   "clClientSupport": {
-    "clients": [
-      "Lodestar",
-      "Lighthouse",
-      "Prysm"
-    ],
-    "matrix": [
-      {
-        "eipNumber": 7928,
-        "label": "EIP-7928",
-        "support": {
-          "Lodestar": "glamsterdam-devnet-0",
-          "Lighthouse": "unknown",
-          "Prysm": "unknown"
-        }
-      }
-    ]
+    "clients": [],
+    "matrix": []
   },
   "specReferences": {
     "consensusSpecs": {
@@ -245,6 +90,5 @@
       "version": "bal@v5.6.1",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
-  },
-  "sameSpecAs": "glamsterdam-devnet-0"
+  }
 }

--- a/src/data/devnets/glamsterdam-devnet-2.json
+++ b/src/data/devnets/glamsterdam-devnet-2.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-2",
   "title": "glamsterdam-devnet-2",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-2",
-  "scrapedAt": "2026-05-11T18:46:20.023Z",
+  "scrapedAt": "2026-05-11T18:37:21.042Z",
   "announcements": [
     "glamsterdam-devnet-2 targets to launch on the 30th of April 2026."
   ],

--- a/src/data/devnets/glamsterdam-devnet-2.json
+++ b/src/data/devnets/glamsterdam-devnet-2.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-2",
   "title": "glamsterdam-devnet-2",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-2",
-  "scrapedAt": "2026-05-11T18:37:21.042Z",
+  "scrapedAt": "2026-05-11T18:52:30.007Z",
   "announcements": [
     "glamsterdam-devnet-2 targets to launch on the 30th of April 2026."
   ],

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -2,10 +2,8 @@
   "id": "glamsterdam-devnet-3",
   "title": "glamsterdam-devnet-3",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3",
-  "scrapedAt": "2026-05-11T18:26:13.216Z",
-  "announcements": [
-    "glamsterdam-devnet-2 targets to launch on the 30th of April 2026."
-  ],
+  "scrapedAt": "2026-05-11T18:37:14.945Z",
+  "announcements": [],
   "eips": [
     {
       "number": 7708,
@@ -98,5 +96,6 @@
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
   },
-  "sameSpecAs": "glamsterdam-devnet-2"
+  "sameSpecAs": "glamsterdam-devnet-2",
+  "genesisTime": 1778082084
 }

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -1,0 +1,102 @@
+{
+  "id": "glamsterdam-devnet-3",
+  "title": "glamsterdam-devnet-3",
+  "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3",
+  "scrapedAt": "2026-05-11T18:26:13.216Z",
+  "announcements": [
+    "glamsterdam-devnet-2 targets to launch on the 30th of April 2026."
+  ],
+  "eips": [
+    {
+      "number": 7708,
+      "title": "ETH transfers emit a log",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7708"
+    },
+    {
+      "number": 7732,
+      "title": "Enshrined Proposer-Builder Separation",
+      "status": "updated",
+      "url": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7732.md"
+    },
+    {
+      "number": 7778,
+      "title": "Block Gas Accounting without Refunds",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7778"
+    },
+    {
+      "number": 7843,
+      "title": "SLOTNUM opcode",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7843"
+    },
+    {
+      "number": 7928,
+      "title": "Block-Level Access Lists",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-7928"
+    },
+    {
+      "number": 7954,
+      "title": "Increase Maximum Contract Size",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7954"
+    },
+    {
+      "number": 7975,
+      "title": "eth/70 - partial block receipt lists",
+      "status": "optional",
+      "url": "https://eips.ethereum.org/EIPS/eip-7975"
+    },
+    {
+      "number": 7976,
+      "title": "Increase Calldata Floor Cost (64/64)",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7976"
+    },
+    {
+      "number": 7981,
+      "title": "Increase Access List Cost",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7981"
+    },
+    {
+      "number": 8024,
+      "title": "Backward compatible SWAPN, DUPN, EXCHANGE",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-8024"
+    },
+    {
+      "number": 8061,
+      "title": "Increase exit and consolidation churn",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-8061"
+    },
+    {
+      "number": 8159,
+      "title": "eth/71 - Block Access List Exchange",
+      "status": "optional",
+      "url": "https://eips.ethereum.org/EIPS/eip-8159"
+    }
+  ],
+  "elClientSupport": {
+    "clients": [],
+    "matrix": []
+  },
+  "clClientSupport": {
+    "clients": [],
+    "matrix": []
+  },
+  "specReferences": {
+    "consensusSpecs": {
+      "version": "v1.7.0-alpha.7",
+      "url": "https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.7"
+    },
+    "executionSpecs": {
+      "version": "bal@v5.6.1",
+      "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
+    }
+  },
+  "sameSpecAs": "glamsterdam-devnet-2"
+}

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-3",
   "title": "glamsterdam-devnet-3",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3",
-  "scrapedAt": "2026-05-11T18:37:14.945Z",
+  "scrapedAt": "2026-05-11T18:59:56.849Z",
   "announcements": [],
   "eips": [
     {

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -2,7 +2,8 @@
   "id": "glamsterdam-devnet-3",
   "title": "glamsterdam-devnet-3",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3",
-  "scrapedAt": "2026-05-11T18:59:56.849Z",
+  "scrapedAt": "2026-05-11T19:59:21.496Z",
+  "sameSpecAs": "glamsterdam-devnet-2",
   "announcements": [],
   "eips": [
     {
@@ -96,6 +97,5 @@
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
   },
-  "sameSpecAs": "glamsterdam-devnet-2",
   "genesisTime": 1778082084
 }

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -34,6 +34,8 @@ export interface DevnetSpec {
   title: string;
   sourceUrl: string;
   scrapedAt: string;
+  /** When set, this devnet reuses the spec of another devnet (by ID). */
+  sameSpecAs?: string;
   announcements: string[];
   eips: DevnetSpecEip[];
   elClientSupport: ClientSupportMatrix;

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -36,6 +36,8 @@ export interface DevnetSpec {
   scrapedAt: string;
   /** When set, this devnet reuses the spec of another devnet (by ID). */
   sameSpecAs?: string;
+  /** Unix timestamp (seconds) of the devnet genesis, from cartographoor. */
+  genesisTime?: number;
   announcements: string[];
   eips: DevnetSpecEip[];
   elClientSupport: ClientSupportMatrix;


### PR DESCRIPTION
on devnets pages:
- spec page is sometimes skipped when duplicate of previous in series ([example](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3)). scrape script accounts for this with a simple text pattern match.
- notes specify a target date, but arent updated with the actual launch timestamp. script now grabs that from cartographoor when live (not available for devnets already shut down).
- script now probes to see if next iteration in a series exists, so it can add new devnets in existing series automatically. naturally, this does not apply to new series, because the devnet name cannot be known in advance in an automated fashion.