### PR TITLE
Fix mobile decision list wrapping

### DIFF
--- a/src/components/DecisionsPage.tsx
+++ b/src/components/DecisionsPage.tsx
@@ -157,12 +157,14 @@ const DecisionsPage: React.FC = () => {
                     return (
                       <li
                         key={index}
-                        className="text-sm before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                        className="arrow-list-item text-sm text-slate-600 dark:text-slate-400"
                       >
-                        {isStructured
-                          ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                          : decision.original_text
-                        }
+                        <span className="arrow-list-content">
+                          {isStructured
+                            ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
+                            : decision.original_text
+                          }
+                        </span>
                       </li>
                     );
                   })}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -353,11 +353,13 @@ const HomePage = () => {
                     return (
                       <li
                         key={i}
-                        className="text-sm before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                        className="arrow-list-item text-sm text-slate-600 dark:text-slate-400"
                       >
-                        {isStructured
-                          ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                          : decision.original_text}
+                        <span className="arrow-list-content">
+                          {isStructured
+                            ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
+                            : decision.original_text}
+                        </span>
                       </li>
                     );
                   })}

--- a/src/components/call/CallPlanPage.tsx
+++ b/src/components/call/CallPlanPage.tsx
@@ -1026,12 +1026,14 @@ const CallPlanPage: React.FC = () => {
                                           return (
                                             <li
                                               key={index}
-                                              className="text-sm before:content-['\2192'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                                              className="arrow-list-item text-sm text-slate-600 dark:text-slate-400"
                                             >
-                                              {isStructured
-                                                ? <StructuredDecisionContent decision={decision} eipMap={eipMap} />
-                                                : decision.original_text
-                                              }
+                                              <span className="arrow-list-content">
+                                                {isStructured
+                                                  ? <StructuredDecisionContent decision={decision} eipMap={eipMap} />
+                                                  : decision.original_text
+                                                }
+                                              </span>
                                             </li>
                                           );
                                         })}
