### PR TITLE
upgrade: fix tooltip stack bug

### DIFF
--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 interface TooltipProps {
   children: React.ReactNode;
@@ -59,13 +60,14 @@ export const Tooltip: React.FC<TooltipProps> = ({
       onMouseLeave={() => setIsVisible(false)}
     >
       {children}
-      {isVisible && (
+      {isVisible && createPortal(
         <span
-          className="bg-white dark:bg-slate-800 border-2 border-purple-300 dark:border-purple-600 text-slate-900 dark:text-slate-100 text-xs px-3 py-1.5 rounded-lg whitespace-nowrap z-[9999] shadow-xl block"
+          className="bg-white dark:bg-slate-800 border-2 border-purple-300 dark:border-purple-600 text-slate-900 dark:text-slate-100 text-xs px-3 py-1.5 rounded-lg whitespace-nowrap z-[9999] shadow-xl block pointer-events-none"
           style={getTooltipStyle()}
         >
           {content || text}
-        </span>
+        </span>,
+        document.body
       )}
     </span>
   );


### PR DESCRIPTION
fix for upgrade page TOC tooltips rendering under other components:

<img width="711" height="160" alt="Screenshot 2026-05-12 at 11 33 14 AM" src="https://github.com/user-attachments/assets/b33e106b-f355-43e7-a280-3104fa32c83d" />
