### PR TITLE
eip: display spec change history

### DIFF
--- a/.github/workflows/fetch-eips.yml
+++ b/.github/workflows/fetch-eips.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Fetch EIPs
         run: node scripts/fetch-all-eips.mjs
 
+      - name: Fetch EIP spec history
+        run: node scripts/fetch-eip-history.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check for changes
         id: changes
         run: |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check-reviewers": "node scripts/eips-by-reviewer.mjs",
     "validate-eips": "node scripts/validate-eip-metadata.mjs",
     "fetch-eips": "node scripts/fetch-all-eips.mjs",
+    "fetch-eip-history": "node scripts/fetch-eip-history.mjs",
     "generate-configs": "node scripts/generate-configs.cjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/public/eips/history/7610.json
+++ b/public/eips/history/7610.json
@@ -1,0 +1,53 @@
+{
+  "eipId": 7610,
+  "commits": [
+    {
+      "sha": "7707fe333322ed68d1b5efa50bdb4f35909255a7",
+      "date": "2025-11-06T01:04:36Z",
+      "message": "Update EIP-7610: Clarify the relationship between the EIP-7610 and EIP-7702",
+      "author": "rjl493456442",
+      "prNumber": null,
+      "patch": "@@ -23,12 +23,12 @@ If a contract creation is attempted due to a creation transaction, the `CREATE`\n \n This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empty storage for contract deployment.\n \n+This EIP will not affect [EIP-7702](./eip-7702.md), since the authority's nonce is always incremented after an authorization is applied, which conflicts with the condition required for contract deployment.\n+\n ## Rationale\n \n EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-161](./eip-161.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.\n \n-As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instance.\n-\n ## Backwards Compatibility\n \n This is an execution layer upgrade, and so it requires a hard fork."
+    },
+    {
+      "sha": "fa587161f3f3b8ade481c5fc6478ad25c3518a90",
+      "date": "2025-09-29T00:06:02Z",
+      "message": "Update EIP-7610: fixed typos in EIPS/eip-7610.md",
+      "author": "CreeptoGengar",
+      "prNumber": null,
+      "patch": "@@ -27,7 +27,7 @@ This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empt\n \n EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-161](./eip-161.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.\n \n-As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instanace.\n+As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instance.\n \n ## Backwards Compatibility\n \n@@ -41,7 +41,7 @@ Refilling the existing tests will provide sufficient coverage for this EIP.\n \n ## Security Considerations\n \n-This EIP is a security upgrade: it enforces the imutability of deployed code.\n+This EIP is a security upgrade: it enforces the immutability of deployed code.\n \n ## Copyright\n "
+    },
+    {
+      "sha": "fd89c8f734f4ddd6abee784cf91cf8e38e117d75",
+      "date": "2024-11-07T08:14:40Z",
+      "message": "Update EIP-7610: Move to Last Call",
+      "author": "timbeiko",
+      "prNumber": null,
+      "patch": "@@ -4,7 +4,8 @@ title: Revert creation in case of non-empty storage\n description: Revert contract creation if address already has the non-empty storage\n author: Gary Rong (@rjl493456442), Martin Holst Swende (@holiman)\n discussions-to: https://ethereum-magicians.org/t/eip-revert-creation-in-case-of-non-empty-storage/18452\n-status: Review\n+status: Last Call\n+last-call-deadline: 2024-11-20\n type: Standards Track\n category: Core\n created: 2024-02-02"
+    },
+    {
+      "sha": "df5ce1cbddcb06a59e8a6f873204beb0c40a6b24",
+      "date": "2024-07-23T14:21:45Z",
+      "message": "Update EIP-7610: Move to Review",
+      "author": "timbeiko",
+      "prNumber": null,
+      "patch": "@@ -4,7 +4,7 @@ title: Revert creation in case of non-empty storage\n description: Revert contract creation if address already has the non-empty storage\n author: Gary Rong (@rjl493456442), Martin Holst Swende (@holiman)\n discussions-to: https://ethereum-magicians.org/t/eip-revert-creation-in-case-of-non-empty-storage/18452\n-status: Draft\n+status: Review\n type: Standards Track\n category: Core\n created: 2024-02-02"
+    },
+    {
+      "sha": "dc288af4e30e2244ce1a92aad89b25531a885123",
+      "date": "2024-07-19T11:38:04Z",
+      "message": "Update EIP-7610: Point to correct EIP-161",
+      "author": "jochem-brouwer",
+      "prNumber": null,
+      "patch": "@@ -24,7 +24,7 @@ This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empt\n \n ## Rationale\n \n-EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-158](./eip-158.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.\n+EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-161](./eip-161.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.\n \n As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instanace.\n "
+    },
+    {
+      "sha": "d21656a0f46b33323e0784785cf5439677a84f3b",
+      "date": "2024-04-08T17:21:03Z",
+      "message": "Add EIP: Revert creation in case of non-empty storage",
+      "author": "rjl493456442",
+      "prNumber": null,
+      "patch": "@@ -0,0 +1,47 @@\n+---\n+eip: 7610\n+title: Revert creation in case of non-empty storage\n+description: Revert contract creation if address already has the non-empty storage\n+author: Gary Rong (@rjl493456442), Martin Holst Swende (@holiman)\n+discussions-to: https://ethereum-magicians.org/t/eip-revert-creation-in-case-of-non-empty-storage/18452\n+status: Draft\n+type: Standards Track\n+category: Core\n+created: 2024-02-02\n+---\n+\n+## Abstract\n+\n+This EIP causes contract creation to throw an error when attempted at an address with pre-existing storage.\n+\n+## Specification\n+\n+The key words \"MUST\", \"MUST NOT\", \"REQUIRED\", \"SHALL\", \"SHALL NOT\", \"SHOULD\", \"SHOULD NOT\", \"RECOMMENDED\", \"NOT RECOMMENDED\", \"MAY\", and \"OPTIONAL\" in this document are to be interpreted as described in RFC 2119 and RFC 8174.\n+\n+If a contract creation is attempted due to a creation transaction, the `CREATE` opcode, the `CREATE2` opcode, or any other reason, and the destination address already has either a nonzero nonce, a nonzero code length, or non-empty storage, then the creation MUST throw as if the first byte in the init code were an invalid opcode. This change MUST apply retroactively for all existing blocks.\n+\n+This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empty storage for contract deployment.\n+\n+## Rationale\n+\n+EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-158](./eip-158.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.\n+\n+As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instanace.\n+\n+## Backwards Compatibility\n+\n+This is an execution layer upgrade, and so it requires a hard fork.\n+\n+## Test Cases\n+\n+There exists quite a number of tests in the ethereum tests repo as well as in the execution spec tests, which test the scenario of deployment to targets with non-empty storage. These tests have been considered problematic in the past; Reth and EELS both intentionally implement a version of the account reset solely to pass the tests. Py-evm declared the situation impossible and never implemented account reset.\n+\n+Refilling the existing tests will provide sufficient coverage for this EIP.\n+\n+## Security Considerations\n+\n+This EIP is a security upgrade: it enforces the imutability of deployed code.\n+\n+## Copyright\n+\n+Copyright and related rights waived via [CC0](../LICENSE.md)."
+    }
+  ]
+}

