### PR TITLE
sync: set video/transcript offsets for ZKEVM 004

### DIFF
--- a/public/artifacts/zkevm/2026-05-13_004/config.json
+++ b/public/artifacts/zkevm/2026-05-13_004/config.json
@@ -2,7 +2,7 @@
   "issue": 2047,
   "videoUrl": "https://www.youtube.com/watch?v=whI_KURDylw",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:07:22",
+    "videoStartTime": "00:07:22"
   }
 }

--- a/public/artifacts/zkevm/2026-05-13_004/tldr.json
+++ b/public/artifacts/zkevm/2026-05-13_004/tldr.json
@@ -8,7 +8,7 @@
       },
       {
         "timestamp": "00:11:33",
-        "highlight": "Optional proof spec still based on Gossip; plan to migrate to Gloas soon"
+        "highlight": "Optional proof spec still based on Fulu; plan to migrate to Gloas soon"
       },
       {
         "timestamp": "00:11:46",
@@ -105,14 +105,6 @@
     {
       "timestamp": "00:17:21",
       "decision": "Validator proof re-signing proposal deprecated; peer scoring is sufficient for DOS prevention"
-    },
-    {
-      "timestamp": "00:39:29",
-      "decision": "Misaligned jump standard: must cause abnormal termination \u2014 no recovery, no address rounding permitted"
-    },
-    {
-      "timestamp": "00:41:10",
-      "decision": "U256 acceleration interface not yet standardized; further investigation needed on addition/subtraction and bitwise acceleration"
     }
   ],
   "targets": [


### PR DESCRIPTION
## Summary
- Set video/transcript start offsets for ZKEVM 004 to `00:07:22`

## Test plan
- [x] Confirmed sync looks correct on the call page