### PR TITLE
devnets: show upcoming on all series

### DIFF
--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -291,9 +291,14 @@ async function main() {
     console.log(`  genesis time: ${new Date(genesisTime * 1000).toISOString()}`);
   }
 
-  if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
-
+  // Preserve the `canceled` flag from the existing file if present
   const outPath = join(OUTPUT_DIR, `${id}.json`);
+  if (existsSync(outPath)) {
+    const existing = JSON.parse(readFileSync(outPath, 'utf-8'));
+    if (existing.canceled) spec.canceled = true;
+  }
+
+  if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
   writeFileSync(outPath, JSON.stringify(spec, null, 2) + '\n');
   console.log(`Wrote ${outPath}`);
 }

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -357,7 +357,7 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
               rel="noopener noreferrer"
               className="hover:text-purple-600 dark:hover:text-purple-400 transition-colors underline decoration-1 underline-offset-2"
             >
-              View Source
+              View Specification
             </a>
             <span>&middot;</span>
             {spec.genesisTime && (

--- a/src/components/DevnetsIndexPage.tsx
+++ b/src/components/DevnetsIndexPage.tsx
@@ -67,7 +67,7 @@ function parseSpecId(id: string): { category: string; version: number } | null {
  * - Active series get an upcomingSpecId if a local spec exists with a higher version.
  * - Spec-only series (no active networks at all) are synthesised as upcoming cards.
  */
-function buildCardItems(activeSeries: ActiveDevnetSeries[]): DevnetCardItem[] {
+function buildCardItems(activeSeries: ActiveDevnetSeries[], inactiveSeries: InactiveDevnetSeries[]): DevnetCardItem[] {
   const allSpecIds = getAllDevnetSpecIds();
 
   // Start with a copy of every active series, enriched with upcoming spec info
@@ -81,6 +81,20 @@ function buildCardItems(activeSeries: ActiveDevnetSeries[]): DevnetCardItem[] {
       upcomingSpecId: upcomingSpec?.id ?? null,
     };
   });
+
+  // Promote inactive series that have a spec beyond the highest version ever deployed
+  for (const s of inactiveSeries) {
+    const upcomingSpec = findUpcomingSpec(allSpecIds, s.categoryKey, s.highestKnownVersion ?? -1);
+    if (upcomingSpec) {
+      items.push({
+        categoryKey: s.categoryKey,
+        displayName: s.displayName,
+        description: s.description,
+        activeKeys: [],
+        upcomingSpecId: upcomingSpec.id,
+      });
+    }
+  }
 
   items.sort((a, b) => a.displayName.localeCompare(b.displayName));
   return items;
@@ -165,7 +179,7 @@ function InactiveCard({ item }: { item: InactiveDevnetSeries }) {
 const DevnetsIndexPage: React.FC = () => {
   const { activeSeries, inactiveSeries, loading, error } = useDevnetNetworks();
   const [showInactive, setShowInactive] = useState(false);
-  const cardItems = buildCardItems(activeSeries);
+  const cardItems = buildCardItems(activeSeries, inactiveSeries);
   const isForkAffiliated = (key: string) =>
     GLAMSTERDAM_CATEGORIES.has(key) || FUSAKA_CATEGORIES.has(key) || PECTRA_CATEGORIES.has(key) || DENCUN_CATEGORIES.has(key);
   const glamsterdamCards = cardItems.filter((c) => GLAMSTERDAM_CATEGORIES.has(c.categoryKey));
@@ -173,11 +187,13 @@ const DevnetsIndexPage: React.FC = () => {
   const pectraCards = cardItems.filter((c) => PECTRA_CATEGORIES.has(c.categoryKey));
   const dencunCards = cardItems.filter((c) => DENCUN_CATEGORIES.has(c.categoryKey));
   const generalCards = cardItems.filter((c) => !isForkAffiliated(c.categoryKey));
-  const glamsterdamInactive = inactiveSeries.filter((c) => GLAMSTERDAM_CATEGORIES.has(c.categoryKey));
-  const fusakaInactive = inactiveSeries.filter((c) => FUSAKA_CATEGORIES.has(c.categoryKey));
-  const pectraInactive = inactiveSeries.filter((c) => PECTRA_CATEGORIES.has(c.categoryKey));
-  const dencunInactive = inactiveSeries.filter((c) => DENCUN_CATEGORIES.has(c.categoryKey));
-  const generalInactive = inactiveSeries.filter((c) => !isForkAffiliated(c.categoryKey));
+  const promotedKeys = new Set(cardItems.filter((c) => c.activeKeys.length === 0).map((c) => c.categoryKey));
+  const remainingInactive = inactiveSeries.filter((c) => !promotedKeys.has(c.categoryKey));
+  const glamsterdamInactive = remainingInactive.filter((c) => GLAMSTERDAM_CATEGORIES.has(c.categoryKey));
+  const fusakaInactive = remainingInactive.filter((c) => FUSAKA_CATEGORIES.has(c.categoryKey));
+  const pectraInactive = remainingInactive.filter((c) => PECTRA_CATEGORIES.has(c.categoryKey));
+  const dencunInactive = remainingInactive.filter((c) => DENCUN_CATEGORIES.has(c.categoryKey));
+  const generalInactive = remainingInactive.filter((c) => !isForkAffiliated(c.categoryKey));
 
   useMetaTags({
     title: 'Devnet Tracker - Forkcast',

--- a/src/components/devnets/GlamsterdamPrioritizationSection.tsx
+++ b/src/components/devnets/GlamsterdamPrioritizationSection.tsx
@@ -16,7 +16,6 @@ import {
 import { getInclusionStageColor } from '../../utils/colors';
 import { InclusionStage } from '../../types';
 import { EipAggregateStance } from '../../types/prioritization';
-import { useDevnetNetworks } from '../../hooks/useDevnetNetworks';
 import {
   compareExecutionSpecTestCounts,
   getExecutionSpecTestCaseCount,
@@ -24,45 +23,26 @@ import {
   getExecutionSpecTestDirectoryUrl,
   type ExecutionSpecTestCount,
 } from '../../domain/execution-specs/execution-specs';
-import devnetDataRaw from '../../data/devnets/glamsterdam.json';
-
-
-const devnetData = devnetDataRaw as {
-  upgrade: string;
-  lastUpdated: string;
-  devnets: Array<{
-    id: string;
-    type: string;
-    headliner?: string;
-    version: number;
-    launchDate: string;
-    eips: number[];
-    updatedEips?: number[];
-    optionalEips?: number[];
-    isTarget?: boolean;
-  }>;
-};
+import { getAllDevnetSpecIds, getDevnetSpec } from '../../data/devnet-specs';
 
 type SortField = 'eip' | 'complexity' | 'support' | 'stage' | 'devnets' | 'tests';
 type SortDirection = 'asc' | 'desc';
 
 const GAS_REPRICING_EIPS = new Set([2780, 7778, 7904, 7976, 7981, 8037, 8038]);
 
+const GLAMSTERDAM_SERIES = new Set(['bal', 'epbs', 'glamsterdam']);
+
 interface DevnetInfo {
   id: string;
-  type: string;
   headliner: string;
   version: number;
-  launchDate?: string;
-  isTarget?: boolean;
-  optional?: boolean;
 }
 
-/** Derive a headliner label from the devnet id (e.g. "glamsterdam-devnet-0" → "GLAMSTERDAM"). */
-function deriveHeadliner(devnet: { id: string; headliner?: string }): string {
-  if (devnet.headliner) return devnet.headliner;
-  const match = devnet.id.match(/^(.+)-devnet-\d+$/);
-  return match ? match[1].toUpperCase() : devnet.id.toUpperCase();
+/** Parse "bal-devnet-3" → { series: "bal", version: 3 } */
+function parseDevnetId(id: string): { series: string; version: number } | null {
+  const match = id.match(/^(.+)-devnet-(\d+)$/);
+  if (!match) return null;
+  return { series: match[1], version: parseInt(match[2], 10) };
 }
 
 interface CombinedEipData {
@@ -76,35 +56,39 @@ interface CombinedEipData {
   testCount: ExecutionSpecTestCount | null;
 }
 
-function buildDevnetMap(activeKeys: Set<string>): Map<number, DevnetInfo[]> {
+/**
+ * For each EIP, find the most recent devnet per series that includes it.
+ * Sources data from scraped spec files so new devnets appear automatically.
+ */
+function buildDevnetMap(): Map<number, DevnetInfo[]> {
+  // Find the latest spec per glamsterdam-affiliated series
+  const latestBySeriesMap = new Map<string, { id: string; series: string; version: number }>();
+  for (const specId of getAllDevnetSpecIds()) {
+    const parsed = parseDevnetId(specId);
+    if (!parsed || !GLAMSTERDAM_SERIES.has(parsed.series)) continue;
+    const existing = latestBySeriesMap.get(parsed.series);
+    if (!existing || parsed.version > existing.version) {
+      latestBySeriesMap.set(parsed.series, { id: specId, ...parsed });
+    }
+  }
+
+  // Build EIP → DevnetInfo[] from the latest spec per series
+  const raw = new Map<number, Map<string, DevnetInfo>>();
+  for (const entry of latestBySeriesMap.values()) {
+    const spec = getDevnetSpec(entry.id);
+    if (!spec) continue;
+    const headliner = entry.series.toUpperCase();
+    const info: DevnetInfo = { id: entry.id, headliner, version: entry.version };
+
+    for (const eip of spec.eips) {
+      if (!raw.has(eip.number)) raw.set(eip.number, new Map());
+      raw.get(eip.number)!.set(headliner, info);
+    }
+  }
+
   const map = new Map<number, DevnetInfo[]>();
-  for (const devnet of devnetData.devnets) {
-    if (!activeKeys.has(devnet.id)) continue;
-    for (const eipId of devnet.eips) {
-      const existing = map.get(eipId) || [];
-      existing.push({
-        id: devnet.id,
-        type: devnet.type,
-        headliner: deriveHeadliner(devnet),
-        version: devnet.version,
-        launchDate: devnet.launchDate,
-        isTarget: devnet.isTarget,
-      });
-      map.set(eipId, existing);
-    }
-    for (const eipId of devnet.optionalEips || []) {
-      const existing = map.get(eipId) || [];
-      existing.push({
-        id: devnet.id,
-        type: devnet.type,
-        headliner: deriveHeadliner(devnet),
-        version: devnet.version,
-        launchDate: devnet.launchDate,
-        isTarget: devnet.isTarget,
-        optional: true,
-      });
-      map.set(eipId, existing);
-    }
+  for (const [eipId, byHeadliner] of raw) {
+    map.set(eipId, Array.from(byHeadliner.values()));
   }
   return map;
 }
@@ -154,17 +138,8 @@ const GlamsterdamPrioritizationSection: React.FC = () => {
   };
 
   const { aggregates: priorityAggregates } = usePrioritizationData('glamsterdam');
-  const { activeSeries } = useDevnetNetworks();
 
-  const devnetMap = useMemo(() => {
-    const activeKeys = new Set<string>();
-    for (const series of activeSeries) {
-      for (const key of series.activeKeys) {
-        activeKeys.add(key);
-      }
-    }
-    return buildDevnetMap(activeKeys);
-  }, [activeSeries]);
+  const devnetMap = useMemo(() => buildDevnetMap(), []);
 
   const stageOptions = [
     'Included',
@@ -481,12 +456,13 @@ const GlamsterdamPrioritizationSection: React.FC = () => {
                     {getStageAbbreviation(item.stage)}
                   </span>
                   {item.devnets.map((devnet) => (
-                    <span
+                    <Link
                       key={devnet.id}
-                      className={`inline-block px-1.5 py-0.5 text-[10px] font-medium rounded ${getDevnetColor(devnet.headliner)}`}
+                      to={`/devnets/${devnet.id}`}
+                      className={`inline-block px-1.5 py-0.5 text-[10px] font-medium rounded hover:opacity-80 transition-opacity ${getDevnetColor(devnet.headliner)}`}
                     >
                       {devnet.id}
-                    </span>
+                    </Link>
                   ))}
                 </div>
                 <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
@@ -561,7 +537,7 @@ const GlamsterdamPrioritizationSection: React.FC = () => {
                   onClick={() => handleSort('devnets')}
                 >
                   <div className="flex items-center gap-2">
-                    Active Devnets
+                    Devnets
                     <SortIcon field="devnets" />
                   </div>
                 </th>
@@ -654,13 +630,14 @@ const GlamsterdamPrioritizationSection: React.FC = () => {
                             {item.devnets
                               .sort((a, b) => a.version - b.version)
                               .map((devnet) => (
-                                <span
+                                <Link
                                   key={devnet.id}
-                                  className={`inline-block px-1.5 py-0.5 text-[10px] font-medium rounded ${getDevnetColor(devnet.headliner)}`}
-                                  title={devnet.optional ? `${devnet.id} (optional)` : devnet.id}
+                                  to={`/devnets/${devnet.id}`}
+                                  className={`inline-block px-1.5 py-0.5 text-[10px] font-medium rounded hover:opacity-80 transition-opacity ${getDevnetColor(devnet.headliner)}`}
+                                  title={devnet.id}
                                 >
-                                  {devnet.id}{devnet.optional ? '*' : ''}
-                                </span>
+                                  {devnet.id}
+                                </Link>
                               ))}
                           </div>
                         ) : (

--- a/src/data/devnet-specs.ts
+++ b/src/data/devnet-specs.ts
@@ -7,7 +7,8 @@ function isDevnetSpec(obj: unknown): obj is DevnetSpec {
     typeof obj === 'object' &&
     obj !== null &&
     'id' in obj &&
-    !('upgrade' in obj)
+    !('upgrade' in obj) &&
+    !(obj as Record<string, unknown>).canceled
   );
 }
 

--- a/src/data/devnets/epbs-devnet-2.json
+++ b/src/data/devnets/epbs-devnet-2.json
@@ -2,7 +2,8 @@
   "id": "epbs-devnet-2",
   "title": "epbs-devnet-2",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/epbs-devnet-2",
-  "scrapedAt": "2026-05-21T07:29:13.172Z",
+  "scrapedAt": "2026-05-18T18:45:01.398Z",
+  "canceled": true,
   "announcements": [
     "epbs-devnet-2 will no longer happen. For latest info please head over to https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-0",
     "Everything below is outdated!!"

--- a/src/data/devnets/glamsterdam.json
+++ b/src/data/devnets/glamsterdam.json
@@ -1,6 +1,6 @@
 {
   "upgrade": "glamsterdam",
-  "lastUpdated": "2026-05-06",
+  "lastUpdated": "2026-05-21",
   "devnets": [
     {
       "id": "bal-devnet-0",
@@ -106,6 +106,15 @@
       "launchDate": "2026-05-06",
       "eips": [7708, 7732, 7778, 7843, 7928, 7954, 8024, 7976, 7981, 8061],
       "optionalEips": [7975, 8159]
+    },
+    {
+      "id": "bal-devnet-7",
+      "type": "headliner",
+      "headliner": "BAL",
+      "version": 7,
+      "launchDate": "2026-05-18",
+      "eips": [7928, 8024, 7843, 7708, 7778, 8037, 7954, 7976, 7981, 7975, 8159],
+      "updatedEips": [8037]
     }
   ]
 }

--- a/src/hooks/useDevnetNetworks.ts
+++ b/src/hooks/useDevnetNetworks.ts
@@ -54,6 +54,21 @@ function findActiveNetworks(
   return results;
 }
 
+/** Find the highest version number across all networks (any status) for a category. */
+function findHighestVersion(
+  categoryKey: string,
+  networks: Record<string, NetworkEntry>,
+): number | null {
+  let max: number | null = null;
+  for (const key of Object.keys(networks)) {
+    const match = key.match(new RegExp(`^${categoryKey}-.*-(\\d+)$`));
+    if (!match) continue;
+    const version = parseInt(match[1], 10);
+    if (max === null || version > max) max = version;
+  }
+  return max;
+}
+
 export function useDevnetNetworks(): UseDevnetNetworksResult {
   const [activeSeries, setActiveSeries] = useState<ActiveDevnetSeries[]>(cachedSeries || []);
   const [inactiveSeries, setInactiveSeries] = useState<InactiveDevnetSeries[]>(cachedInactive || []);
@@ -80,6 +95,7 @@ export function useDevnetNetworks(): UseDevnetNetworksResult {
             categoryKey,
             displayName: meta.displayName,
             description: meta.description,
+            highestKnownVersion: findHighestVersion(categoryKey, data.networks),
           });
           continue;
         }

--- a/src/types/devnet-networks.ts
+++ b/src/types/devnet-networks.ts
@@ -69,6 +69,8 @@ export interface InactiveDevnetSeries {
   categoryKey: string;
   displayName: string;
   description: string;
+  /** Highest version number ever seen for this category (active or inactive), or null. */
+  highestKnownVersion: number | null;
 }
 
 /** Processed type used by components */


### PR DESCRIPTION
bug: upcoming devnets are only shown on "active" devnets, i.e., those that have one devnet currently running. this doesnt gel with reality though: glam-devnet-3 is already shut down, glam-devnet-4 is upcoming, but not displayed, because the series is now "inactive."

couple other little UX updates included: inclusion page automation, labels in the table link to the devnets, table displays more recent devnet in a series even if inactive.