@@ -1041,9 +1043,11 @@ const CallPlanPage: React.FC = () => {
                                         {tldrData.decisions.map((decision, index) => (
                                           <li
                                             key={index}
-                                            className="text-sm before:content-['\2192'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                                            className="arrow-list-item text-sm text-slate-600 dark:text-slate-400"
                                           >
-                                            {decision.decision}
+                                            <span className="arrow-list-content">
+                                              {decision.decision}
+                                            </span>
                                           </li>
                                         ))}
                                       </ul>

--- a/src/components/call/KeyDecisionsSection.tsx
+++ b/src/components/call/KeyDecisionsSection.tsx
@@ -277,20 +277,22 @@ const KeyDecisionsSection: React.FC<KeyDecisionsSectionProps> = ({
           <li
             key={index}
             onClick={(e) => handleTimestampClick(decision.timestamp, e)}
-            className="text-sm cursor-pointer group before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+            className="arrow-list-item text-sm cursor-pointer group text-slate-600 dark:text-slate-400"
           >
-            <span className={`rounded px-1 py-0.5 transition-colors inline ${
-              isSelected
-                ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
-                : 'hover:text-slate-900 dark:hover:text-slate-100'
-            }`}>
-              {isStructured
-                ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                : decision.original_text
-              }
-            </span>
-            <span className="text-xs text-slate-400 dark:text-slate-500 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              {getDisplayTimestamp(decision.timestamp)}
+            <span className="arrow-list-content">
+              <span className={`rounded px-1 py-0.5 transition-colors inline ${
+                isSelected
+                  ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
+                  : 'hover:text-slate-900 dark:hover:text-slate-100'
+              }`}>
+                {isStructured
+                  ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
+                  : decision.original_text
+                }
+              </span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                {getDisplayTimestamp(decision.timestamp)}
+              </span>
             </span>
           </li>
         );

--- a/src/components/call/TldrSummary.tsx
+++ b/src/components/call/TldrSummary.tsx
@@ -214,17 +214,19 @@ const TldrSummary: React.FC<TldrSummaryProps> = ({
                     <li
                       key={index}
                       onClick={(e) => handleTimestampClick(decision.timestamp, e)}
-                      className="text-sm cursor-pointer group before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                      className="arrow-list-item text-sm cursor-pointer group text-slate-600 dark:text-slate-400"
                     >
-                      <span className={`rounded px-1 py-0.5 transition-colors inline ${
-                        isSelected
-                          ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
-                          : 'hover:text-slate-900 dark:hover:text-slate-100'
-                      }`}>
-                        {decision.decision}
-                      </span>
-                      <span className="text-xs text-slate-400 dark:text-slate-500 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                        {getDisplayTimestamp(decision.timestamp)}
+                      <span className="arrow-list-content">
+                        <span className={`rounded px-1 py-0.5 transition-colors inline ${
+                          isSelected
+                            ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
+                            : 'hover:text-slate-900 dark:hover:text-slate-100'
+                        }`}>
+                          {decision.decision}
+                        </span>
+                        <span className="text-xs text-slate-400 dark:text-slate-500 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          {getDisplayTimestamp(decision.timestamp)}
+                        </span>
                       </span>
                     </li>
                   );
@@ -248,17 +250,19 @@ const TldrSummary: React.FC<TldrSummaryProps> = ({
                   <li
                     key={index}
                     onClick={(e) => handleTimestampClick(item.timestamp, e)}
-                    className="text-sm cursor-pointer group before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                    className="arrow-list-item text-sm cursor-pointer group text-slate-600 dark:text-slate-400"
                   >
-                    <span className={`rounded px-1 py-0.5 transition-colors inline ${
-                      isSelected
-                        ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
-                        : 'hover:text-slate-900 dark:hover:text-slate-100'
-                    }`}>
-                      <span className="font-normal">{item.owner}:</span> {item.action}
-                    </span>
-                    <span className="text-xs text-slate-400 dark:text-slate-400 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      {getDisplayTimestamp(item.timestamp)}
+                    <span className="arrow-list-content">
+                      <span className={`rounded px-1 py-0.5 transition-colors inline ${
+                        isSelected
+                          ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
+                          : 'hover:text-slate-900 dark:hover:text-slate-100'
+                      }`}>
+                        <span className="font-normal">{item.owner}:</span> {item.action}
+                      </span>
+                      <span className="text-xs text-slate-400 dark:text-slate-400 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {getDisplayTimestamp(item.timestamp)}
+                      </span>
                     </span>
                   </li>
                 );
@@ -281,17 +285,19 @@ const TldrSummary: React.FC<TldrSummaryProps> = ({
                   <li
                     key={index}
                     onClick={(e) => handleTimestampClick(target.timestamp, e)}
-                    className="text-sm cursor-pointer group before:content-['→'] before:mr-2 before:text-slate-400 dark:before:text-slate-500 text-slate-600 dark:text-slate-400"
+                    className="arrow-list-item text-sm cursor-pointer group text-slate-600 dark:text-slate-400"
                   >
-                    <span className={`rounded px-1 py-0.5 transition-colors inline ${
-                      isSelected
-                        ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
-                        : 'hover:text-slate-900 dark:hover:text-slate-100'
-                    }`}>
-                      {target.target}
-                    </span>
-                    <span className="text-xs text-slate-400 dark:text-slate-400 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      {getDisplayTimestamp(target.timestamp)}
+                    <span className="arrow-list-content">
+                      <span className={`rounded px-1 py-0.5 transition-colors inline ${
+                        isSelected
+                          ? 'bg-yellow-50 dark:bg-yellow-900/50 text-slate-900 dark:text-slate-100'
+                          : 'hover:text-slate-900 dark:hover:text-slate-100'
+                      }`}>
+                        {target.target}
+                      </span>
+                      <span className="text-xs text-slate-400 dark:text-slate-400 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {getDisplayTimestamp(target.timestamp)}
+                      </span>
                     </span>
                   </li>
                 );

--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,27 @@
 
 /* Custom dark mode styles for the application */
 @layer components {
+  .arrow-list-item {
+    display: grid;
+    grid-template-columns: 1rem minmax(0, 1fr);
+    column-gap: 0.5rem;
+    align-items: start;
+  }
+
+  .arrow-list-item::before {
+    content: '→';
+    color: var(--color-slate-400);
+  }
+
+  .dark .arrow-list-item::before {
+    color: var(--color-slate-500);
+  }
+
+  .arrow-list-content {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
   .dark .bg-slate-50 {
     background-color: #000004;
   }


### PR DESCRIPTION
## Summary

Fixes mobile wrapping for decision-style list rows by giving the arrow and content separate layout columns.

## Root Cause

The previous arrow marker was an inline pseudo-element. On narrow viewports, long structured decision text and EIP link groups wrapped without a stable content column, which could make the Decisions card layout look broken.

## Changes

- Added shared `arrow-list-item` and `arrow-list-content` styles.
- Applied the layout to key decisions, fallback decisions, action items, targets, recent decisions, and call-plan decisions.
- Preserved the existing visual arrow treatment while allowing long content to wrap inside the card boundary.

## Validation

- `npm run lint`
- `npm run build`
- Checked the affected call page in a mobile-sized viewport.