### PR TITLE
eip-8025: proposed for Hegota at ACDC 178

### DIFF
--- a/src/data/eips/8025.json
+++ b/src/data/eips/8025.json
@@ -8,6 +8,35 @@
   "category": "Core",
   "createdDate": "2025-09-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-optional-execution-proofs/25500",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acdc/178",
+          "date": "2026-05-14",
+          "timestamp": 4125
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acdc/178",
+          "date": "2026-05-14",
+          "timestamp": 4125
+        }
+      ],
+      "champions": [
+        {
+          "name": "Francesco Risitano"
+        },
+        {
+          "name": "Ignacio Hagopian",
+          "discord": "jsign"
+        }
+      ]
+    }
+  ],
   "tradeoffs": null
 }


### PR DESCRIPTION
## Summary
- Add Hegota fork relationship for EIP-8025 (Optional Execution Proofs)
- `statusHistory`: Proposed (acdc/178, 2026-05-14)
- `presentationHistory`: presentation entry pointing at the ACDC 178 video at ~01:08:45 (4125s)
- Champions: Francesco Risitano (EF zkEVM) and Ignacio Hagopian (`@jsign`, EF zkEVM)

## Context
Francesco Risitano and Ignacio Hagopian presented EIP-8025 during ACDC 178 (2026-05-14) and proposed it for inclusion in Hegota. EIP is opt-in only (no consensus gating), with Lighthouse and Prysm implementations.

Slides: https://frisitano.github.io/slides/presentations/eip8025-acdc-proposal-2026-05-14/index.html
EIP PR (updated): https://github.com/ethereum/EIPs/pull/11604

## Test plan
- [x] tsc clean
- [x] compile-eips.mjs regenerates eips.json without errors
- [ ] Spot-check EIP-8025 page on local dev server