### PR TITLE
upcoming calls: add missing series mappings

### DIFF
--- a/docs/acdbot-forkcast-asset-pipeline.md
+++ b/docs/acdbot-forkcast-asset-pipeline.md
@@ -175,9 +175,9 @@ Use the table below as a checklist. Every new series requires all of these chang
 |---|------|-----------|
 | 1 | `src/data/calls.ts` | Add the short code to the `CallType` union and add a `name: 'Display Name'` entry to `callTypeNames`. If the series has an associated EIP, add it to `eipCallTypes`. |
 | 2 | `scripts/sync-call-assets.mjs` | Add the short code to `KNOWN_TYPES`. If the PM series name differs from the short code (it usually does for breakouts), add a mapping in `SERIES_TO_TYPE`. |
-| 3 | `src/components/CallsIndexPage.tsx` | Add the short code with a color to all four color maps: `upcomingCallTypeColors`, `upcomingCallTypeBadgeColors`, `callTypeColors`, `callTypeBadgeColors`. |
+| 3 | `src/components/calls-index/CallsIndexTimeline.tsx` | Add the short code with a color to both maps: `CALL_TYPE_BORDER_COLORS`, `CALL_TYPE_BADGE_COLORS`. |
 | 4 | `src/components/HomePage.tsx` | Add the short code to the `callTypeBadgeColors` map. |
-| 5 | `src/utils/github.ts` | Add the short code to the `UpcomingCall.type` union. Add a regex matcher in `parseCallFromTitle` for the GitHub issue title format. Increment the `foundTypes.size` limit. |
+| 5 | `src/domain/calls/upcomingCalls.ts` | Add an entry to `UPCOMING_CALL_SERIES_TO_TYPE`, keyed by the lowercased `### Call Series` value (e.g. `'encrypt the mempool'`). |
 
 ### Naming conventions
 
@@ -188,7 +188,7 @@ Use the table below as a checklist. Every new series requires all of these chang
 
 ### Verifying
 
-After making all changes, run `npx tsc --noEmit` — the `Record<CallType, string>` types will catch any maps you missed. Then run the sync script to confirm the new series is recognized:
+After making all changes, run `npx tsc --noEmit` — the `Record<CallType, string>` types will catch any maps you missed. `SERIES_TO_TYPE` and `UPCOMING_CALL_SERIES_TO_TYPE` are not type-enforced; verify those by hand. Then run the sync script to confirm the new series is recognized:
 
 ```sh
 node scripts/sync-call-assets.mjs

--- a/src/domain/calls/upcomingCalls.ts
+++ b/src/domain/calls/upcomingCalls.ts
@@ -40,6 +40,12 @@ const UPCOMING_CALL_SERIES_TO_TYPE: Record<string, CallType> = {
   'rpc standards': 'rpc',
   'focil breakout': 'focil',
   'eip-7928 breakout room': 'bal',
+  'eip-7732 breakout room': 'epbs',
+  'glamsterdam repricings': 'price',
+  'trustless log index': 'tli',
+  'encrypt the mempool': 'etm',
+  'native account abstraction': 'aa',
+  'p2p networking': 'p2p',
 };
 
 // Fetch YouTube URL from issue comments


### PR DESCRIPTION
## Summary

Six series present in `CallType` (`epbs`, `price`, `tli`, `etm`, `aa`, `p2p`) were missing from `UPCOMING_CALL_SERIES_TO_TYPE` in `src/domain/calls/upcomingCalls.ts`. As a result, `resolveUpcomingCallType` returned `undefined` for issues from those series and they were silently filtered out of the upcoming-calls list — even though their assets sync correctly once a video and transcript are produced.

Concretely: Glamsterdam Repricings 7 wasn't appearing on the calls index despite being on the protocol calendar.

Also fixed three stale references in `docs/acdbot-forkcast-asset-pipeline.md`:
- Item 3 — color maps moved from `CallsIndexPage.tsx` (4 maps) to `calls-index/CallsIndexTimeline.tsx` (2 maps).
- Item 5 — file renamed from `src/utils/github.ts` to `src/domain/calls/upcomingCalls.ts`; the `foundTypes.size` limit no longer exists; primary mechanism is now `UPCOMING_CALL_SERIES_TO_TYPE`.
- Verifying section — called out which maps are type-enforced vs. need manual verification.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test -- --run upcomingCalls` — 33/33 pass
- [x] Confirm Glamsterdam Repricings 7 appears on the upcoming calls index after deploy