### PR TITLE
harden: set ignore-scripts=true in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 min-release-age=7
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- Blocks dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) from running on `npm install`, a small supply-chain hardening step.
- Verified the three packages with build scripts (`esbuild`, `pre-commit`, `spawn-sync`) don't need them for this project: build passes, and the local `.git/hooks/pre-commit` is already in place.
- Caveat: on a fresh clone, `npm install` will no longer auto-install the format-on-commit git hook. Run `node node_modules/pre-commit/install.js` once if you want it. CI / `npm run format:check` still enforces formatting.

## Test plan
- [x] `npm install` completes without running dep scripts
- [x] `npm run build` succeeds
- [x] Confirm CI green