### PR TITLE
sync: set video/transcript offsets for AWD 39, P2P 1, and PQI 40

### DIFF
--- a/public/artifacts/awd/2026-05-20_039/config.json
+++ b/public/artifacts/awd/2026-05-20_039/config.json
@@ -2,7 +2,7 @@
   "issue": 1997,
   "videoUrl": "https://www.youtube.com/watch?v=kjhHvfgPODk",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:05:12",
+    "videoStartTime": "00:05:12"
   }
 }

--- a/public/artifacts/p2p/2026-05-20_001/config.json
+++ b/public/artifacts/p2p/2026-05-20_001/config.json
@@ -2,7 +2,7 @@
   "issue": 2051,
   "videoUrl": "https://www.youtube.com/watch?v=sxhosPIdzWM",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:10:32",
+    "videoStartTime": "00:10:32"
   }
 }

--- a/public/artifacts/pqi/2026-05-20_040/config.json
+++ b/public/artifacts/pqi/2026-05-20_040/config.json
@@ -2,7 +2,7 @@
   "issue": 2065,
   "videoUrl": "https://www.youtube.com/watch?v=IogrdpVyLzQ",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:04:39",
+    "videoStartTime": "00:04:39"
   }
 }


### PR DESCRIPTION
Sets video/transcript sync offsets for newly synced calls:

- AWD 39 → `00:05:12`
- P2P 1 → `00:10:32`
- PQI 40 → `00:04:39`