--- a/public/eips/history/7688.json
+++ b/public/eips/history/7688.json
@@ -1,0 +1,216 @@
+{
+  "eipId": 7688,
+  "commits": [
+    {
+      "sha": "f2e6d7fb01194d590e16fcdcae8061d06cf1a7f1",
+      "date": "2026-05-19T16:56:56Z",
+      "message": "Update EIP-7688: Rebase requirements to be based on Fusaka",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -8,7 +8,7 @@ status: Review\n type: Standards Track\n category: Core\n created: 2024-04-15\n-requires: 6110, 7002, 7251, 7495, 7549, 7569, 7916\n+requires: 7495, 7607, 7916\n ---\n \n ## Abstract"
+    },
+    {
+      "sha": "aea03b391168915770667f3564c445e7de589a17",
+      "date": "2026-05-19T16:11:43Z",
+      "message": "Update EIP-7688: Improve wording / address nits",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "19f03bc45b9fa63fe434f9ad7fdc2b82f174cc2f",
+      "date": "2026-05-19T14:57:40Z",
+      "message": "Update EIP-7688: Resolve the 'cleanup opportunities' section",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "9eb1fadbc0941fbc877294c5d647c30fb42c5bfb",
+      "date": "2026-05-19T13:55:59Z",
+      "message": "Update EIP-7688: Add rationale for Validator remaining Container",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "5f4a908c019f83e5d8dc00abccba37c312fca02f",
+      "date": "2026-05-18T19:53:51Z",
+      "message": "Update EIP-7688: Suggest constants for network message size bounds",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "d2fb2b2e6104e7484f552bf142c500a9d2a6ef4e",
+      "date": "2026-05-05T20:31:25Z",
+      "message": "Update EIP-7688: Make Transaction progressive",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -72,7 +72,9 @@ The following types SHALL be converted to `ProgressiveContainer`:\n   - The `attesting_indices` field is redefined to use `ProgressiveList`\n - [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/beacon-chain.md#executionpayload)\n   - The `transactions` and `withdrawals` fields are redefined to use `ProgressiveList`\n-  - The `MAX_TRANSACTIONS_PER_PAYLOAD` (1M) limit is no longer enforced (the limit is unreachable with `MAX_PAYLOAD_SIZE` 10 MB)\n+  - The `MAX_TRANSACTIONS_PER_PAYLOAD` (1M) limit is no longer enforced\n+- [`Transaction`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#custom-types) is redefined as `ProgressiveByteList`\n+  - The `MAX_BYTES_PER_TRANSACTION` (1 GB) limit is no longer enforced\n - [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#executionrequests)\n   - The `deposits`, `withdrawals` and `consolidations` fields are redefined to use `ProgressiveList`\n - [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconblockbody)\n@@ -111,7 +113,6 @@ These types are used as part of the `ProgressiveContainer` definitions, and, as\n | [`SignedVoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/phase0/beacon-chain.md#signedvoluntaryexit) | Tuple of voluntary exit request and its signature |\n | [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/altair/beacon-chain.md#syncaggregate) | Cryptographic type representing an aggregate sync committee signature |\n | [`ExecutionAddress`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#custom-types) | Byte vector containing an account address on the execution layer |\n-| [`Transaction`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#custom-types) | Byte list containing an RLP encoded transaction |\n | [`WithdrawalIndex`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/capella/beacon-chain.md#custom-types) | Unique index of a withdrawal from any validator's balance to the execution layer |\n | [`Withdrawal`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/capella/beacon-chain.md#withdrawal) | Withdrawal from a beacon chain validator's balance to the execution layer |\n | [`DepositRequest`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#depositrequest) | Tuple of flattened deposit data and its sequential index |"
+    },
+    {
+      "sha": "53a85823f374965161ab1b711a0ee3084db8d6c0",
+      "date": "2025-12-30T09:24:03Z",
+      "message": "Update EIP-7688: Fix field naming and wording",
+      "author": "showmespinet",
+      "prNumber": null,
+      "patch": "@@ -74,7 +74,7 @@ The following types SHALL be converted to `ProgressiveContainer`:\n   - The `transactions` and `withdrawals` fields are redefined to use `ProgressiveList`\n   - The `MAX_TRANSACTIONS_PER_PAYLOAD` (1M) limit is no longer enforced (the limit is unreachable with `MAX_PAYLOAD_SIZE` 10 MB)\n - [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#executionrequests)\n-  - The `deposits`, `withdrawals` and `consolidation` fields are redefined to use `ProgressiveList`\n+  - The `deposits`, `withdrawals` and `consolidations` fields are redefined to use `ProgressiveList`\n - [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconblockbody)\n   - The `proposer_slashings`, `attester_slashings`, `attestations`, `deposits`, `voluntary_exits` and `bls_to_execution_changes` fields are redefined to use `ProgressiveList`\n - [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconstate)\n@@ -184,7 +184,7 @@ For other requests (withdrawal / consolidation requests), a shared total limit b\n \n #### `BeaconBlockHeader`\n \n-The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as is breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks.\n+The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as it breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks.\n \n #### `Validator`\n "
+    },
+    {
+      "sha": "95a263d15ccbbad813fd002666d7c753a126280c",
+      "date": "2025-12-02T16:31:52Z",
+      "message": "Update EIP-7688: Move to Review",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -4,7 +4,7 @@ title: Forward compatible consensus data structures\n description: Transition consensus SSZ data structures to ProgressiveContainer\n author: Etan Kissling (@etan-status), Cayman (@wemeetagain)\n discussions-to: https://ethereum-magicians.org/t/eip-7688-forward-compatible-consensus-data-structures/19673\n-status: Draft\n+status: Review\n type: Standards Track\n category: Core\n created: 2024-04-15"
+    },
+    {
+      "sha": "92a822fba7d243a8ee6038b80bfb45e59dd3b4f7",
+      "date": "2025-11-05T13:01:55Z",
+      "message": "Update EIP-7688: Correct ProgressiveContainer reference",
+      "author": "parraddise",
+      "prNumber": null,
+      "patch": "@@ -133,7 +133,7 @@ Applying this EIP breaks `hash_tree_root` and Merkle tree verifiers a single tim\n \n ### Can this be applied retroactively?\n \n-While `Profile` serializes in the same way as the legacy `Container`, the merkleization and `hash_tree_root` of affected data structures changes. Therefore, verifiers that wish to process Merkle proofs of legacy variants still need to support the corresponding legacy schemes.\n+While `ProgressiveContainer` serializes in the same way as the legacy `Container`, the merkleization and `hash_tree_root` of affected data structures changes. Therefore, verifiers that wish to process Merkle proofs of legacy variants still need to support the corresponding legacy schemes.\n \n ### Immutability\n "
+    },
+    {
+      "sha": "cfb56cc2fef7d780f89c1f3890d64425f684ea2a",
+      "date": "2025-10-12T09:12:54Z",
+      "message": "Update EIP-7688: Update eip-7688.md",
+      "author": "pendrue",
+      "prNumber": null,
+      "patch": "@@ -188,7 +188,7 @@ The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `Be\n \n #### `Validator`\n \n-The `Validator` container is currently proposed to be kept as is. Updating the `Validator` to `ProgressiveContainer` would add an extra hash for each validator; validators are mostly immutable so rarely need to be re-hashed. With a conversion, implementations may have to incrementally construct the new `Validator` entries ahead of the fork when validator counts are high. It should be evaluated whether the hashing overhead is worth a clean transition to future fields, e.g., for holding postquantum keys. Also consider that that such a transition may also involve a new hash function, which is a breaking change to the Merkle proofs, so generalized indices do not have to be stable across that transition.\n+The `Validator` container is currently proposed to be kept as is. Updating the `Validator` to `ProgressiveContainer` would add an extra hash for each validator; validators are mostly immutable so rarely need to be re-hashed. With a conversion, implementations may have to incrementally construct the new `Validator` entries ahead of the fork when validator counts are high. It should be evaluated whether the hashing overhead is worth a clean transition to future fields, e.g., for holding postquantum keys. Also consider that such a transition may also involve a new hash function, which is a breaking change to the Merkle proofs, so generalized indices do not have to be stable across that transition.\n \n ## Backwards Compatibility\n "
+    },
+    {
+      "sha": "148db0a7caa981448e1cc7b0cbbded60fa8ea92a",
+      "date": "2025-10-02T02:26:15Z",
+      "message": "Update EIP-7688: Refer to correct EIP for 6110 refs",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -152,7 +152,7 @@ With `ProgressiveContainer`, stable Merkleization requires these rules to become\n \n #### `BeaconState`\n \n-- The `eth1_data`, `eth1_data_votes`, `eth1_deposit_index` and `deposit_requests_start_index` fields could be dropped as they are no longer needed post Fulu.\n+- The `eth1_data`, `eth1_data_votes`, `eth1_deposit_index` and `deposit_requests_start_index` fields could be dropped as they are no longer needed after the [EIP-6110](./eip-6110.md#eth1data-poll-deprecation) transition period finishes.\n - `historical_summaries` could be redefined to use `ProgressiveList` and also integrate the historical `historical_roots` data by merging in full `HistoricalSummary` data from an archive (`historical_root` is frozen since Capella), simplifying access to historical block and state roots.\n \n #### `Attestation`"
+    },
+    {
+      "sha": "f84409415728844ea0057f559cb03b11dc196132",
+      "date": "2025-10-01T23:02:39Z",
+      "message": "Update EIP-7688: Add security considerations and add blob lists",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -76,9 +76,10 @@ The following types SHALL be converted to `ProgressiveContainer`:\n - [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#executionrequests)\n   - The `deposits`, `withdrawals` and `consolidation` fields are redefined to use `ProgressiveList`\n - [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconblockbody)\n-  - The `proposer_slashings`, `attester_slashings`, `attestations`, `deposits`, `voluntary_exits`, `bls_to_execution_changes` and `blob_kzg_commitments` fields are redefined to use `ProgressiveList`\n+  - The `proposer_slashings`, `attester_slashings`, `attestations`, `deposits`, `voluntary_exits` and `bls_to_execution_changes` fields are redefined to use `ProgressiveList`\n - [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconstate)\n   - The `validators`, `balances`, `previous_epoch_participation`, `current_epoch_participation`, `inactivity_scores`, `pending_deposits`, `pending_partial_withdrawals` and `pending_consolidations` fields are redefined to use `ProgressiveList`\n+- The `blob_kzg_commitments`, `kzg_proofs` and `column` fields are redefined to use `ProgressiveList`\n \n ### Immutable types\n \n@@ -195,7 +196,11 @@ Existing Merkle proof verifiers need to be updated to support the new Merkle tre\n \n ## Security Considerations\n \n-None\n+Before this EIP, all `List` types had a fixed upper bound, enabling implementations to reject messages exceeding that size early. With `ProgressiveList`, that is no longer possible, as there is no more maximum message size. Instead, the length checks have to be implemented as part of P2P gossip validation, and as part of the state transition logic. However, many of the limits are not practically reachable (e.g., the gas limit is reached before the maximum payload size). Further note that SSZ is simple enough that clever implementations could still enforce those length checks on the serialized data, before fully decoding it.\n+\n+All data inbound via libp2p is decrypted, then uncompressed with Snappy, then hashed with `MESSAGE_DOMAIN_VALID_SNAPPY` / `MESSAGE_DOMAIN_INVALID_SNAPPY` prefix depending on whether the decompression worked to compute the libp2p message ID, while honoring a global `MAX_PAYLOAD_SIZE` message size limit. This has to be done even if the underlying SSZ data ends up being invalid.\n+\n+As SSZ does not use variable-length encoding, it does not have uncontrolled blowup (no 1 byte becomes 100 MB). Therefore, attempting to decode a `MAX_PAYLOAD_SIZE` message before checking dynamic `List` limits does not decrease security. Any intentional DoS attacks can already target a heavier portion of the processing pipeline (e.g., by sending invalid BLS signatures, or by sending invalid Snappy data that still needs to be hashed to compute the message ID). Therefore, the EIP does not notably impact security.\n \n ## Copyright\n "
+    },
+    {
+      "sha": "360ef59657a062a8f09b42a61b753506c4f49634",
+      "date": "2025-09-26T09:21:06Z",
+      "message": "Update EIP-7688: Add notes for ExecutionPayload and ExecutionRequests",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "d0de8bd93595b247e6841e3161cbc2918403c2e1",
+      "date": "2025-09-19T09:14:43Z",
+      "message": "Update EIP-7688: Add IndexedAttestation as cleanup opportunity",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -158,6 +158,19 @@ With `ProgressiveContainer`, stable Merkleization requires these rules to become\n \n - The `committee_bits` is defined as a `Bitvector`, but the top bits are forced to 0 based on `get_committee_count_per_slot(state, data.target.epoch)`. It could be re-defined as a `ProgressiveBitlist`.\n \n+#### `IndexedAttestation`\n+\n+The `attesting_indices` are limited to [`MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#indexedattestation), which is insufficient when the `IndexedAttestation` is formed from [`SingleAttestation`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#singleattestation) traffic. `SingleAttestation` allows validators that are not assigned to a slot to produce signatures that are not aggregatable into an `Attestation` (as such validators are not assigned), but that are still slashable.\n+\n+Further, [`MAX_ATTESTER_SLASHINGS_ELECTRA`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#max-operations-per-block) at 1 limits inclusion delay of slashings in non-finality scenarios with a lot of forks where slashings happen across multiple different `AttestationData` values.\n+\n+Limits could be rethought to be based on actual resource usage, e.g., by limiting:\n+\n+- The total number of `attesting_indices` across all `AttesterSlashing` (shared total)\n+- The total number of signature checks across all `AttesterSlashing`, `ProposerSlashing`, `VoluntaryExit`, and `SignedBLSToExecutionChange` messages\n+\n+Limiting totals rather than individual resource limits would allow extra attester slashings to be included at the cost of potentially delaying inclusion of a couple altruistic messages (if there even are any `VoluntaryExit` / `SignedBLSToExecutionChange` messages at that time), thus increasing security and block packing efficiency.\n+\n #### `BeaconBlockHeader`\n \n Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as is breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks."
+    },
+    {
+      "sha": "94af9bb708ca55b89ad97b1eabdccb28f568c6c7",
+      "date": "2025-09-17T13:53:22Z",
+      "message": "Update EIP-7688: Move committee_bits to cleanup opportunities",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -68,7 +68,6 @@ The following types SHALL be converted to `ProgressiveContainer`:\n \n - [`Attestation`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#attestation)\n   - The `aggregation_bits` field is redefined to use `ProgressiveBitlist`\n-  - The `committee_bits` field is redefined to use `ProgressiveBitlist`\n - [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#indexedattestation)\n   - The `attesting_indices` field is redefined to use `ProgressiveList`\n - [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/beacon-chain.md#executionpayload)\n@@ -148,18 +147,22 @@ Furthermore, new fields have to be appended at the end of `ProgressiveContainer`\n \n With `ProgressiveContainer`, stable Merkleization requires these rules to become strict.\n \n-### Cleanup opportunity\n+### Cleanup opportunities\n \n-Several fields in the `BeaconState` are no longer relevant in current specification versions.\n+#### `BeaconState`\n \n - The `eth1_data`, `eth1_data_votes`, `eth1_deposit_index` and `deposit_requests_start_index` fields could be dropped as they are no longer needed post Fulu.\n - `historical_summaries` could be redefined to use `ProgressiveList` and also integrate the historical `historical_roots` data by merging in full `HistoricalSummary` data from an archive (`historical_root` is frozen since Capella), simplifying access to historical block and state roots.\n \n-### `BeaconBlockHeader`?\n+#### `Attestation`\n+\n+- The `committee_bits` is defined as a `Bitvector`, but the top bits are forced to 0 based on `get_committee_count_per_slot(state, data.target.epoch)`. It could be re-defined as a `ProgressiveBitlist`.\n+\n+#### `BeaconBlockHeader`\n \n Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as is breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks.\n \n-### `Validator`?\n+#### `Validator`\n \n Updating the `Validator` to `ProgressiveContainer` would add an extra hash for each validator; validators are mostly immutable so rarely need rehashing. Due to the large hash count, implementations may have to incrementally construct the new `Validator` entries ahead of the fork. It should be evaluated whether the hashing overhead is worth a clean transition to future fields, e.g., for holding postquantum keys.\n "
+    },
+    {
+      "sha": "89d746cc86b8b7332050331baf91777a2fee3031",
+      "date": "2025-09-16T12:53:36Z",
+      "message": "Update EIP-7688: Also make committee bits progressive",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -68,6 +68,7 @@ The following types SHALL be converted to `ProgressiveContainer`:\n \n - [`Attestation`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#attestation)\n   - The `aggregation_bits` field is redefined to use `ProgressiveBitlist`\n+  - The `committee_bits` field is redefined to use `ProgressiveBitlist`\n - [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#indexedattestation)\n   - The `attesting_indices` field is redefined to use `ProgressiveList`\n - [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/beacon-chain.md#executionpayload)"
+    },
+    {
+      "sha": "de33cd5e3599cb09f8c8b8fcb08d80f48257cf28",
+      "date": "2025-08-04T13:38:45Z",
+      "message": "Update EIP-6404: Use correct Python syntax for active_fields",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -29,7 +29,7 @@ The key words \"MUST\", \"MUST NOT\", \"REQUIRED\", \"SHALL\", \"SHALL NOT\", \"SHOULD\", \"S\n \n ### `Container` conversion\n \n-`Container` types that are expected to evolve over forks SHALL be redefined as `ProgressiveContainer[active_fields=[1] * len(type.fields())]`.\n+`Container` types that are expected to evolve over forks SHALL be redefined as `ProgressiveContainer(active_fields=[1] * len(type.fields()))`.\n \n For example, given a type in the old fork:\n \n@@ -42,7 +42,7 @@ class Foo(Container):\n This type can be converted to support stable Merkleization in the new fork:\n \n ```python\n-class Foo(ProgressiveContainer[active_fields=[1, 1]]):\n+class Foo(ProgressiveContainer(active_fields=[1, 1])):\n     a: uint8\n     b: uint16\n ```"
+    },
+    {
+      "sha": "20674997972fceccb613a08720c5a42448d56464",
+      "date": "2025-07-01T10:14:32Z",
+      "message": "Update EIP-7688: Adopt `ProgressiveContainer` / `ProgressiveList`",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "565882cf0997844708d47752eae563f2db7f0744",
+      "date": "2025-04-15T03:32:04Z",
+      "message": "Update EIP-7495: Move to Draft",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -4,7 +4,7 @@ title: Forward compatible consensus data structures\n description: Transition consensus SSZ data structures to StableContainer\n author: Etan Kissling (@etan-status), Cayman (@wemeetagain)\n discussions-to: https://ethereum-magicians.org/t/eip-7688-forward-compatible-consensus-data-structures/19673\n-status: Review\n+status: Draft\n type: Standards Track\n category: Core\n created: 2024-04-15"
+    },
+    {
+      "sha": "167b4b57da0d050127cb93acf5858e8d3b028cc3",
+      "date": "2025-02-10T16:05:08Z",
+      "message": "Update EIP-6404: Bump links to tagged beta spec version",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "2ccac851e7c0389e393f761a5c34d9c8af15e8ff",
+      "date": "2024-10-11T11:05:15Z",
+      "message": "Update EIP-7495: Rename `PendingBalanceDeposit` > `PendingDeposit`",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "815286789ae0f715eda3df83d12c0f8141dba023",
+      "date": "2024-09-23T14:03:07Z",
+      "message": "Update EIP-7688: Adjustments for `v1.5.0-alpha.6` specs",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -97,6 +97,7 @@ These types are used as part of the `StableContainer` definitions, and, as they\n | `MAX_ATTESTATION_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `StableAttestation` can ever grow in the future |\n | `MAX_INDEXED_ATTESTATION_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `StableIndexedAttestation` can ever grow in the future |\n | `MAX_EXECUTION_PAYLOAD_FIELDS` | `uint64(2**6)` (= 64) | Maximum number of fields to which `StableExecutionPayload` can ever grow in the future |\n+| `MAX_EXECUTION_REQUESTS_FIELDS` | `uint64(2**4)` (= 16) | Maximum number of fields to which `StableExecutionRequests` can ever grow in the future |\n | `MAX_BEACON_BLOCK_BODY_FIELDS` | `uint64(2**6)` (= 64) | Maximum number of fields to which `StableBeaconBlockBody` can ever grow in the future |\n | `MAX_BEACON_STATE_FIELDS` | `uint64(2**7)` (= 128) | Maximum number of fields to which `StableBeaconState` can ever grow in the future |\n \n@@ -143,11 +144,6 @@ class StableExecutionPayload(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]):\n     withdrawals: Optional[List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]]  # [New in Capella]\n     blob_gas_used: Optional[uint64]  # [New in Deneb:EIP4844]\n     excess_blob_gas: Optional[uint64]  # [New in Deneb:EIP4844]\n-    deposit_requests: Optional[List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP6110]\n-    # [New in Electra:EIP7002:EIP7251]\n-    withdrawal_requests: Optional[List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]]\n-    # [New in Electra:EIP7251]\n-    consolidation_requests: Optional[List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]]\n \n class StableExecutionPayloadHeader(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]):\n     parent_hash: Optional[Hash32]\n@@ -167,9 +163,11 @@ class StableExecutionPayloadHeader(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]\n     withdrawals_root: Optional[Root]  # [New in Capella]\n     blob_gas_used: Optional[uint64]  # [New in Deneb:EIP4844]\n     excess_blob_gas: Optional[uint64]  # [New in Deneb:EIP4844]\n-    deposit_requests_root: Optional[Root]  # [New in Electra:EIP6110]\n-    withdrawal_requests_root: Optional[Root]  # [New in Electra:EIP7002:EIP7251]\n-    consolidation_requests_root: Optional[Root]  # [New in Electra:EIP7251]\n+\n+class StableExecutionRequests(StableContainer[MAX_EXECUTION_REQUESTS_FIELDS]):\n+    deposits: Optional[List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP6110]\n+    withdrawals: Optional[List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP7002:EIP7251]\n+    consolidations: Optional[List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP7251]\n \n class StableBeaconBlockBody(StableContainer[MAX_BEACON_BLOCK_BODY_FIELDS]):\n     randao_reveal: Optional[BLSSignature]\n@@ -184,6 +182,7 @@ class StableBeaconBlockBody(StableContainer[MAX_BEACON_BLOCK_BODY_FIELDS]):\n     execution_payload: Optional[StableExecutionPayload]  # [New in Bellatrix]\n     bls_to_execution_changes: Optional[List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]]  # [New in Capella]\n     blob_kzg_commitments: Optional[List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]]  # [New in Deneb:EIP4844]\n+    execution_requests: Optional[StableExecutionRequests]  # [New in Electra]\n \n class StableBeaconState(StableContainer[MAX_BEACON_STATE_FIELDS]):\n     # Versioning\n@@ -256,6 +255,9 @@ class ExecutionPayload(Profile[StableExecutionPayload]):\n class ExecutionPayloadHeader(Profile[StableExecutionPayloadHeader]):\n     ...\n \n+class ExecutionRequests(Profile[StableExecutionRequests]):\n+    ...\n+\n class BeaconBlockBody(Profile[StableBeaconBlockBody]):\n     ...\n "
+    },
+    {
+      "sha": "a73b0c4fd7a7253090555a43fe22f0ea6c5d44a3",
+      "date": "2024-07-09T14:16:09Z",
+      "message": "Update EIP-7688: Move to Review",
+      "author": "etan-status",
+      "prNumber": null,
+      "patch": "@@ -4,7 +4,7 @@ title: Forward compatible consensus data structures\n description: Transition consensus SSZ data structures to StableContainer\n author: Etan Kissling (@etan-status), Cayman (@wemeetagain)\n discussions-to: https://ethereum-magicians.org/t/eip-7688-forward-compatible-consensus-data-structures/19673\n-status: Draft\n+status: Review\n type: Standards Track\n category: Core\n created: 2024-04-15"
+    },
+    {
+      "sha": "8d74fc3a6b52b0c199423c683db370e24b77a12a",
+      "date": "2024-06-26T09:47:24Z",
+      "message": "Update EIP-7688: Bump for consensus-specs `v1.5.0-alpha.3`",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "df0d2d029b66ae6829e0ea7d1cbeae1b1da8674f",
+      "date": "2024-05-30T18:03:35Z",
+      "message": "Update EIP-7688: Document types considered immutable",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "e95cfaaab79c5e68ecc32e90024ba20ac55cb8c6",
+      "date": "2024-05-16T14:06:20Z",
+      "message": "Update EIP-7688: Adopt `Profile`, and match EIP-7549 `Atetstation` order",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "8fda943c25dfecb670dcc68c2fc666462c11ebd1",
+      "date": "2024-05-14T06:24:37Z",
+      "message": "Update EIP-7688: Include EIP-7549 attestation data structure changes",
+      "author": "etan-status",
+      "prNumber": null
+    },
+    {
+      "sha": "a639237e18b24102f30df80f3bc9ce089a4c6c65",
+      "date": "2024-05-05T19:38:57Z",
+      "message": "Add EIP: Forward compatible consensus data structures",
+      "author": "etan-status",
+      "prNumber": null
+    }
+  ]
+}

--- a/public/eips/history/7732.json
+++ b/public/eips/history/7732.json
@@ -1,0 +1,50 @@
+{
+  "eipId": 7732,
+  "commits": [
+    {
+      "sha": "c36a2e58a4496ed21bef6b1c97505b03fd159f0a",
+      "date": "2026-04-17T15:05:14Z",
+      "message": "Update EIP-7732: Add Nico Flaig as coauthor",
+      "author": "potuz",
+      "prNumber": null,
+      "patch": "@@ -2,7 +2,7 @@\n eip: 7732\n title: Enshrined Proposer-Builder Separation\n description: Separates the ethereum block in consensus and execution parts, adds a mechanism for the consensus proposer to choose the execution proposer.\n-author: Francesco D'Amato <francesco.damato@ethereum.org>, Barnabé Monnot <barnabe.monnot@ethereum.org>, Michael Neuder <michael.neuder@ethereum.org>, Potuz (@potuz), Justin Traglia <jtraglia@ethereum.org>, Terence Tsao <ttsao@offchainlabs.com>\n+author: Francesco D'Amato <francesco.damato@ethereum.org>, Nico Flaig <nflaig@protonmail.com>, Barnabé Monnot <barnabe.monnot@ethereum.org>, Michael Neuder <michael.neuder@ethereum.org>, Potuz (@potuz), Justin Traglia <jtraglia@ethereum.org>, Terence Tsao <ttsao@offchainlabs.com>\n discussions-to: https://ethereum-magicians.org/t/eip-7732-enshrined-proposer-builder-separation-epbs/19634\n status: Draft\n type: Standards Track"
+    },
+    {
+      "sha": "4d7af9552edad39b66d82e4ea8403dce563a20be",
+      "date": "2026-02-03T21:36:55Z",
+      "message": "Update EIP-7732: update consensus links",
+      "author": "potuz",
+      "prNumber": null
+    },
+    {
+      "sha": "105ac0656c0931dc6052581c41fa6225ea90afef",
+      "date": "2025-08-12T17:16:28Z",
+      "message": "Update EIP-7732: update to latest CL-spec version",
+      "author": "potuz",
+      "prNumber": null
+    },
+    {
+      "sha": "2a6b6965e64787815f7fffb9a4c27660d9683846",
+      "date": "2025-02-12T13:16:12Z",
+      "message": "Update EIP-7732: fix typos",
+      "author": "syjn99",
+      "prNumber": null,
+      "patch": "@@ -120,7 +120,7 @@ The `BeaconState` container is modified with the addition of:\n \n - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. \n - `latest_full_slot`, of type `Slot`, to track the latest slot in which an execution payload was included. \n-- `latest_widthdrawals_root` of type `Root` to track the hash tree root of the latests withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. \n+- `latest_withdrawals_root` of type `Root` to track the hash tree root of the latest withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. \n \n The `BeaconBlockBody` is modified with the addition of:\n \n@@ -133,7 +133,7 @@ State transition logic is modified by:\n \n - A new beacon state getter `get_ptc` returns the PTC members for a given slot. \n - `get_attesting_indices` is modified to not return the beacon committee members that are included in the PTC.\n-- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_widthdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. \n+- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_withdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. \n - `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_header` is included, this function validates the `SignedExecutionPayloadHeader` included in the `BeaconBlockBody` and transfers the payment from the builder's balance to the proposer. \n - `process_deposit_request` is removed from `process_operations` and deferred until `process_execution_payload`. \n - `process_withdrawal_request` is removed from `process_operations` and deferred until `process_execution_payload`. \n@@ -232,7 +232,7 @@ When a builder reveals an expected payload and the PTC achieved consensus that i\n \n Similarly, when a builder reveals a *payload withheld* message and the PTC achieved consensus by having at least `PAYLOAD_TIMELY_THRESHOLD` votes for `PAYLOAD_WITHHELD`, then the parent consensus block receives a boost equivalent to 40% of the beacon committee. Given the `(Block, Slot)` nature of fork choice voting, this boost counts **against** the consensus block containing the builder's commitment. \n \n-Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Secutiry Considerations](#security-considerations) section. \n+Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Security Considerations](#security-considerations) section. \n \n ### PTC equivocations\n "
+    },
+    {
+      "sha": "233696d2599e8ad5213a3f26ad1cdf2d8b740be9",
+      "date": "2024-08-06T16:54:11Z",
+      "message": "Update EIP-7732: Links to consensus repo",
+      "author": "potuz",
+      "prNumber": null,
+      "patch": "@@ -35,12 +35,12 @@ No changes are required.\n \n The full consensus changes can be found in the consensus-specs Github repository. They are split between: \n \n-- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/beacon-chain.md) changes.\n-- [Fork choice](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/fork-choice.md) changes.\n-- [P2P](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/p2p-interface.md) changes.\n-- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/validator.md) changes.\n-- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/builder.md) guide. \n-- [Fork logic](https://github.com/ethereum/consensus-specs/blob/1508f51b80df5488a515bfedf486f98435200e02/specs/_features/eipxxxx/fork.md) changes. \n+- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/beacon-chain.md) changes.\n+- [Fork choice](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/fork-choice.md) changes.\n+- [P2P](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/p2p-interface.md) changes.\n+- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/validator.md) changes.\n+- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/builder.md) guide. \n+- [Fork logic](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/fork.md) changes. \n \n A summary of the main changes is included below, the [Rationale](#rationale) section contains explanation for most of the design decisions around these changes. \n "
+    },
+    {
+      "sha": "e469fd6c8d736b2a3e1ce632263e3ad36fc8624d",
+      "date": "2024-07-03T18:41:55Z",
+      "message": "Add EIP: Enshrined Proposer-Builder Separation",
+      "author": "potuz",
+      "prNumber": null
+    }
+  ]
+}

--- a/public/eips/history/manifest.json
+++ b/public/eips/history/manifest.json
@@ -1,0 +1,26 @@
+{
+  "2780": {
+    "lastSha": "4b612eec2ef70611bba3e0819d137dcfb9b6cd81",
+    "lastCommitDate": "2026-05-08T12:06:13Z",
+    "fetchedAt": "2026-05-19T17:02:48.709Z",
+    "commitCount": 38
+  },
+  "7610": {
+    "lastSha": "7707fe333322ed68d1b5efa50bdb4f35909255a7",
+    "lastCommitDate": "2025-11-06T01:04:36Z",
+    "fetchedAt": "2026-05-19T17:02:40.709Z",
+    "commitCount": 6
+  },
+  "7688": {
+    "lastSha": "f2e6d7fb01194d590e16fcdcae8061d06cf1a7f1",
+    "lastCommitDate": "2026-05-19T16:56:56Z",
+    "fetchedAt": "2026-05-19T17:02:47.043Z",
+    "commitCount": 28
+  },
+  "7732": {
+    "lastSha": "c36a2e58a4496ed21bef6b1c97505b03fd159f0a",
+    "lastCommitDate": "2026-04-17T15:05:14Z",
+    "fetchedAt": "2026-05-19T18:33:21.373Z",
+    "commitCount": 6
+  }
+}

--- a/scripts/fetch-eip-history.mjs
+++ b/scripts/fetch-eip-history.mjs
@@ -1,0 +1,327 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const EIPS_DIR = path.join(__dirname, '../src/data/eips');
+const EIPS_MD_DIR = path.join(__dirname, '../public/eips');
+const HISTORY_DIR = path.join(EIPS_MD_DIR, 'history');
+const MANIFEST_PATH = path.join(HISTORY_DIR, 'manifest.json');
+const BATCH_SIZE = 3;
+const BATCH_DELAY = 500;
+const MAX_PATCH_SIZE = 5000; // bytes — patches larger than this are dropped
+
+// Only fetch history for EIPs that are actively under consideration for these forks
+const TARGET_FORKS = new Set(['Glamsterdam', 'Hegota']);
+const ACTIVE_STATUSES = new Set(['Proposed', 'Considered', 'Scheduled']);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const eipArg = args.find((a) => a.startsWith('--eip='));
+  return {
+    help: args.includes('--help') || args.includes('-h'),
+    singleEip: eipArg ? parseInt(eipArg.split('=')[1], 10) : null,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function loadManifest() {
+  if (!fs.existsSync(MANIFEST_PATH)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function loadExistingHistory(eipNumber) {
+  const filePath = path.join(HISTORY_DIR, `${eipNumber}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function getAuthHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.warn(
+      'Warning: GITHUB_TOKEN not set. Using unauthenticated requests (60 req/hr limit).',
+    );
+    return {};
+  }
+  return { Authorization: `Bearer ${token}` };
+}
+
+function parsePrNumber(message) {
+  const match = message.match(/\(#(\d+)\)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function truncateMessage(message) {
+  const firstLine = message.split('\n')[0];
+  return firstLine.length > 200 ? firstLine.slice(0, 200) + '...' : firstLine;
+}
+
+/**
+ * Get EIP IDs that are PFI, CFI, or SFI in Glamsterdam or Hegota.
+ */
+function getActiveEipIds() {
+  const ids = new Set();
+  const files = fs
+    .readdirSync(EIPS_DIR)
+    .filter((f) => /^\d+\.json$/.test(f));
+
+  for (const file of files) {
+    const eip = JSON.parse(fs.readFileSync(path.join(EIPS_DIR, file), 'utf8'));
+    for (const rel of eip.forkRelationships || []) {
+      if (!TARGET_FORKS.has(rel.forkName)) continue;
+      const latest = rel.statusHistory?.[rel.statusHistory.length - 1];
+      if (latest && ACTIVE_STATUSES.has(latest.status)) {
+        ids.add(eip.id);
+      }
+    }
+  }
+
+  return [...ids].sort((a, b) => a - b);
+}
+
+/**
+ * Parse the Link header from GitHub API responses for pagination.
+ */
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  const parts = linkHeader.split(',');
+  for (const part of parts) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Fetch the patch for a specific file from a single commit.
+ * Returns the unified diff string (capped at MAX_PATCH_SIZE), or null.
+ */
+async function fetchPatchForCommit(sha, eipNumber, headers) {
+  const url = `https://api.github.com/repos/ethereum/EIPs/commits/${sha}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) return null;
+
+  const data = await response.json();
+  const eipFile = (data.files || []).find(
+    (f) =>
+      f.filename === `EIPS/eip-${eipNumber}.md` ||
+      f.previous_filename === `EIPS/eip-${eipNumber}.md`,
+  );
+  const patch = eipFile?.patch || null;
+  if (patch && patch.length > MAX_PATCH_SIZE) return null;
+  return patch;
+}
+
+/**
+ * Fetch all commits for a given EIP file, following pagination.
+ */
+async function fetchCommitsForEip(eipNumber, headers, since) {
+  const params = new URLSearchParams({
+    path: `EIPS/eip-${eipNumber}.md`,
+    per_page: '100',
+  });
+  if (since) {
+    const sinceDate = new Date(new Date(since).getTime() + 1000);
+    params.set('since', sinceDate.toISOString());
+  }
+
+  let url = `https://api.github.com/repos/ethereum/EIPs/commits?${params}`;
+  const allCommits = [];
+
+  while (url) {
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      if (response.status === 409) return [];
+      throw new Error(`HTTP ${response.status} for EIP-${eipNumber}`);
+    }
+
+    const data = await response.json();
+    for (const item of data) {
+      allCommits.push({
+        sha: item.sha,
+        date: item.commit.author.date,
+        message: truncateMessage(item.commit.message),
+        author: item.author?.login || item.commit.author.name || 'unknown',
+        prNumber: parsePrNumber(item.commit.message),
+      });
+    }
+
+    url = parseNextLink(response.headers.get('link'));
+  }
+
+  return allCommits;
+}
+
+async function main() {
+  const options = parseArgs();
+
+  if (options.help) {
+    console.log(`
+Fetch EIP Spec History
+======================
+
+Fetches commit history for EIP spec files from the ethereum/EIPs GitHub repo.
+Only fetches for EIPs that are PFI, CFI, or SFI in Glamsterdam or Hegota.
+
+Usage:
+  node scripts/fetch-eip-history.mjs [options]
+
+Options:
+  --eip=NUMBER  Fetch history for a single EIP (bypasses fork filter)
+  -h, --help    Show this help message
+
+Environment:
+  GITHUB_TOKEN  GitHub personal access token (recommended for higher rate limits)
+`);
+    process.exit(0);
+  }
+
+  if (!fs.existsSync(HISTORY_DIR)) {
+    fs.mkdirSync(HISTORY_DIR, { recursive: true });
+  }
+
+  const headers = {
+    Accept: 'application/vnd.github.v3+json',
+    ...getAuthHeaders(),
+  };
+
+  const manifest = loadManifest();
+
+  let eipNumbers;
+  if (options.singleEip) {
+    eipNumbers = [options.singleEip];
+    console.log(`Fetching history for EIP-${options.singleEip}...`);
+  } else {
+    eipNumbers = getActiveEipIds();
+    console.log(
+      `Fetching history for ${eipNumbers.length} active EIPs (PFI/CFI/SFI in ${[...TARGET_FORKS].join('/')})...`,
+    );
+  }
+
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (let i = 0; i < eipNumbers.length; i += BATCH_SIZE) {
+    const batch = eipNumbers.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (eipNumber) => {
+        try {
+          const entry = manifest[eipNumber];
+          const historyFileExists = fs.existsSync(path.join(HISTORY_DIR, `${eipNumber}.json`));
+          const since = entry && historyFileExists ? entry.lastCommitDate : null;
+
+          const newCommits = await fetchCommitsForEip(
+            eipNumber,
+            headers,
+            since,
+          );
+
+          if (newCommits.length === 0 && entry && historyFileExists) {
+            return { eipNumber, skipped: true };
+          }
+
+          const existing = loadExistingHistory(eipNumber);
+          const existingShas = new Set(
+            (existing?.commits || []).map((c) => c.sha),
+          );
+          const dedupedNew = newCommits.filter(
+            (c) => !existingShas.has(c.sha),
+          );
+
+          // Fetch patches for new commits
+          for (const commit of dedupedNew) {
+            const patch = await fetchPatchForCommit(
+              commit.sha,
+              eipNumber,
+              headers,
+            );
+            if (patch) commit.patch = patch;
+            await sleep(100);
+          }
+
+          // Backfill patches for existing commits missing them
+          const existingCommits = existing?.commits || [];
+          const missingPatches = existingCommits.filter((c) => !c.patch);
+          for (const commit of missingPatches) {
+            const patch = await fetchPatchForCommit(
+              commit.sha,
+              eipNumber,
+              headers,
+            );
+            if (patch) commit.patch = patch;
+            await sleep(100);
+          }
+
+          const allCommits = [...dedupedNew, ...(existing?.commits || [])];
+          allCommits.sort(
+            (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+          );
+
+          const history = {
+            eipId: eipNumber,
+            commits: allCommits,
+          };
+
+          const filePath = path.join(HISTORY_DIR, `${eipNumber}.json`);
+          fs.writeFileSync(filePath, JSON.stringify(history, null, 2) + '\n');
+
+          manifest[eipNumber] = {
+            lastSha: allCommits[0]?.sha || null,
+            lastCommitDate: allCommits[0]?.date || null,
+            fetchedAt: new Date().toISOString(),
+            commitCount: allCommits.length,
+          };
+
+          return { eipNumber, updated: true, newCount: dedupedNew.length };
+        } catch (err) {
+          console.error(`  Error fetching EIP-${eipNumber}: ${err.message}`);
+          return { eipNumber, error: true };
+        }
+      }),
+    );
+
+    for (const r of results) {
+      if (r.error) errors++;
+      else if (r.skipped) skipped++;
+      else if (r.updated) updated++;
+    }
+
+    if (!options.singleEip) {
+      process.stdout.write(
+        `\rProcessed ${Math.min(i + BATCH_SIZE, eipNumbers.length)}/${eipNumbers.length}...`,
+      );
+    }
+
+    if (i + BATCH_SIZE < eipNumbers.length) {
+      await sleep(BATCH_DELAY);
+    }
+  }
+
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+
+  console.log('\n');
+  console.log('Done!');
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped (no new commits): ${skipped}`);
+  if (errors > 0) console.log(`  Errors: ${errors}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useCallback, useState, lazy, Suspense } from 'react';
-import { Link, useParams, Navigate, useNavigate } from 'react-router-dom';
+import { Link, useParams, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { eipsData } from '../../data/eips';
 import { useMetaTags } from '../../hooks/useMetaTags';
 import { useAnalytics } from '../../hooks/useAnalytics';
@@ -16,6 +16,8 @@ import { Tooltip } from '../ui';
 import { EipTimeline } from './EipTimeline';
 import { EipSearch } from './EipSearch';
 import EipSearchModal from './EipSearchModal';
+import { EipSpecHistory } from './EipSpecHistory';
+import { useEipHistory } from '../../hooks/useEipHistory';
 import { isSearchHotkey } from '../search/searchShortcuts';
 import {
   eipCallTypes,
@@ -67,6 +69,7 @@ export const EipPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { trackLinkClick } = useAnalytics();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [upcomingCall, setUpcomingCall] = useState<UpcomingCall | null>(null);
 
@@ -88,9 +91,25 @@ export const EipPage: React.FC = () => {
     ),
   );
 
-  // View mode: "analysis" shows analysis content, "spec" shows raw markdown
-  const [viewMode, setViewMode] = useState<'analysis' | 'spec'>(hasAnalysis ? 'analysis' : 'spec');
+  // View mode derived from URL ?tab= param
+  const validTabs = ['analysis', 'spec', 'history'] as const;
+  type ViewMode = typeof validTabs[number];
+  const defaultTab: ViewMode = hasAnalysis ? 'analysis' : 'spec';
+  const tabParam = searchParams.get('tab') as ViewMode | null;
+  const viewMode: ViewMode = tabParam && validTabs.includes(tabParam) ? tabParam : defaultTab;
+
+  const setViewMode = (mode: ViewMode) => {
+    const next = new URLSearchParams(searchParams);
+    if (mode === defaultTab) {
+      next.delete('tab');
+    } else {
+      next.set('tab', mode);
+    }
+    setSearchParams(next, { replace: true });
+  };
+
   const { content: specContent, loading: specLoading, error: specError } = useEipMarkdown(eipId, viewMode === 'spec');
+  const { history, loading: historyLoading, error: historyError } = useEipHistory(eipId, viewMode === 'history');
 
   // Get sorted EIPs for navigation
   const sortedEips = useMemo(() => [...eipsData].sort((a, b) => a.id - b.id), []);
@@ -98,10 +117,18 @@ export const EipPage: React.FC = () => {
   const prevEip = currentIndex > 0 ? sortedEips[currentIndex - 1] : null;
   const nextEip = currentIndex < sortedEips.length - 1 ? sortedEips[currentIndex + 1] : null;
 
+  const prevIdRef = React.useRef(id);
   useEffect(() => {
     window.scrollTo(0, 0);
-    setViewMode(hasAnalysis ? 'analysis' : 'spec');
-  }, [id, hasAnalysis]);
+    // Reset to default tab only when navigating to a different EIP
+    if (prevIdRef.current !== id && searchParams.has('tab')) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('tab');
+      setSearchParams(next, { replace: true });
+    }
+    prevIdRef.current = id;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
 
 
   // Fetch upcoming breakout call if this EIP has one
@@ -304,8 +331,8 @@ export const EipPage: React.FC = () => {
           </header>
 
           {/* View mode tabs */}
-          {hasAnalysis && (
-            <div className="flex border-b border-slate-200 dark:border-slate-700">
+          <div className="flex border-b border-slate-200 dark:border-slate-700">
+            {hasAnalysis && (
               <button
                 onClick={() => setViewMode('analysis')}
                 className={`px-6 py-3 text-sm font-medium transition-colors ${
@@ -316,18 +343,28 @@ export const EipPage: React.FC = () => {
               >
                 Analysis
               </button>
-              <button
-                onClick={() => setViewMode('spec')}
-                className={`px-6 py-3 text-sm font-medium transition-colors ${
-                  viewMode === 'spec'
-                    ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
-                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
-                }`}
-              >
-                Specification
-              </button>
-            </div>
-          )}
+            )}
+            <button
+              onClick={() => setViewMode('spec')}
+              className={`px-6 py-3 text-sm font-medium transition-colors ${
+                viewMode === 'spec'
+                  ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
+                  : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
+              }`}
+            >
+              Specification
+            </button>
+            <button
+              onClick={() => setViewMode('history')}
+              className={`px-6 py-3 text-sm font-medium transition-colors ${
+                viewMode === 'history'
+                  ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
+                  : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
+              }`}
+            >
+              History
+            </button>
+          </div>
 
           {/* Body Content */}
           <div className="p-6 space-y-8">
@@ -503,10 +540,19 @@ export const EipPage: React.FC = () => {
                 )}
               </>
             )}
+
+            {viewMode === 'history' && (
+              <EipSpecHistory
+                eipId={eipId}
+                history={history}
+                loading={historyLoading}
+                error={historyError}
+              />
+            )}
           </div>
         </article>
 
-        {/* Previous/Next Navigation */}
+        {/* Previous/Next Navigation + GitHub link */}
         <nav className="mt-6 flex items-center justify-between">
           {prevEip ? (
             <Link
@@ -521,6 +567,17 @@ export const EipPage: React.FC = () => {
           ) : (
             <div />
           )}
+          <a
+            href={`https://github.com/ethereum/forkcast/blob/main/src/data/eips/${eip.id}.json`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => handleExternalLinkClick('github_eip', `https://github.com/ethereum/forkcast/blob/main/src/data/eips/${eip.id}.json`)}
+            className="text-slate-400 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+            </svg>
+          </a>
           {nextEip ? (
             <Link
               to={`/eips/${nextEip.id}`}
@@ -535,21 +592,6 @@ export const EipPage: React.FC = () => {
             <div />
           )}
         </nav>
-
-        {/* Footer */}
-        <footer className="mt-8 text-center text-sm text-slate-500 dark:text-slate-400 space-y-3">
-          <a
-            href={`https://github.com/ethereum/forkcast/blob/main/src/data/eips/${eip.id}.json`}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => handleExternalLinkClick('github_eip', `https://github.com/ethereum/forkcast/blob/main/src/data/eips/${eip.id}.json`)}
-            className="inline-block text-slate-400 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300 transition-colors"
-          >
-            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-              <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-            </svg>
-          </a>
-        </footer>
       </div>
 
       {/* Search Modal */}

--- a/src/components/eip/EipSpecHistory.tsx
+++ b/src/components/eip/EipSpecHistory.tsx
@@ -1,0 +1,304 @@
+import React, { useState } from 'react';
+import type { EipSpecHistory as EipSpecHistoryType, EipSpecCommit } from '../../types/eip';
+
+interface EipSpecHistoryProps {
+  eipId: number;
+  history: EipSpecHistoryType | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const INITIAL_DISPLAY_COUNT = 20;
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function cleanMessage(message: string): string {
+  // Remove trailing PR reference like (#1234)
+  let cleaned = message.replace(/\s*\(#\d+\)\s*$/, '').trim();
+  // Strip redundant EIP prefix: "Update EIP-7702: ...", "Add EIP-7702: ...", "EIP-7702: ..."
+  cleaned = cleaned.replace(/^(?:Update|Add|Move|Rename)\s+EIP-\d+:\s*/i, '').trim();
+  cleaned = cleaned.replace(/^EIP-\d+:\s*/, '').trim();
+  // Capitalize first letter after stripping
+  if (cleaned.length > 0) {
+    cleaned = cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+  }
+  return cleaned;
+}
+
+function getDiffStats(patch: string): { additions: number; deletions: number } | null {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+    else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+  }
+  if (additions === 0 && deletions === 0) return null;
+  return { additions, deletions };
+}
+
+interface DiffLine {
+  type: 'add' | 'remove' | 'context' | 'hunk';
+  content: string;
+}
+
+function parsePatch(patch: string): DiffLine[] {
+  return patch.split('\n').map((line) => {
+    if (line.startsWith('@@')) return { type: 'hunk', content: line };
+    if (line.startsWith('+')) return { type: 'add', content: line.slice(1) };
+    if (line.startsWith('-')) return { type: 'remove', content: line.slice(1) };
+    return { type: 'context', content: line.startsWith(' ') ? line.slice(1) : line };
+  });
+}
+
+const InlineDiff: React.FC<{ patch: string }> = ({ patch }) => {
+  const lines = parsePatch(patch);
+
+  return (
+    <div className="mt-2 rounded border border-slate-200 dark:border-slate-600 overflow-x-auto text-xs font-mono">
+      {lines.map((line, i) => {
+        if (line.type === 'hunk') {
+          return (
+            <div key={i} className="px-3 py-0.5 bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 select-none">
+              {line.content}
+            </div>
+          );
+        }
+
+        const bgClass =
+          line.type === 'add'
+            ? 'bg-emerald-50 dark:bg-emerald-900/20'
+            : line.type === 'remove'
+              ? 'bg-red-50 dark:bg-red-900/20'
+              : '';
+
+        const textClass =
+          line.type === 'add'
+            ? 'text-emerald-800 dark:text-emerald-300'
+            : line.type === 'remove'
+              ? 'text-red-800 dark:text-red-300'
+              : 'text-slate-600 dark:text-slate-400';
+
+        const prefix =
+          line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' ';
+
+        return (
+          <div key={i} className={`px-3 py-0 whitespace-pre-wrap break-all ${bgClass} ${textClass}`}>
+            <span className="select-none opacity-50 mr-2">{prefix}</span>
+            {line.content}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const ExternalLinkIcon: React.FC = () => (
+  <svg className="w-3 h-3 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+  </svg>
+);
+
+const CommitEntry: React.FC<{ commit: EipSpecCommit; expanded: boolean; onToggle: () => void }> = ({ commit, expanded, onToggle }) => {
+  const stats = commit.patch ? getDiffStats(commit.patch) : null;
+
+  return (
+    <div>
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-medium text-slate-900 dark:text-slate-100 leading-snug break-words">
+          {cleanMessage(commit.message)}
+        </p>
+        {stats && (
+          <span className="shrink-0 text-xs font-mono whitespace-nowrap pt-0.5">
+            <span className="text-emerald-600 dark:text-emerald-400">+{stats.additions}</span>
+            {' '}
+            <span className="text-red-500 dark:text-red-400">-{stats.deletions}</span>
+          </span>
+        )}
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-slate-400 dark:text-slate-400">
+        <span>{formatDate(commit.date)}</span>
+        <span>
+          by{' '}
+          <a
+            href={`https://github.com/${commit.author}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          >
+            {commit.author}
+          </a>
+        </span>
+        {(commit.prNumber || commit.sha) && (
+          <>
+            <span className="text-slate-300 dark:text-slate-500">|</span>
+            {commit.prNumber && (
+              <a
+                href={`https://github.com/ethereum/EIPs/pull/${commit.prNumber}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-purple-600 dark:text-purple-400 hover:underline underline-offset-2 inline-flex items-center gap-1"
+              >
+                PR #{commit.prNumber} <ExternalLinkIcon />
+              </a>
+            )}
+            {!commit.prNumber && (
+              <a
+                href={`https://github.com/ethereum/EIPs/commit/${commit.sha}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-purple-600 dark:text-purple-400 hover:underline underline-offset-2 inline-flex items-center gap-1"
+              >
+                Commit <ExternalLinkIcon />
+              </a>
+            )}
+          </>
+        )}
+      </div>
+      {commit.patch && (
+        <button
+          onClick={onToggle}
+          className="mt-1.5 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-purple-400 dark:hover:border-purple-500 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+        >
+          <svg className={`w-3 h-3 transition-transform ${expanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          {expanded ? 'Hide diff' : 'Show diff'}
+        </button>
+      )}
+      {expanded && commit.patch && <InlineDiff patch={commit.patch} />}
+    </div>
+  );
+};
+
+export const EipSpecHistory: React.FC<EipSpecHistoryProps> = ({
+  eipId,
+  history,
+  loading,
+  error,
+}) => {
+  const [showAll, setShowAll] = useState(false);
+  const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
+  const [allExpanded, setAllExpanded] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        Loading history...
+      </div>
+    );
+  }
+
+  if (error || !history || history.commits.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400 italic">
+        <a
+          href={`https://github.com/ethereum/EIPs/commits/master/EIPS/eip-${eipId}.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-purple-600 dark:text-purple-400 underline underline-offset-2"
+        >
+          View history on GitHub
+        </a>
+      </p>
+    );
+  }
+
+  const commits = history.commits;
+  const displayedCommits = showAll
+    ? commits
+    : commits.slice(0, INITIAL_DISPLAY_COUNT);
+  const hasMore = commits.length > INITIAL_DISPLAY_COUNT;
+  const hasPatchCommits = displayedCommits.some((c) => c.patch);
+
+  const toggleCommit = (sha: string) => {
+    setExpandedShas((prev) => {
+      const next = new Set(prev);
+      if (next.has(sha)) next.delete(sha);
+      else next.add(sha);
+      return next;
+    });
+    setAllExpanded(false);
+  };
+
+  const toggleAll = () => {
+    if (allExpanded) {
+      setExpandedShas(new Set());
+      setAllExpanded(false);
+    } else {
+      setExpandedShas(new Set(displayedCommits.filter((c) => c.patch).map((c) => c.sha)));
+      setAllExpanded(true);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100 uppercase tracking-wide">
+          Spec Change History
+        </h3>
+        <div className="flex items-center gap-3">
+          {hasPatchCommits && (
+            <button
+              onClick={toggleAll}
+              className="text-xs text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+            >
+              {allExpanded ? 'Collapse all' : 'Expand all'}
+            </button>
+          )}
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            {commits.length} {commits.length === 1 ? 'change' : 'changes'}
+          </span>
+        </div>
+      </div>
+
+      <div className="relative">
+        {displayedCommits.map((commit, index) => {
+          const isLast = index === displayedCommits.length - 1;
+          const isExpanded = allExpanded ? !!commit.patch : expandedShas.has(commit.sha);
+
+          return (
+            <div key={commit.sha} className="relative flex gap-3">
+              {/* Timeline dot and line */}
+              <div className="relative w-2.5 shrink-0 flex flex-col items-center pt-1">
+                <div className="w-2.5 h-2.5 rounded-full shrink-0 bg-slate-400 dark:bg-slate-500" />
+                {!isLast && (
+                  <div className="w-0.5 flex-1 bg-slate-200 dark:bg-slate-700 mb-[-4px]" />
+                )}
+              </div>
+
+              {/* Content */}
+              <div className={`min-w-0 flex-1 ${isLast ? '' : 'pb-4'}`}>
+                <CommitEntry
+                  commit={commit}
+                  expanded={isExpanded}
+                  onToggle={() => toggleCommit(commit.sha)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Show more button */}
+      {hasMore && !showAll && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="mt-4 w-full text-center text-sm text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+        >
+          Show all {commits.length} changes
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useEipHistory.ts
+++ b/src/hooks/useEipHistory.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import type { EipSpecHistory } from '../types/eip';
+
+const cache = new Map<number, EipSpecHistory>();
+
+export function useEipHistory(eipId: number, enabled: boolean) {
+  const [history, setHistory] = useState<EipSpecHistory | null>(
+    cache.get(eipId) ?? null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (cache.has(eipId)) {
+      setHistory(cache.get(eipId)!);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setHistory(null);
+    setLoading(true);
+    setError(null);
+
+    fetch(`/eips/history/${eipId}.json`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const contentType = res.headers.get('content-type') || '';
+        if (contentType.includes('text/html')) {
+          throw new Error('History not available');
+        }
+        return res.json();
+      })
+      .then((data: EipSpecHistory) => {
+        if (cancelled) return;
+        cache.set(eipId, data);
+        setHistory(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err.message);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [eipId, enabled]);
+
+  return { history, loading, error };
+}

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -95,3 +95,17 @@ export interface KeyDecision {
   fork?: string;
   context?: string;
 }
+
+export interface EipSpecCommit {
+  sha: string;
+  date: string;
+  message: string;
+  author: string;
+  prNumber: number | null;
+  patch?: string;
+}
+
+export interface EipSpecHistory {
+  eipId: number;
+  commits: EipSpecCommit[];
+}


### PR DESCRIPTION
client dev feature request: show eip spec history, i.e., when and how a spec changed over time.

- to the twice daily eip workflow, this PR adds a git commit history check, limited to EIPs that are PFI, CFI, or SFI in hegota or glamsterdam
- diff size adds up; if the diff is over 5kb, dont store it and just render the commit link
- a few EIPs are seeded here (7732, 7610, 7688). the rest will be triggered by CI.