### PR TITLE
devnet: handle complex titles, required status

### DIFF
--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -73,6 +73,9 @@ function parseStatusCell(text) {
     return 'new_optional';
   if (t.includes(':new:') || t.includes('🆕')) return 'new';
   if (/^optional$/i.test(t)) return 'optional';
+  if (t.includes(':exclamation:') || t.includes('❗')) {
+    if (/required/i.test(t)) return 'required';
+  }
   return null;
 }
 
@@ -83,11 +86,11 @@ function parseEipTable(md) {
   //   B) | status_emoji | [EIP-NNNN](url) | title |  (emoji before EIP link)
   const eips = [];
   const rowRegex =
-    /\|([^[]*?)\[EIP-(\d+)\]\((https?:\/\/[^\s)]+)\)\s*\|\s*([^|]+?)\s*\|\s*([^|\n]*)/g;
+    /\|([^[\n]*?)\[EIP-(\d+)\]\((https?:\/\/[^\s)]+)\)\s*\|\s*([^|\n]+)[^\S\n]*(?:\|[^\S\n]*([^|\n]*))?/g;
   let match;
   while ((match = rowRegex.exec(md)) !== null) {
     const [, preEip, numberStr, url, title, postTitle] = match;
-    const status = parseStatusCell(preEip) || parseStatusCell(postTitle);
+    const status = parseStatusCell(preEip) || (postTitle ? parseStatusCell(postTitle) : null);
 
     eips.push({
       number: parseInt(numberStr, 10),

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -47,6 +47,13 @@ function StatusBadge({ status }: { status: EipDevnetStatus }) {
       </span>
     );
   }
+  if (status === 'required') {
+    return (
+      <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300">
+        Required
+      </span>
+    );
+  }
   const labels: Record<string, string> = {
     updated: 'Updated',
     new: 'New',

--- a/src/data/devnets/bal-devnet-7.json
+++ b/src/data/devnets/bal-devnet-7.json
@@ -2,7 +2,7 @@
   "id": "bal-devnet-7",
   "title": "bal-devnet-7",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/bal-devnet-7",
-  "scrapedAt": "2026-05-21T07:29:10.236Z",
+  "scrapedAt": "2026-05-21T17:47:32.098Z",
   "announcements": [
     "bal-devnet-7 target launch: **Monday 18.05** (subject to ACDT today).",
     "**Last `bal-` prefixed devnet.** Consolidates the bal-devnet-3 optimisations with the EIP-8037 spec changes finalised since bal-devnet-6 — confirmed in [`tests-bal@v7.0.0`](https://github.com/ethereum/execution-specs/releases/tag/tests-bal@v7.0.0). Future devnet releases will be prefixed `glamsterdam-`.",

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-3",
   "title": "glamsterdam-devnet-3",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-3",
-  "scrapedAt": "2026-05-21T07:29:15.452Z",
+  "scrapedAt": "2026-05-21T16:02:44.872Z",
   "sameSpecAs": "glamsterdam-devnet-2",
   "announcements": [],
   "eips": [

--- a/src/data/devnets/glamsterdam-devnet-4.json
+++ b/src/data/devnets/glamsterdam-devnet-4.json
@@ -2,7 +2,7 @@
   "id": "glamsterdam-devnet-4",
   "title": "glamsterdam-devnet-4",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-4",
-  "scrapedAt": "2026-05-21T07:29:16.030Z",
+  "scrapedAt": "2026-05-21T17:52:14.268Z",
   "announcements": [
     "glamsterdam-devnet-4 targets to launch in late May 2026.",
     "**First `glamsterdam-` prefixed CL+EL devnet** combining `consensus-specs` **v1.7.0-alpha.8** with the **bal-devnet-7** EL feature set, plus the new `targetGasLimit` engine API field ([execution-apis#796](https://github.com/ethereum/execution-apis/pull/796) ↔ [consensus-specs#5235](https://github.com/ethereum/consensus-specs/pull/5235)).",
@@ -50,7 +50,7 @@
     {
       "number": 7975,
       "title": "eth/70 - partial block receipt lists",
-      "status": null,
+      "status": "required",
       "url": "https://eips.ethereum.org/EIPS/eip-7975"
     },
     {
@@ -72,15 +72,21 @@
       "url": "https://eips.ethereum.org/EIPS/eip-8024"
     },
     {
+      "number": 8037,
+      "title": "State Creation Gas — CPSB=1530, system-call gas bump, halt/revert + SELFDESTRUCT refunds",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-8037"
+    },
+    {
       "number": 8061,
       "title": "Increase exit and consolidation churn",
-      "status": "updated",
+      "status": null,
       "url": "https://eips.ethereum.org/EIPS/eip-8061"
     },
     {
       "number": 8159,
       "title": "eth/71 - Block Access List Exchange",
-      "status": null,
+      "status": "required",
       "url": "https://eips.ethereum.org/EIPS/eip-8159"
     }
   ],

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -1,4 +1,4 @@
-export type EipDevnetStatus = 'updated' | 'new' | 'new_optional' | 'optional' | null;
+export type EipDevnetStatus = 'updated' | 'new' | 'new_optional' | 'optional' | 'required' | null;
 export type ClientSupportStatus =
   | 'supported'
   | 'not_supported'


### PR DESCRIPTION
bug: glam-devnet-4 had "required" statuses not reflected in the eip table + 8037 was omitted from the table by the title regex