### PR TITLE
Fix P2P 001 transcript typos

### DIFF
--- a/public/artifacts/p2p/2026-05-20_001/tldr.json
+++ b/public/artifacts/p2p/2026-05-20_001/tldr.json
@@ -8,7 +8,7 @@
       },
       {
         "timestamp": "00:33:10",
-        "highlight": "Lighthouse plans to enable partial columns on Hoodie by default (mainnet off); release targeting June"
+        "highlight": "Lighthouse plans to enable partial columns on Hoodi by default (mainnet off); release targeting June"
       },
       {
         "timestamp": "00:27:30",
@@ -48,7 +48,7 @@
     {
       "timestamp": "00:19:36",
       "action": "Run CPU profile on Geth node during devnet load test to diagnose GetBlobs latency",
-      "owner": "Marco Munizaga / EthMan Ops"
+      "owner": "Marco Munizaga / EthPandaOps"
     },
     {
       "timestamp": "01:06:11",
@@ -59,13 +59,13 @@
   "decisions": [
     {
       "timestamp": "00:34:09",
-      "decision": "Lighthouse will enable partial columns on Hoodie by default while keeping it disabled on mainnet"
+      "decision": "Lighthouse will enable partial columns on Hoodi by default while keeping it disabled on mainnet"
     }
   ],
   "targets": [
     {
       "timestamp": "00:34:48",
-      "target": "June 2026 \u2014 Lighthouse partial columns release targeting Hoodie deployment"
+      "target": "June 2026 \u2014 Lighthouse partial columns release targeting Hoodi deployment"
     }
   ]
 }

--- a/public/artifacts/p2p/2026-05-20_001/transcript_corrected.vtt
+++ b/public/artifacts/p2p/2026-05-20_001/transcript_corrected.vtt
@@ -70,7 +70,7 @@ Daniel Knopik: I don't expect this to be merged that soon, but it's, yeah, ongoi
 
 18
 00:12:09.820 --> 00:12:18.250
-Daniel Knopik: We also, ran some notes on hoodie, with partial messages, it's…
+Daniel Knopik: We also, ran some nodes on Hoodi, with partial messages, it's…
 
 19
 00:12:18.370 --> 00:12:25.219
@@ -102,7 +102,7 @@ Daniel Knopik: Joao isn't here, right? Okay, there's…
 
 26
 00:13:07.480 --> 00:13:21.960
-Daniel Knopik: some internal refractor in Rusta P2P, basically switching back to a different… Stack of, pro-buff deserization.
+Daniel Knopik: some internal refactor in rust-libp2p, basically switching back to a different… Stack of, protobuf deserialization.
 
 27
 00:13:22.220 --> 00:13:29.350
@@ -154,7 +154,7 @@ Kamil Salakhiev: Okay, no one, yeah, any other CL clients?
 
 39
 00:14:34.570 --> 00:14:47.480
-Kamil Salakhiev: Yeah, if not, yeah, we can just go into EL part, yeah, I see Basel, so, yeah, how things are sparse BlowPool, yeah, we've been discussing last time, yeah, with this,
+Kamil Salakhiev: Yeah, if not, yeah, we can just go into EL part, yeah, I see Bosul, so, yeah, how things are sparse blob pool, yeah, we've been discussing last time, yeah, with this,
 
 40
 00:14:47.530 --> 00:14:58.760
@@ -170,7 +170,7 @@ Bosul Mun: Aye.
 
 43
 00:15:04.820 --> 00:15:07.390
-Bosul Mun: about CapFlow's V3.
+Bosul Mun: about GetBlobs V3.
 
 44
 00:15:07.620 --> 00:15:10.929
@@ -178,7 +178,7 @@ Bosul Mun: I… I couldn't take care much.
 
 45
 00:15:11.130 --> 00:15:19.519
-Bosul Mun: about that problem, because I was working… also on Sports Poppool, and its 71 is also going on, so…
+Bosul Mun: about that problem, because I was working… also on sparse blob pool, and its 71 is also going on, so…
 
 46
 00:15:19.700 --> 00:15:25.940
@@ -186,7 +186,7 @@ Bosul Mun: But I will invest… I really want to investigate it. But for now,
 
 47
 00:15:27.730 --> 00:15:31.769
-Bosul Mun: It's making sparse buffal pool more solid.
+Bosul Mun: It's making sparse blob pool more solid.
 
 48
 00:15:32.200 --> 00:15:37.809
@@ -302,7 +302,7 @@ Bosul Mun: Hmm.
 
 76
 00:17:32.600 --> 00:17:51.969
-Raúl Kripalani: Yeah. We were… we were going into the… I don't know if you've seen Discord, Bosal, I tagged you in… in a thread. I posted the… the findings here. I think what's happening is that, Geth and just like many other Go clients, are using KB stores, that are, usually SMT that have…
+Raúl Kripalani: Yeah. We were… we were going into the… I don't know if you've seen Discord, Bosul, I tagged you in… in a thread. I posted the… the findings here. I think what's happening is that, Geth and just like many other Go clients, are using KB stores, that are, usually SMT that have…
 
 77
 00:17:51.970 --> 00:18:06.040
@@ -490,7 +490,7 @@ Csaba: worth looking into.
 
 123
 00:22:23.370 --> 00:22:37.289
-Kamil Salakhiev: Yeah, alright. Also, I think you also were mentioning that Nethermind, I think they had some issues with the sparse blog post, I think, like, treating, like, this beatmap, incorrectly because of, like, Indiana, something like that.
+Kamil Salakhiev: Yeah, alright. Also, I think you also were mentioning that Nethermind, I think they had some issues with the sparse blob pool, I think, like, treating, like, this bitmap, incorrectly because of, like, endianness, something like that.
 
 124
 00:22:37.610 --> 00:22:40.940
@@ -642,7 +642,7 @@ Bosul Mun: there were some problems with sending global transactions to Glamster
 
 161
 00:25:29.910 --> 00:25:40.389
-Bosul Mun: much sense to deploy a sparse code pool on there, because there's… there will be nothing to be tested. So,
+Bosul Mun: much sense to deploy a sparse blob pool on there, because there's… there will be nothing to be tested. So,
 
 162
 00:25:41.320 --> 00:25:56.040
@@ -938,7 +938,7 @@ Daniel Knopik: Partial message with that.
 
 235
 00:33:12.930 --> 00:33:22.220
-Daniel Knopik: The thing is, so, of course, we won't encourage people to run this on mainnet just yet. The idea would be for people to try it on Hoodie.
+Daniel Knopik: The thing is, so, of course, we won't encourage people to run this on mainnet just yet. The idea would be for people to try it on Hoodi.
 
 236
 00:33:22.640 --> 00:33:27.529
@@ -950,7 +950,7 @@ Daniel Knopik: Especially on testnets. That's even worse there.
 
 238
 00:33:32.820 --> 00:33:52.340
-Daniel Knopik: And having partial messages feature-flagged a way where we would put out a blog post explaining what it does, we would need people to update and figure out this blog post and decide to enable it, and personally, I don't see the adoption rate on Hoodie to be
+Daniel Knopik: And having partial messages feature-flagged a way where we would put out a blog post explaining what it does, we would need people to update and figure out this blog post and decide to enable it, and personally, I don't see the adoption rate on Hoodi to be
 
 239
 00:33:52.590 --> 00:33:58.200
@@ -958,7 +958,7 @@ Daniel Knopik: Large enough for us to gain any meaningful insight from that.
 
 240
 00:33:58.610 --> 00:34:09.470
-Daniel Knopik: So… We actually consider enabling partial columns on Hoodie by default.
+Daniel Knopik: So… We actually consider enabling partial columns on Hoodi by default.
 
 241
 00:34:10.130 --> 00:34:14.130
@@ -998,7 +998,7 @@ Daniel Knopik: Gotta keep you updated.
 
 250
 00:34:56.880 --> 00:35:04.909
-Kamil Salakhiev: Do you know, like, what is the ratio? I mean, what is the portion of lighthouse notes in Hoodie? Like, once you have this enabled by default, so that,
+Kamil Salakhiev: Do you know, like, what is the ratio? I mean, what is the portion of lighthouse nodes in Hoodi? Like, once you have this enabled by default, so that,
 
 251
 00:35:05.850 --> 00:35:07.569
@@ -1018,7 +1018,7 @@ Daniel Knopik: I don't have any stats in mind, I'll need to check if any of the�
 
 255
 00:35:15.980 --> 00:35:19.950
-Daniel Knopik: Scrapers also scrape on Hoodie. Probably someone does.
+Daniel Knopik: Scrapers also scrape on Hoodi. Probably someone does.
 
 256
 00:35:21.610 --> 00:35:31.200
@@ -1026,11 +1026,11 @@ Daniel Knopik: But that being said, it's… it's really not really in the… as 
 
 257
 00:35:32.400 --> 00:35:36.149
-Daniel Knopik: Of course, like, the hosted notes by…
+Daniel Knopik: Of course, like, the hosted nodes by…
 
 258
 00:35:36.380 --> 00:35:46.270
-Daniel Knopik: if PandaOps shell would probably be updated rather quickly, and the Lighthouse internal notes are already running it 100%.
+Daniel Knopik: if EthPandaOps shall, would probably be updated rather quickly, and the Lighthouse internal nodes are already running it 100%.
 
 259
 00:35:46.910 --> 00:35:48.899
@@ -1054,7 +1054,7 @@ Csaba: So, we'll see.
 
 264
 00:35:59.270 --> 00:36:02.580
-Csaba: Searching… what's the question on Lighthouse notes on Hoodie?
+Csaba: Searching… what's the question on Lighthouse nodes on Hoodi?
 
 265
 00:36:03.300 --> 00:36:04.030


### PR DESCRIPTION
## Summary
- Normalize \`Hoodie\` -> \`Hoodi\` (testnet name) in tldr + transcript (10 occurrences).
- Fix \`EthMan Ops\` -> \`EthPandaOps\` in the action_items owner field.
- Repair several mangled phrases in the transcript: \`notes\` -> \`nodes\` (where context is clear), \`Rusta P2P\` -> \`rust-libp2p\`, \`pro-buff deserization\` -> \`protobuf deserialization\`, and multiple variants of \`sparse blob pool\` (\`BlowPool\`, \`buffal pool\`, \`sparse code pool\`, \`Sports Poppool\`, \`sparse blog post\`).
- Fix \`beatmap\` -> \`bitmap\`, \`Indiana\` -> \`endianness\`, \`CapFlow's V3\` -> \`GetBlobs V3\`, and \`Basel\`/\`Bosal\` -> \`Bosul\` (Bosul Mun).

Pairs with the PM PR: https://github.com/ethereum/pm/pull/2069 (vocab additions so future calls auto-correct).

## Test plan
- [ ] After deploy, the call page at forkcast.org renders \`Hoodi\` (not \`Hoodie\`) and \`EthPandaOps\` (not \`EthMan Ops\`).