### PR TITLE
sync: set video/transcript offsets for ACDT 80 and RPC 26

### DIFF
--- a/public/artifacts/acdt/2026-05-18_080/config.json
+++ b/public/artifacts/acdt/2026-05-18_080/config.json
@@ -2,7 +2,7 @@
   "issue": 2049,
   "videoUrl": "https://youtube.com/watch?v=AHm0HzNRjUQ",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:08:00",
+    "videoStartTime": "00:04:01"
   }
 }

--- a/public/artifacts/rpc/2026-05-18_026/config.json
+++ b/public/artifacts/rpc/2026-05-18_026/config.json
@@ -2,7 +2,7 @@
   "issue": 2056,
   "videoUrl": "https://www.youtube.com/watch?v=GyAuXsk1ds0",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:02:45",
+    "videoStartTime": "00:02:45"
   }
 }


### PR DESCRIPTION
## Summary
- ACDT 80: livestreamed call, set video offset `00:04:01` and transcript offset `00:08:00`
- RPC 26: non-livestreamed call, set both offsets to `00:02:45` to skip dead air

## Test plan
- [x] Verified sync on local dev server for both calls