### PR TITLE
eip: display dependent eips

### DIFF
--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -18,6 +18,7 @@
     "layer": { "type": "string" },
     "collection": { "type": "string" },
     "specificationUrl": { "type": "string" },
+    "requires": { "type": "array", "items": { "type": "integer" } },
     "laymanDescription": { "type": "string" },
     "northStars": {
       "type": "array",

--- a/scripts/fetch-all-eips.mjs
+++ b/scripts/fetch-all-eips.mjs
@@ -15,7 +15,7 @@ const BATCH_DELAY = 200;
 
 // Official metadata fields that are always synced from upstream.
 // All other fields (forkRelationships, laymanDescription, benefits, etc.) are preserved.
-const METADATA_FIELDS = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type', 'discussionLink'];
+const METADATA_FIELDS = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type', 'discussionLink', 'requires'];
 
 // EIPs with status "Moved" (e.g., ERCs moved to their own repo) are excluded
 const EXCLUDED_STATUSES = new Set(['Moved']);
@@ -89,6 +89,7 @@ function buildNewEipJson(eipNumber, mapped) {
     ...(mapped.category && { category: mapped.category }),
     createdDate: mapped.createdDate || '',
     ...(mapped.discussionLink && { discussionLink: mapped.discussionLink }),
+    ...(mapped.requires?.length && { requires: mapped.requires }),
     forkRelationships: [],
     tradeoffs: null,
   };

--- a/scripts/fetch-all-eips.mjs
+++ b/scripts/fetch-all-eips.mjs
@@ -13,9 +13,10 @@ const MANIFEST_PATH = path.join(EIPS_MD_DIR, 'manifest.json');
 const BATCH_SIZE = 5;
 const BATCH_DELAY = 200;
 
-// Official metadata fields that are always synced from upstream.
+// Official metadata fields that are synced from upstream.
 // All other fields (forkRelationships, laymanDescription, benefits, etc.) are preserved.
 const METADATA_FIELDS = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type', 'discussionLink', 'requires'];
+const OPTIONAL_METADATA_FIELDS = new Set(['category', 'discussionLink', 'requires']);
 
 // EIPs with status "Moved" (e.g., ERCs moved to their own repo) are excluded
 const EXCLUDED_STATUSES = new Set(['Moved']);
@@ -103,6 +104,14 @@ function normalize(str) {
   return str.toString().trim().replace(/\s+/g, ' ');
 }
 
+function officialMetadataValue(field, eipNumber, mapped) {
+  if (field === 'title') {
+    return `EIP-${eipNumber}: ${mapped.title || ''}`;
+  }
+
+  return mapped[field];
+}
+
 /**
  * Update an existing EIP's official metadata fields, preserving all other fields.
  * Returns true if any field changed.
@@ -112,15 +121,16 @@ function updateExistingEip(eipNumber, existing, mapped) {
   let changed = false;
 
   for (const field of METADATA_FIELDS) {
-    let officialValue;
-    if (field === 'title') {
-      officialValue = `EIP-${eipNumber}: ${mapped.title || ''}`;
-    } else {
-      officialValue = mapped[field];
-    }
+    const officialValue = officialMetadataValue(field, eipNumber, mapped);
 
-    // Skip undefined/null official values (don't erase local data)
-    if (officialValue === undefined || officialValue === null) continue;
+    // Optional upstream metadata should be removed locally when upstream omits it.
+    if (officialValue === undefined || officialValue === null) {
+      if (OPTIONAL_METADATA_FIELDS.has(field) && field in updated) {
+        delete updated[field];
+        changed = true;
+      }
+      continue;
+    }
 
     if (normalize(existing[field]) !== normalize(officialValue)) {
       updated[field] = officialValue;

--- a/scripts/lib/eip-parsing.mjs
+++ b/scripts/lib/eip-parsing.mjs
@@ -40,6 +40,10 @@ export function parseFrontmatter(content) {
  * Map official frontmatter keys to local schema keys
  */
 export function mapOfficialToLocal(official) {
+  const requires = official.requires
+    ? official.requires.split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n))
+    : undefined;
+
   return {
     title: official.title,
     description: official.description,
@@ -49,5 +53,6 @@ export function mapOfficialToLocal(official) {
     createdDate: official.created,
     type: official.type,
     discussionLink: official['discussions-to'] || undefined,
+    ...(requires?.length && { requires }),
   };
 }

--- a/scripts/lib/eip-parsing.mjs
+++ b/scripts/lib/eip-parsing.mjs
@@ -36,14 +36,31 @@ export function parseFrontmatter(content) {
   return frontmatter;
 }
 
+function parseRequires(value) {
+  if (value === undefined || value === null) return [];
+
+  const raw = String(value).trim();
+  if (raw === '') return [];
+
+  return raw.split(',').map((part) => {
+    const trimmed = part.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`Invalid requires EIP number: ${trimmed}`);
+    }
+
+    const eipNumber = Number(trimmed);
+    if (!Number.isSafeInteger(eipNumber) || eipNumber <= 0) {
+      throw new Error(`Invalid requires EIP number: ${trimmed}`);
+    }
+
+    return eipNumber;
+  });
+}
+
 /**
  * Map official frontmatter keys to local schema keys
  */
 export function mapOfficialToLocal(official) {
-  const requires = official.requires
-    ? official.requires.split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n))
-    : undefined;
-
   return {
     title: official.title,
     description: official.description,
@@ -53,6 +70,6 @@ export function mapOfficialToLocal(official) {
     createdDate: official.created,
     type: official.type,
     discussionLink: official['discussions-to'] || undefined,
-    ...(requires?.length && { requires }),
+    ...(official.requires && { requires: parseRequires(official.requires) }),
   };
 }

--- a/scripts/validate-eip-metadata.mjs
+++ b/scripts/validate-eip-metadata.mjs
@@ -10,7 +10,8 @@ const EIPS_DIR = path.join(__dirname, '../src/data/eips');
 const OFFICIAL_EIP_BASE_URL = 'https://raw.githubusercontent.com/ethereum/EIPs/refs/heads/master/EIPS/eip-';
 
 // Fields to compare between local and official
-const FIELDS_TO_CHECK = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type'];
+const FIELDS_TO_CHECK = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type', 'discussionLink', 'requires'];
+const OPTIONAL_METADATA_FIELDS = new Set(['category', 'discussionLink', 'requires']);
 
 // Rate limiting: delay between requests (ms)
 const REQUEST_DELAY = 200;
@@ -158,6 +159,12 @@ function normalize(str) {
   return str.toString().trim().replace(/\s+/g, ' ');
 }
 
+function formatValue(value) {
+  if (value === undefined || value === null) return '(empty)';
+  if (Array.isArray(value)) return value.join(', ');
+  return value;
+}
+
 /**
  * Compare a field between local and official
  */
@@ -171,8 +178,8 @@ function compareField(fieldName, localValue, officialValue) {
 
   return {
     field: fieldName,
-    local: localValue || '(empty)',
-    official: officialValue || '(empty)',
+    local: formatValue(localValue),
+    official: formatValue(officialValue),
   };
 }
 
@@ -224,6 +231,8 @@ function updateLocalEip(eipNumber, localEip, officialMapped) {
       }
     } else if (officialMapped[field] !== undefined && officialMapped[field] !== null) {
       updated[field] = officialMapped[field];
+    } else if (OPTIONAL_METADATA_FIELDS.has(field) && field in updated) {
+      delete updated[field];
     }
   }
 
@@ -315,7 +324,7 @@ async function validateMetadata() {
 
     for (const field of FIELDS_TO_CHECK) {
       let localValue = localEip[field];
-      let officialValue = officialMapped[field];
+      const officialValue = officialMapped[field];
 
       // Special handling for title (local has "EIP-XXXX:" prefix)
       if (field === 'title') {

--- a/src/components/eip/EipDependents.tsx
+++ b/src/components/eip/EipDependents.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { EIP } from '../../types/eip';
+import { getProposalPrefix, getLaymanTitle } from '../../utils';
+
+interface EipDependentsProps {
+  dependents: EIP[];
+}
+
+export const EipDependents: React.FC<EipDependentsProps> = ({ dependents }) => {
+  const sorted = [...dependents].sort((a, b) => a.id - b.id);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        {sorted.length} EIP{sorted.length !== 1 ? 's' : ''} depend{sorted.length === 1 ? 's' : ''} on this proposal.
+      </p>
+      <div className="space-y-2">
+        {sorted.map((eip) => (
+          <Link
+            key={eip.id}
+            to={`/eips/${eip.id}`}
+            className="block bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg p-4 hover:border-purple-400 dark:hover:border-purple-500 transition-colors"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-mono text-sm text-slate-400 dark:text-slate-400">
+                {getProposalPrefix(eip)}-{eip.id}
+              </span>
+              <span className="px-2 py-0.5 text-xs font-medium rounded bg-slate-100 dark:bg-slate-600 text-slate-600 dark:text-slate-300">
+                {eip.status}
+              </span>
+            </div>
+            <h4 className="text-sm font-medium text-slate-900 dark:text-slate-100">
+              {getLaymanTitle(eip)}
+            </h4>
+            {eip.description && (
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
+                {eip.description}
+              </p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -400,6 +400,8 @@ export const EipPage: React.FC = () => {
     return <Navigate to="/" replace />;
   }
 
+  const requiredEipIds = eip.requires ?? [];
+
   const handleExternalLinkClick = (linkType: string, url: string) => {
     trackLinkClick(linkType, url);
   };
@@ -496,8 +498,8 @@ export const EipPage: React.FC = () => {
             </p>
 
             {/* Authors & Requires */}
-            <div className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-              <span>
+            <div className="mt-3 space-y-2 text-sm text-slate-500 dark:text-slate-400">
+              <div>
                 Authors:{' '}
                 {parseAuthors(eip.author).map((author, index, arr) => (
                   <span key={index}>
@@ -516,17 +518,15 @@ export const EipPage: React.FC = () => {
                     {index < arr.length - 1 && ', '}
                   </span>
                 ))}
-              </span>
-              {eip.requires && eip.requires.length > 0 && (
-                <>
-                  <span className="mx-2 text-slate-300 dark:text-slate-600">|</span>
-                  <span className="text-xs inline-flex items-center gap-1.5 flex-wrap">
-                    Requires:{' '}
-                    {eip.requires.map((reqId, i) => {
+              </div>
+              {requiredEipIds.length > 0 && (
+                <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-1">
+                  <span>Requires:</span>
+                  <span className="inline-flex flex-wrap items-baseline gap-x-1.5 gap-y-1">
+                    {requiredEipIds.map((reqId, i) => {
                       const reqEip = eipById.get(reqId);
                       return (
                         <span key={reqId} className="inline-flex items-center">
-                          {i > 0 && <span className="mr-1.5">,</span>}
                           {reqEip ? (
                             <Link
                               to={`/eips/${reqId}`}
@@ -562,11 +562,12 @@ export const EipPage: React.FC = () => {
                               EIP-{reqId}
                             </a>
                           )}
+                          {i < requiredEipIds.length - 1 && <span>,</span>}
                         </span>
                       );
                     })}
                   </span>
-                </>
+                </div>
               )}
             </div>
 
@@ -608,11 +609,11 @@ export const EipPage: React.FC = () => {
           </header>
 
           {/* View mode tabs */}
-          <div className="flex border-b border-slate-200 dark:border-slate-700">
+          <div className="flex overflow-x-auto border-b border-slate-200 dark:border-slate-700">
             {hasAnalysis && (
               <button
                 onClick={() => setViewMode('analysis')}
-                className={`px-6 py-3 text-sm font-medium transition-colors ${
+                className={`shrink-0 px-6 py-3 text-sm font-medium transition-colors ${
                   viewMode === 'analysis'
                     ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
                     : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
@@ -623,7 +624,7 @@ export const EipPage: React.FC = () => {
             )}
             <button
               onClick={() => setViewMode('spec')}
-              className={`px-6 py-3 text-sm font-medium transition-colors ${
+              className={`shrink-0 px-6 py-3 text-sm font-medium transition-colors ${
                 viewMode === 'spec'
                   ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
                   : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
@@ -633,7 +634,7 @@ export const EipPage: React.FC = () => {
             </button>
             <button
               onClick={() => setViewMode('history')}
-              className={`px-6 py-3 text-sm font-medium transition-colors ${
+              className={`shrink-0 px-6 py-3 text-sm font-medium transition-colors ${
                 viewMode === 'history'
                   ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
                   : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
@@ -644,7 +645,7 @@ export const EipPage: React.FC = () => {
             {hasDependents && (
               <button
                 onClick={() => setViewMode('dependents')}
-                className={`px-6 py-3 text-sm font-medium transition-colors ${
+                className={`shrink-0 px-6 py-3 text-sm font-medium transition-colors ${
                   viewMode === 'dependents'
                     ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
                     : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
@@ -897,7 +898,7 @@ export const EipPage: React.FC = () => {
       {/* Hover card for required EIPs */}
       {hoveredReq && reqTooltipPos && createPortal(
         <div
-          className="fixed z-50 pointer-events-none"
+          className="hidden md:block fixed z-50 pointer-events-none"
           style={{
             left: reqTooltipPos.x,
             top: reqTooltipPos.y,

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useCallback, useState, lazy, Suspense } from 'react';
+import { createPortal } from 'react-dom';
 import { Link, useParams, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { EIP } from '../../types/eip';
 import { eipsData } from '../../data/eips';
 import { useMetaTags } from '../../hooks/useMetaTags';
 import { useAnalytics } from '../../hooks/useAnalytics';
@@ -11,12 +13,14 @@ import {
   parseMarkdownLinks,
   parseAuthors,
   getEipLayer,
+  buildDependentsMap,
 } from '../../utils';
 import { Tooltip } from '../ui';
 import { EipTimeline } from './EipTimeline';
 import { EipSearch } from './EipSearch';
 import EipSearchModal from './EipSearchModal';
 import { EipSpecHistory } from './EipSpecHistory';
+import { EipDependents } from './EipDependents';
 import { useEipHistory } from '../../hooks/useEipHistory';
 import { isSearchHotkey } from '../search/searchShortcuts';
 import {
@@ -254,6 +258,8 @@ const LazyEipMarkdown = lazy(() =>
   ),
 );
 
+const dependentsMap = buildDependentsMap(eipsData);
+
 export const EipPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { trackLinkClick } = useAnalytics();
@@ -261,6 +267,8 @@ export const EipPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [upcomingCall, setUpcomingCall] = useState<UpcomingCall | null>(null);
+  const [hoveredReq, setHoveredReq] = useState<EIP | null>(null);
+  const [reqTooltipPos, setReqTooltipPos] = useState<{ x: number; y: number } | null>(null);
 
   const eipId = parseInt(id || '', 10);
   const eip = eipsData.find((e) => e.id === eipId);
@@ -280,13 +288,17 @@ export const EipPage: React.FC = () => {
     ),
   );
 
+  const dependents = dependentsMap.get(eipId) || [];
+  const hasDependents = dependents.length > 0;
+
   // View mode derived from URL ?tab= param
-  const validTabs = ['analysis', 'spec', 'history'] as const;
+  const validTabs = ['analysis', 'spec', 'dependents', 'history'] as const;
   type ViewMode = typeof validTabs[number];
   const defaultTab: ViewMode = hasAnalysis ? 'analysis' : 'spec';
   const tabParam = searchParams.get('tab') as ViewMode | null;
   const hasHash = typeof window !== 'undefined' && window.location.hash.length > 1;
-  const viewMode: ViewMode = tabParam && validTabs.includes(tabParam) ? tabParam : hasHash ? 'spec' : defaultTab;
+  const isValidTab = tabParam && validTabs.includes(tabParam) && (tabParam !== 'dependents' || hasDependents);
+  const viewMode: ViewMode = isValidTab ? tabParam : hasHash ? 'spec' : defaultTab;
 
   const setViewMode = (mode: ViewMode) => {
     const next = new URLSearchParams(searchParams);
@@ -433,26 +445,6 @@ export const EipPage: React.FC = () => {
                 <h1 className="text-2xl font-medium text-slate-900 dark:text-slate-100 leading-tight">
                   {getLaymanTitle(eip)}
                 </h1>
-                <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                  Authors:{' '}
-                  {parseAuthors(eip.author).map((author, index, arr) => (
-                    <span key={index}>
-                      {author.handle ? (
-                        <Tooltip text={`${author.handle} (click to copy)`} className="inline">
-                          <span
-                            className="cursor-pointer hover:text-slate-700 dark:hover:text-slate-200"
-                            onClick={() => navigator.clipboard.writeText(author.handle!)}
-                          >
-                            {author.name}
-                          </span>
-                        </Tooltip>
-                      ) : (
-                        <span>{author.name}</span>
-                      )}
-                      {index < arr.length - 1 && ', '}
-                    </span>
-                  ))}
-                </p>
               </div>
 
               {/* External links */}
@@ -500,6 +492,70 @@ export const EipPage: React.FC = () => {
             <p className="mt-4 text-slate-700 dark:text-slate-300 leading-relaxed">
               {parseMarkdownLinks(eip.description)}
             </p>
+
+            {/* Authors & Requires */}
+            <div className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+              <span>
+                Authors:{' '}
+                {parseAuthors(eip.author).map((author, index, arr) => (
+                  <span key={index}>
+                    {author.handle ? (
+                      <Tooltip text={`${author.handle} (click to copy)`} className="inline">
+                        <span
+                          className="cursor-pointer hover:text-slate-700 dark:hover:text-slate-200"
+                          onClick={() => navigator.clipboard.writeText(author.handle!)}
+                        >
+                          {author.name}
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      <span>{author.name}</span>
+                    )}
+                    {index < arr.length - 1 && ', '}
+                  </span>
+                ))}
+              </span>
+              {eip.requires && eip.requires.length > 0 && (
+                <>
+                  <span className="mx-2 text-slate-300 dark:text-slate-600">|</span>
+                  <span className="text-xs inline-flex items-center gap-1.5 flex-wrap">
+                    Requires:{' '}
+                    {eip.requires.map((reqId, i) => {
+                      const reqEip = eipsData.find((e) => e.id === reqId);
+                      return (
+                        <span key={reqId} className="inline-flex items-center">
+                          {i > 0 && <span className="mr-1.5">,</span>}
+                          <Link
+                            to={`/eips/${reqId}`}
+                            className="font-mono hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+                            style={{ borderBottom: '1px dotted currentColor' }}
+                            onMouseEnter={(e) => {
+                              if (!reqEip) return;
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              const tooltipWidth = 360;
+                              const padding = 8;
+                              let x = rect.left + rect.width / 2 - tooltipWidth / 2;
+                              if (x + tooltipWidth > window.innerWidth - padding) {
+                                x = window.innerWidth - tooltipWidth - padding;
+                              }
+                              if (x < padding) x = padding;
+                              setHoveredReq(reqEip);
+                              setReqTooltipPos({ x, y: rect.bottom + padding });
+                            }}
+                            onMouseLeave={() => {
+                              setHoveredReq(null);
+                              setReqTooltipPos(null);
+                            }}
+                          >
+                            EIP-{reqId}
+                          </Link>
+                        </span>
+                      );
+                    })}
+                  </span>
+                </>
+              )}
+            </div>
 
             {/* Breakout Call */}
             {callType && (callNav?.previous || upcomingCall) && (
@@ -572,6 +628,19 @@ export const EipPage: React.FC = () => {
             >
               History
             </button>
+            {hasDependents && (
+              <button
+                onClick={() => setViewMode('dependents')}
+                className={`px-6 py-3 text-sm font-medium transition-colors ${
+                  viewMode === 'dependents'
+                    ? 'text-purple-600 dark:text-purple-400 border-b-2 border-purple-600 dark:border-purple-400'
+                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
+                }`}
+              >
+                Dependents
+                <span className="ml-1.5 text-xs text-slate-400 dark:text-slate-400">{dependents.length}</span>
+              </button>
+            )}
           </div>
 
           {/* Body Content */}
@@ -749,6 +818,10 @@ export const EipPage: React.FC = () => {
               </>
             )}
 
+            {viewMode === 'dependents' && (
+              <EipDependents dependents={dependents} />
+            )}
+
             {viewMode === 'history' && (
               <EipSpecHistory
                 eipId={eipId}
@@ -807,6 +880,38 @@ export const EipPage: React.FC = () => {
         isOpen={searchModalOpen}
         onClose={() => setSearchModalOpen(false)}
       />
+
+      {/* Hover card for required EIPs */}
+      {hoveredReq && reqTooltipPos && createPortal(
+        <div
+          className="fixed z-50 pointer-events-none"
+          style={{
+            left: reqTooltipPos.x,
+            top: reqTooltipPos.y,
+            maxWidth: 360,
+          }}
+        >
+          <div className="bg-white dark:bg-slate-800 border-2 border-purple-300 dark:border-purple-600 rounded-lg shadow-2xl p-4">
+            <div className="flex items-start gap-2 mb-2">
+              <span className="text-sm font-mono font-bold text-purple-600 dark:text-purple-400">
+                {getProposalPrefix(hoveredReq)}-{hoveredReq.id}
+              </span>
+              <span className="px-2 py-0.5 text-xs font-medium rounded bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
+                {hoveredReq.status}
+              </span>
+            </div>
+            <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100 mb-2">
+              {getLaymanTitle(hoveredReq)}
+            </h4>
+            {hoveredReq.description && (
+              <p className="text-xs text-slate-600 dark:text-slate-300 leading-relaxed">
+                {hoveredReq.description}
+              </p>
+            )}
+          </div>
+        </div>,
+        document.body,
+      )}
     </div>
   );
 };

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useCallback, useState, lazy, Suspense } from
 import { createPortal } from 'react-dom';
 import { Link, useParams, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { EIP } from '../../types/eip';
-import { eipsData } from '../../data/eips';
+import { eipById, eipsData } from '../../data/eips';
 import { useMetaTags } from '../../hooks/useMetaTags';
 import { useAnalytics } from '../../hooks/useAnalytics';
 import { useEipMarkdown } from '../../hooks/useEipMarkdown';
@@ -259,6 +259,8 @@ const LazyEipMarkdown = lazy(() =>
 );
 
 const dependentsMap = buildDependentsMap(eipsData);
+const requiredEipSpecUrl = (eipId: number): string => `https://eips.ethereum.org/EIPS/eip-${eipId}`;
+const requiredEipLinkClassName = 'font-mono hover:text-slate-700 dark:hover:text-slate-200 transition-colors';
 
 export const EipPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -521,34 +523,45 @@ export const EipPage: React.FC = () => {
                   <span className="text-xs inline-flex items-center gap-1.5 flex-wrap">
                     Requires:{' '}
                     {eip.requires.map((reqId, i) => {
-                      const reqEip = eipsData.find((e) => e.id === reqId);
+                      const reqEip = eipById.get(reqId);
                       return (
                         <span key={reqId} className="inline-flex items-center">
                           {i > 0 && <span className="mr-1.5">,</span>}
-                          <Link
-                            to={`/eips/${reqId}`}
-                            className="font-mono hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
-                            style={{ borderBottom: '1px dotted currentColor' }}
-                            onMouseEnter={(e) => {
-                              if (!reqEip) return;
-                              const rect = e.currentTarget.getBoundingClientRect();
-                              const tooltipWidth = 360;
-                              const padding = 8;
-                              let x = rect.left + rect.width / 2 - tooltipWidth / 2;
-                              if (x + tooltipWidth > window.innerWidth - padding) {
-                                x = window.innerWidth - tooltipWidth - padding;
-                              }
-                              if (x < padding) x = padding;
-                              setHoveredReq(reqEip);
-                              setReqTooltipPos({ x, y: rect.bottom + padding });
-                            }}
-                            onMouseLeave={() => {
-                              setHoveredReq(null);
-                              setReqTooltipPos(null);
-                            }}
-                          >
-                            EIP-{reqId}
-                          </Link>
+                          {reqEip ? (
+                            <Link
+                              to={`/eips/${reqId}`}
+                              className={requiredEipLinkClassName}
+                              style={{ borderBottom: '1px dotted currentColor' }}
+                              onMouseEnter={(e) => {
+                                const rect = e.currentTarget.getBoundingClientRect();
+                                const tooltipWidth = 360;
+                                const padding = 8;
+                                let x = rect.left + rect.width / 2 - tooltipWidth / 2;
+                                if (x + tooltipWidth > window.innerWidth - padding) {
+                                  x = window.innerWidth - tooltipWidth - padding;
+                                }
+                                if (x < padding) x = padding;
+                                setHoveredReq(reqEip);
+                                setReqTooltipPos({ x, y: rect.bottom + padding });
+                              }}
+                              onMouseLeave={() => {
+                                setHoveredReq(null);
+                                setReqTooltipPos(null);
+                              }}
+                            >
+                              EIP-{reqId}
+                            </Link>
+                          ) : (
+                            <a
+                              href={requiredEipSpecUrl(reqId)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={requiredEipLinkClassName}
+                              style={{ borderBottom: '1px dotted currentColor' }}
+                            >
+                              EIP-{reqId}
+                            </a>
+                          )}
                         </span>
                       );
                     })}

--- a/src/data/eips/1013.json
+++ b/src/data/eips/1013.json
@@ -7,5 +7,13 @@
   "type": "Meta",
   "createdDate": "2018-04-20",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    145,
+    609,
+    1014,
+    1052,
+    1234,
+    1283
+  ]
 }

--- a/src/data/eips/1052.json
+++ b/src/data/eips/1052.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-05-02",
   "discussionLink": "https://ethereum-magicians.org/t/extcodehash-opcode/262",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    161
+  ]
 }

--- a/src/data/eips/1102.json
+++ b/src/data/eips/1102.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-05-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1102-opt-in-provider-access/414",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474
+  ]
 }

--- a/src/data/eips/1108.json
+++ b/src/data/eips/1108.json
@@ -9,5 +9,9 @@
   "createdDate": "2018-05-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1108-reduce-alt-bn128-precompile-gas-costs/3206",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    196,
+    197
+  ]
 }

--- a/src/data/eips/1153.json
+++ b/src/data/eips/1153.json
@@ -9,5 +9,9 @@
   "createdDate": "2018-06-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-transient-storage-opcodes/553",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2200,
+    3529
+  ]
 }

--- a/src/data/eips/1186.json
+++ b/src/data/eips/1186.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-06-24",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/1186",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474
+  ]
 }

--- a/src/data/eips/1193.json
+++ b/src/data/eips/1193.json
@@ -9,5 +9,9 @@
   "createdDate": "2018-06-30",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/2319",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    695
+  ]
 }

--- a/src/data/eips/1227.json
+++ b/src/data/eips/1227.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-07-18",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/1227",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    649
+  ]
 }

--- a/src/data/eips/1344.json
+++ b/src/data/eips/1344.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-08-22",
   "discussionLink": "https://ethereum-magicians.org/t/add-chain-id-opcode-for-replay-protection-when-handling-signed-messages-in-contracts/1131",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/1380.json
+++ b/src/data/eips/1380.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-08-31",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1380-reduced-gas-cost-for-call-to-self/1242",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    150
+  ]
 }

--- a/src/data/eips/1418.json
+++ b/src/data/eips/1418.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-09-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1418-storage-rent/10737",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559
+  ]
 }

--- a/src/data/eips/1459.json
+++ b/src/data/eips/1459.json
@@ -9,5 +9,8 @@
   "createdDate": "2018-09-26",
   "discussionLink": "https://github.com/ethereum/devp2p/issues/50",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    778
+  ]
 }

--- a/src/data/eips/1559.json
+++ b/src/data/eips/1559.json
@@ -9,5 +9,9 @@
   "createdDate": "2019-04-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    2930
+  ]
 }

--- a/src/data/eips/1588.json
+++ b/src/data/eips/1588.json
@@ -7,5 +7,8 @@
   "type": "Meta",
   "createdDate": "2018-11-16",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1057
+  ]
 }

--- a/src/data/eips/1679.json
+++ b/src/data/eips/1679.json
@@ -8,5 +8,14 @@
   "createdDate": "2019-01-04",
   "discussionLink": "https://ethereum-magicians.org/t/hardfork-meta-istanbul-discussion/3207",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    152,
+    1108,
+    1344,
+    1716,
+    1884,
+    2028,
+    2200
+  ]
 }

--- a/src/data/eips/1706.json
+++ b/src/data/eips/1706.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-01-15",
   "discussionLink": "https://github.com/alex-forshtat-tbk/EIPs/issues/1",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1283
+  ]
 }

--- a/src/data/eips/1716.json
+++ b/src/data/eips/1716.json
@@ -7,5 +7,9 @@
   "type": "Meta",
   "createdDate": "2019-01-21",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1013,
+    1283
+  ]
 }

--- a/src/data/eips/1803.json
+++ b/src/data/eips/1803.json
@@ -9,5 +9,8 @@
   "createdDate": "2017-07-28",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1803-rename-opcodes-for-clarity/3345",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    141
+  ]
 }

--- a/src/data/eips/1884.json
+++ b/src/data/eips/1884.json
@@ -9,5 +9,9 @@
   "createdDate": "2019-03-28",
   "discussionLink": "https://ethereum-magicians.org/t/opcode-repricing/3024",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    150,
+    1052
+  ]
 }

--- a/src/data/eips/1898.json
+++ b/src/data/eips/1898.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-04-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1898-add-blockhash-option-to-json-rpc-methods-that-currently-support-defaultblock-parameter/11757",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    234
+  ]
 }

--- a/src/data/eips/1959.json
+++ b/src/data/eips/1959.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-04-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1959-valid-chainid-opcode/3170",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/1962.json
+++ b/src/data/eips/1962.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-04-22",
   "discussionLink": "https://ethereum-magicians.org/t/generalised-precompile-for-elliptic-curve-arithmetics-and-pairings-working-group/3208/2",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1109
+  ]
 }

--- a/src/data/eips/1965.json
+++ b/src/data/eips/1965.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-04-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-1965-valid-chainid-for-specific-blocknumber-protect-all-forks/3181",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/2003.json
+++ b/src/data/eips/2003.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-05-09",
   "discussionLink": "https://github.com/ethereum/evmc/issues/259",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1352
+  ]
 }

--- a/src/data/eips/2014.json
+++ b/src/data/eips/2014.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-05-10",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2014-extended-state-oracle/3301",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    140
+  ]
 }

--- a/src/data/eips/2015.json
+++ b/src/data/eips/2015.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-05-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2015-wallet-update-chain-json-rpc-method-wallet-updatechain/3274",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/2025.json
+++ b/src/data/eips/2025.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-04-20",
   "discussionLink": "https://github.com/MadeofTin/EIPs/issues",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1890
+  ]
 }

--- a/src/data/eips/2031.json
+++ b/src/data/eips/2031.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-05-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2031-net-transaction-counter-change-b-from-state-rent-v3-proposal/3283",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2029
+  ]
 }

--- a/src/data/eips/2046.json
+++ b/src/data/eips/2046.json
@@ -9,5 +9,9 @@
   "createdDate": "2019-05-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2046-reduced-gas-cost-for-static-calls-made-to-precompiles/3291",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    214,
+    1352
+  ]
 }

--- a/src/data/eips/2070.json
+++ b/src/data/eips/2070.json
@@ -8,5 +8,8 @@
   "createdDate": "2019-05-20",
   "discussionLink": "https://ethereum-magicians.org/t/hardfork-meta-eip-2070-berlin-discussion/3561",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1679
+  ]
 }

--- a/src/data/eips/2255.json
+++ b/src/data/eips/2255.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-08-22",
   "discussionLink": "https://ethereum-magicians.org/t/web3-login-permissions/3583",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/2256.json
+++ b/src/data/eips/2256.json
@@ -9,5 +9,10 @@
   "createdDate": "2019-08-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedassets-json-rpc-method/3600",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    55,
+    155,
+    1474
+  ]
 }

--- a/src/data/eips/2294.json
+++ b/src/data/eips/2294.json
@@ -8,5 +8,8 @@
   "createdDate": "2019-09-19",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2294-explicit-bound-to-chain-id/11090",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/2315.json
+++ b/src/data/eips/2315.json
@@ -9,5 +9,10 @@
   "createdDate": "2019-10-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2315-simple-subroutines-for-the-evm/3941",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    4200
+  ]
 }

--- a/src/data/eips/2330.json
+++ b/src/data/eips/2330.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-10-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2330-extsload-and-abi-for-lower-gas-cost-and-off-chain-apps/3733",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/234.json
+++ b/src/data/eips/234.json
@@ -9,5 +9,8 @@
   "createdDate": "2017-03-24",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/234",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474
+  ]
 }

--- a/src/data/eips/2364.json
+++ b/src/data/eips/2364.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-11-08",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/2365",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2124
+  ]
 }

--- a/src/data/eips/2387.json
+++ b/src/data/eips/2387.json
@@ -8,5 +8,9 @@
   "createdDate": "2019-11-22",
   "discussionLink": "https://ethereum-magicians.org/t/hard-fork-to-address-the-ice-age-eip-2387",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1679,
+    2384
+  ]
 }

--- a/src/data/eips/2464.json
+++ b/src/data/eips/2464.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-01-13",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/2465",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2364
+  ]
 }

--- a/src/data/eips/2481.json
+++ b/src/data/eips/2481.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-01-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2481-eth-66-request-identifiers/12132",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2464
+  ]
 }

--- a/src/data/eips/2488.json
+++ b/src/data/eips/2488.json
@@ -9,5 +9,8 @@
   "createdDate": "2019-12-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2488-deprecate-the-callcode-opcode/3957",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7
+  ]
 }

--- a/src/data/eips/2539.json
+++ b/src/data/eips/2539.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-02-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2539-bls12-377-precompile-discussion-thread/4659",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1109,
+    2046
+  ]
 }

--- a/src/data/eips/2565.json
+++ b/src/data/eips/2565.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-03-20",
   "discussionLink": "https://ethereum-magicians.org/t/big-integer-modular-exponentiation-eip-198-gas-cost/4150",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    198
+  ]
 }

--- a/src/data/eips/2666.json
+++ b/src/data/eips/2666.json
@@ -9,5 +9,10 @@
   "createdDate": "2020-05-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip2666-global-precompiles-repricing-and-many-more-discussion-thread/4332",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1352,
+    2046,
+    2565
+  ]
 }

--- a/src/data/eips/2711.json
+++ b/src/data/eips/2711.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-06-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2711-separate-gas-payer-from-msg-sender/4353",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/2733.json
+++ b/src/data/eips/2733.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-06-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-transaction-package/4365",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/2780.json
+++ b/src/data/eips/2780.json
@@ -65,5 +65,12 @@
     "Updates legacy fixed cost to new model based on the actual impact of the transaction..",
     "Improves monetary properties of ETH, making it a better payment tool"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    2718,
+    2929,
+    2930,
+    7708
+  ]
 }

--- a/src/data/eips/2786.json
+++ b/src/data/eips/2786.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-07-15",
   "discussionLink": "https://github.com/ethereum/EIPs/issues/2787",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2700
+  ]
 }

--- a/src/data/eips/2831.json
+++ b/src/data/eips/2831.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-07-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2831-transaction-replacement-message-type/4448",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/2926.json
+++ b/src/data/eips/2926.json
@@ -71,5 +71,9 @@
     "Allow for the removal of the code size limit.",
     "Reduction in size for any proof containing partial code reads"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    161,
+    170
+  ]
 }

--- a/src/data/eips/2930.json
+++ b/src/data/eips/2930.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-08-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2930-optional-access-lists/4561",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    2929
+  ]
 }

--- a/src/data/eips/2938.json
+++ b/src/data/eips/2938.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-09-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2938-account-abstraction/4630",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/2972.json
+++ b/src/data/eips/2972.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-09-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2972-wrapped-legacy-transactions/4604",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    2718
+  ]
 }

--- a/src/data/eips/2976.json
+++ b/src/data/eips/2976.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-09-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2976-eth-typed-transactions-over-gossip/4610",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/3026.json
+++ b/src/data/eips/3026.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-10-05",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3026-bw6-761-curve-operations/4790",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2539
+  ]
 }

--- a/src/data/eips/3041.json
+++ b/src/data/eips/3041.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-10-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3041-add-basefee-in-eth-getblockbyhash-response/4825",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474,
+    1559
+  ]
 }

--- a/src/data/eips/3044.json
+++ b/src/data/eips/3044.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-10-14",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3044-add-basefee-to-eth-getblockbynumber/4828",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474,
+    1559
+  ]
 }

--- a/src/data/eips/3045.json
+++ b/src/data/eips/3045.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-10-14",
   "discussionLink": "https://ethereum-magicians.org/t/add-basefee-to-eth-getunclebyblockhashandindex/4829",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474,
+    1559
+  ]
 }

--- a/src/data/eips/3046.json
+++ b/src/data/eips/3046.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-10-14",
   "discussionLink": "https://ethereum-magicians.org/t/add-basefee-to-eth-getunclebyblocknumberandindex/4830",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474,
+    1559
+  ]
 }

--- a/src/data/eips/3068.json
+++ b/src/data/eips/3068.json
@@ -9,5 +9,9 @@
   "createdDate": "2020-10-23",
   "discussionLink": "https://ethereum-magicians.org/t/pre-compile-for-bls/3973",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    198,
+    1108
+  ]
 }

--- a/src/data/eips/3074.json
+++ b/src/data/eips/3074.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-10-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3074-sponsored-transaction-precompile/4880",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/3085.json
+++ b/src/data/eips/3085.json
@@ -9,5 +9,8 @@
   "createdDate": "2020-11-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3085-wallet-addethereumchain/5469",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/3198.json
+++ b/src/data/eips/3198.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-01-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3198-basefeeopcode/5162",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559
+  ]
 }

--- a/src/data/eips/3326.json
+++ b/src/data/eips/3326.json
@@ -9,5 +9,9 @@
   "createdDate": "2021-03-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3326-wallet-switchethereumchain",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    695
+  ]
 }

--- a/src/data/eips/3337.json
+++ b/src/data/eips/3337.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-03-06",
   "discussionLink": "https://ethereum-magicians.org/t/eips-3336-and-3337-improving-the-evms-memory-model/5482",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3336
+  ]
 }

--- a/src/data/eips/3436.json
+++ b/src/data/eips/3436.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-03-25",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3436-expanded-clique-block-choice-rule/5809",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    225
+  ]
 }

--- a/src/data/eips/3520.json
+++ b/src/data/eips/3520.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-04-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3520-transaction-destination-opcode/6058",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3508
+  ]
 }

--- a/src/data/eips/3521.json
+++ b/src/data/eips/3521.json
@@ -9,5 +9,9 @@
   "createdDate": "2021-04-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3521-reduce-access-list-cost/6072",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2028,
+    2930
+  ]
 }

--- a/src/data/eips/3529.json
+++ b/src/data/eips/3529.json
@@ -9,5 +9,10 @@
   "createdDate": "2021-04-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3529-reduction-in-refunds-alternative-to-eip-3298-and-3403-that-better-preserves-existing-clearing-incentives/6097",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2200,
+    2929,
+    2930
+  ]
 }

--- a/src/data/eips/3534.json
+++ b/src/data/eips/3534.json
@@ -9,5 +9,9 @@
   "createdDate": "2021-04-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3534-restricted-chain-context-transaction-type/6112",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    2930
+  ]
 }

--- a/src/data/eips/3540.json
+++ b/src/data/eips/3540.json
@@ -37,5 +37,9 @@
     }
   ],
   "laymanDescription": "This introduces EVM Object Format (EOF), a new standardized container for smart contract bytecode that gets validated once when deployed rather than every time it runs. EOF separates code from data, making contracts more structured and analyzable. It enables future EVM improvements like better jump instructions, multibyte opcodes, and function representations. The format is extensible and versioned, allowing gradual introduction of new features. Only new contracts can use EOF - existing contracts remain unchanged. This is the foundation that makes other EOF-related improvements possible.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3541,
+    3860
+  ]
 }

--- a/src/data/eips/3584.json
+++ b/src/data/eips/3584.json
@@ -9,5 +9,9 @@
   "createdDate": "2021-05-22",
   "discussionLink": "https://ethresear.ch/t/block-access-list-v0-1/9505",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    2930
+  ]
 }

--- a/src/data/eips/3651.json
+++ b/src/data/eips/3651.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-07-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3651-warm-coinbase/6640",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/3670.json
+++ b/src/data/eips/3670.json
@@ -37,5 +37,8 @@
     }
   ],
   "laymanDescription": "This adds strict validation rules for EOF smart contracts when they're deployed. It rejects contracts with invalid bytecode, such as incomplete PUSH instructions or undefined opcodes. It also removes deprecated instructions like CALLCODE and SELFDESTRUCT from EOF contracts. This validation only happens once at deployment time and only affects new EOF contracts - existing legacy contracts remain unchanged. The goal is to make bytecode more predictable and easier to reason about, while ensuring all EVM implementations handle code the same way.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540
+  ]
 }

--- a/src/data/eips/3675.json
+++ b/src/data/eips/3675.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-07-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3675-upgrade-consensus-to-proof-of-stake/6706",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2124
+  ]
 }

--- a/src/data/eips/3690.json
+++ b/src/data/eips/3690.json
@@ -9,5 +9,9 @@
   "createdDate": "2021-06-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3690-eof-jumpdest-table/6806",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670
+  ]
 }

--- a/src/data/eips/3709.json
+++ b/src/data/eips/3709.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-08-07",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3709-deprecate-type-1-transactions/6810",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559
+  ]
 }

--- a/src/data/eips/3788.json
+++ b/src/data/eips/3788.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-09-02",
   "discussionLink": "https://ethereum-magicians.org/t/discussion-to-eip-3788-strict-enforcement-of-chainid/7001",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/3860.json
+++ b/src/data/eips/3860.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-07-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3860-limit-and-meter-initcode/7018",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170
+  ]
 }

--- a/src/data/eips/3978.json
+++ b/src/data/eips/3978.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-09-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-3978-gas-refunds-on-reverts/7071/",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/4200.json
+++ b/src/data/eips/4200.json
@@ -37,5 +37,9 @@
     }
   ],
   "laymanDescription": "This introduces three new jump instructions (RJUMP, RJUMPI, and RJUMPV) for EOF contracts that use relative addressing instead of absolute addressing. These instructions are more gas-efficient than traditional JUMP/JUMPI instructions, don't require JUMPDEST markers, and make code analysis easier. RJUMP does unconditional jumps, RJUMPI does conditional jumps, and RJUMPV provides jump tables for switch-case scenarios. The relative addressing means code can be moved around without breaking, and the static nature allows for better optimization and validation at deployment time.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670
+  ]
 }

--- a/src/data/eips/4399.json
+++ b/src/data/eips/4399.json
@@ -9,5 +9,8 @@
   "createdDate": "2021-10-30",
   "discussionLink": "https://ethereum-magicians.org/t/eip-4399-supplant-difficulty-opcode-with-random/7368",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3675
+  ]
 }

--- a/src/data/eips/4573.json
+++ b/src/data/eips/4573.json
@@ -9,5 +9,12 @@
   "createdDate": "2021-12-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-4573-named-procedures-for-evm-code-sections/7776",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2315,
+    3540,
+    3670,
+    3779,
+    4200
+  ]
 }

--- a/src/data/eips/4747.json
+++ b/src/data/eips/4747.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-02-02",
   "discussionLink": "https://ethereum-magicians.org/t/eip-4747-simplify-eip-161/8246",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    161
+  ]
 }

--- a/src/data/eips/4750.json
+++ b/src/data/eips/4750.json
@@ -37,5 +37,10 @@
     }
   ],
   "laymanDescription": "This introduces proper function support to EOF contracts by allowing multiple code sections, each representing a separate function. It adds two new instructions: CALLF to call functions and RETF to return from them. Functions have defined input/output parameters and their own isolated stack, improving code organization and analysis. Dynamic jumps (JUMP/JUMPI) are completely removed in favor of static function calls, making contracts more predictable and easier to optimize. A return stack tracks function call history, and JUMPDEST becomes a simple NOP instruction since jump analysis is no longer needed.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    5450
+  ]
 }

--- a/src/data/eips/4788.json
+++ b/src/data/eips/4788.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-02-10",
   "discussionLink": "https://ethereum-magicians.org/t/eip-4788-beacon-root-in-evm/8281",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559
+  ]
 }

--- a/src/data/eips/4844.json
+++ b/src/data/eips/4844.json
@@ -21,5 +21,11 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    2718,
+    2930,
+    4895
+  ]
 }

--- a/src/data/eips/4938.json
+++ b/src/data/eips/4938.json
@@ -9,5 +9,9 @@
   "createdDate": "2022-03-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-4938-removal-of-getnodedata/8893",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2464,
+    2481
+  ]
 }

--- a/src/data/eips/5003.json
+++ b/src/data/eips/5003.json
@@ -9,5 +9,9 @@
   "createdDate": "2022-03-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5003-auth-usurp-publishing-code-at-an-eoa-address/8979",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3074,
+    3607
+  ]
 }

--- a/src/data/eips/5027.json
+++ b/src/data/eips/5027.json
@@ -9,5 +9,10 @@
   "createdDate": "2022-04-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5027-unlimit-contract-code-size/9010",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    2929,
+    2930
+  ]
 }

--- a/src/data/eips/5065.json
+++ b/src/data/eips/5065.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-04-30",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5065-instruction-for-transferring-ether/9107",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/5069.json
+++ b/src/data/eips/5069.json
@@ -8,5 +8,8 @@
   "createdDate": "2022-05-02",
   "discussionLink": "https://ethereum-magicians.org/t/pr-5069-eip-editor-handbook/9137",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1
+  ]
 }

--- a/src/data/eips/5081.json
+++ b/src/data/eips/5081.json
@@ -9,5 +9,12 @@
   "createdDate": "2022-05-06",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5081-expirable-transaction/9208",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    1559,
+    2718,
+    2929,
+    2930
+  ]
 }

--- a/src/data/eips/5283.json
+++ b/src/data/eips/5283.json
@@ -9,5 +9,10 @@
   "createdDate": "2022-07-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5283-a-semaphore-for-parallelizable-reentrancy-protection/10236",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    20,
+    1283,
+    1352
+  ]
 }

--- a/src/data/eips/5450.json
+++ b/src/data/eips/5450.json
@@ -37,5 +37,11 @@
     }
   ],
   "laymanDescription": "This adds comprehensive stack validation to EOF contracts at deployment time, ensuring that stack underflow and overflow cannot happen during execution. By analyzing all possible code paths and tracking stack heights, it eliminates the need for most runtime stack checks, making execution faster and more predictable. Only CALLF and JUMPF instructions need runtime stack overflow checks. The validation also prevents deployment of unreachable code and ensures proper function termination. This creates guarantees that enable better compiler optimizations and ahead-of-time compilation while maintaining linear validation complexity.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    4200,
+    4750
+  ]
 }

--- a/src/data/eips/5478.json
+++ b/src/data/eips/5478.json
@@ -9,5 +9,9 @@
   "createdDate": "2022-08-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5478-reducing-the-gas-cost-of-contract-creation-with-existing-code/10419",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1014,
+    2929
+  ]
 }

--- a/src/data/eips/5593.json
+++ b/src/data/eips/5593.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-09-05",
   "discussionLink": "https://ethereum-magicians.org/t/rfc-limiting-provider-object-injection-to-secure-contexts/10670",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/5749.json
+++ b/src/data/eips/5749.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-10-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5749-deprecate-window-ethereum/11195",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/5757.json
+++ b/src/data/eips/5757.json
@@ -8,5 +8,8 @@
   "createdDate": "2022-09-30",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5757-process-for-approving-external-resources/11215",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1
+  ]
 }

--- a/src/data/eips/5792.json
+++ b/src/data/eips/5792.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-10-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5792-wallet-abstract-transaction-send-api/11374",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/5793.json
+++ b/src/data/eips/5793.json
@@ -9,5 +9,10 @@
   "createdDate": "2022-10-18",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5793-eth-68-add-transaction-type-to-tx-announcement/11364",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2464,
+    2481,
+    4938
+  ]
 }

--- a/src/data/eips/5806.json
+++ b/src/data/eips/5806.json
@@ -9,5 +9,9 @@
   "createdDate": "2022-10-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-5806-delegate-transaction/11409",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    2930
+  ]
 }

--- a/src/data/eips/5920.json
+++ b/src/data/eips/5920.json
@@ -87,5 +87,10 @@
     "Creates a dedicated function to tranfer the native token",
     "Improves gas cost for transactions that only tranfesrs ETH"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    214,
+    2929,
+    7523
+  ]
 }

--- a/src/data/eips/6046.json
+++ b/src/data/eips/6046.json
@@ -9,5 +9,10 @@
   "createdDate": "2022-11-25",
   "discussionLink": "https://ethereum-magicians.org/t/almost-self-destructing-selfdestruct-deactivate/11886",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2681,
+    2929,
+    3529
+  ]
 }

--- a/src/data/eips/606.json
+++ b/src/data/eips/606.json
@@ -7,5 +7,10 @@
   "type": "Meta",
   "createdDate": "2017-04-23",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2,
+    7,
+    8
+  ]
 }

--- a/src/data/eips/607.json
+++ b/src/data/eips/607.json
@@ -7,5 +7,12 @@
   "type": "Meta",
   "createdDate": "2017-04-23",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    160,
+    161,
+    170,
+    608
+  ]
 }

--- a/src/data/eips/608.json
+++ b/src/data/eips/608.json
@@ -7,5 +7,9 @@
   "type": "Meta",
   "createdDate": "2017-04-23",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    150,
+    779
+  ]
 }

--- a/src/data/eips/609.json
+++ b/src/data/eips/609.json
@@ -7,5 +7,17 @@
   "type": "Meta",
   "createdDate": "2017-04-23",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    100,
+    140,
+    196,
+    197,
+    198,
+    211,
+    214,
+    607,
+    649,
+    658
+  ]
 }

--- a/src/data/eips/6110.json
+++ b/src/data/eips/6110.json
@@ -60,5 +60,8 @@
     "Future proofing deposit flow with less complexity",
     "Enabling more features built on modern deposit flow"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7685
+  ]
 }

--- a/src/data/eips/6122.json
+++ b/src/data/eips/6122.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-12-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6122-forkid-checks-based-on-timestamps/12130",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2124
+  ]
 }

--- a/src/data/eips/6188.json
+++ b/src/data/eips/6188.json
@@ -9,5 +9,8 @@
   "createdDate": "2022-12-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6190-functional-selfdestruct/12232",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/6189.json
+++ b/src/data/eips/6189.json
@@ -9,5 +9,9 @@
   "createdDate": "2022-12-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6190-functional-selfdestruct/12232",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    6188
+  ]
 }

--- a/src/data/eips/6190.json
+++ b/src/data/eips/6190.json
@@ -9,5 +9,10 @@
   "createdDate": "2022-12-20",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6190-functional-selfdestruct/12232",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    6188,
+    6189
+  ]
 }

--- a/src/data/eips/6206.json
+++ b/src/data/eips/6206.json
@@ -37,5 +37,9 @@
     }
   ],
   "laymanDescription": "This introduces the JUMPF instruction for EOF contracts, enabling tail call optimization by jumping to code sections without adding return stack frames. It also introduces non-returning functions - sections that never return control to their caller. This is particularly efficient for error handling helpers that end with REVERT, allowing compilers to generate more optimal code with reduced gas costs and smaller bytecode size. Functions can jump to other functions with fewer outputs, and non-returning functions don't need to clean up extra stack items before terminating.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4750,
+    5450
+  ]
 }

--- a/src/data/eips/6404.json
+++ b/src/data/eips/6404.json
@@ -66,5 +66,17 @@
     "Aligns execution and consensus around SSZ",
     "Improves forward compatibility for transaction changes"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    1559,
+    2718,
+    2930,
+    4844,
+    7495,
+    7702,
+    7916,
+    7932,
+    8016
+  ]
 }

--- a/src/data/eips/6465.json
+++ b/src/data/eips/6465.json
@@ -9,5 +9,12 @@
   "createdDate": "2023-02-08",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6465-ssz-withdrawals-root/12883",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    4895,
+    6404,
+    7495,
+    7916
+  ]
 }

--- a/src/data/eips/6466.json
+++ b/src/data/eips/6466.json
@@ -66,5 +66,16 @@
     "Includes data to verify from, gasUsed, and contractAddress directly from the receipt.",
     "Eliminates the inefficient logs bloom, reducing storage overhead."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    658,
+    2718,
+    6404,
+    7495,
+    7668,
+    7702,
+    7916,
+    8016,
+    8116
+  ]
 }

--- a/src/data/eips/6493.json
+++ b/src/data/eips/6493.json
@@ -9,5 +9,9 @@
   "createdDate": "2023-02-24",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6493-ssz-transaction-signature-scheme/13050",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6404,
+    6466
+  ]
 }

--- a/src/data/eips/658.json
+++ b/src/data/eips/658.json
@@ -8,5 +8,8 @@
   "category": "Core",
   "createdDate": "2017-06-30",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    140
+  ]
 }

--- a/src/data/eips/663.json
+++ b/src/data/eips/663.json
@@ -37,5 +37,9 @@
     }
   ],
   "laymanDescription": "This adds three new EVM instructions (DUPN, SWAPN, and EXCHANGE) that allow smart contracts to access and manipulate stack items beyond the current 16-item limit, reaching up to 256 items deep. Currently, the EVM stack can hold 1024 items but only the top 16 are easily accessible. These new instructions help compilers write more efficient code for complex functions with many variables by providing better stack management capabilities. The feature only works with the new EOF bytecode format, not legacy contracts.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    5450
+  ]
 }

--- a/src/data/eips/6780.json
+++ b/src/data/eips/6780.json
@@ -9,5 +9,10 @@
   "createdDate": "2023-03-25",
   "discussionLink": "https://ethereum-magicians.org/t/deactivate-selfdestruct-except-where-it-occurs-in-the-same-transaction-in-which-a-contract-was-created/13539",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2681,
+    2929,
+    3529
+  ]
 }

--- a/src/data/eips/6800.json
+++ b/src/data/eips/6800.json
@@ -52,5 +52,8 @@
     "More efficient cryptographic proofs (smaller size)",
     "Foundation for future scalability improvements"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6780
+  ]
 }

--- a/src/data/eips/6810.json
+++ b/src/data/eips/6810.json
@@ -9,5 +9,9 @@
   "createdDate": "2023-04-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6810-ex-post-facto-cascading-revert/13630",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    2929
+  ]
 }

--- a/src/data/eips/695.json
+++ b/src/data/eips/695.json
@@ -9,5 +9,8 @@
   "createdDate": "2017-08-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-695-create-eth-chainid-method-for-json-rpc/1845",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155
+  ]
 }

--- a/src/data/eips/6953.json
+++ b/src/data/eips/6953.json
@@ -8,5 +8,10 @@
   "createdDate": "2023-04-28",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6666-network-upgrade-activation-triggers/14047",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2982,
+    3675,
+    6122
+  ]
 }

--- a/src/data/eips/6963.json
+++ b/src/data/eips/6963.json
@@ -9,5 +9,8 @@
   "createdDate": "2023-05-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-6963-multi-injected-provider-interface-aka-mipi/14076",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/7002.json
+++ b/src/data/eips/7002.json
@@ -58,5 +58,8 @@
     "Trust-minimized exits for staking protocols",
     "Reduces reliance on validator keys access on Beacon Chain"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7685
+  ]
 }

--- a/src/data/eips/7039.json
+++ b/src/data/eips/7039.json
@@ -9,5 +9,8 @@
   "createdDate": "2023-05-15",
   "discussionLink": "https://ethereum-magicians.org/t/shadow-a-scheme-handler-discovery-option-for-wallets/14330",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1193
+  ]
 }

--- a/src/data/eips/7069.json
+++ b/src/data/eips/7069.json
@@ -22,5 +22,12 @@
     }
   ],
   "laymanDescription": "This introduces three new call instructions (EXTCALL, EXTDELEGATECALL, EXTSTATICCALL) for EOF contracts that remove gas observability and simplify call semantics. Unlike legacy CALL instructions, these don't allow specifying gas limits - they use the 63/64th rule automatically. They return extensible status codes (0=success, 1=revert, 2=failure) instead of boolean values, remove output buffer complexity in favor of RETURNDATACOPY, and add RETURNDATALOAD for efficient return data access. This makes contracts more resilient to future gas repricing and eliminates many gas-related attack vectors while simplifying the calling mechanism.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    150,
+    211,
+    214,
+    2929,
+    3540
+  ]
 }

--- a/src/data/eips/712.json
+++ b/src/data/eips/712.json
@@ -9,5 +9,9 @@
   "createdDate": "2017-09-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-712-eth-signtypeddata-as-a-standard-for-machine-verifiable-and-human-readable-typed-data-signing/397",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    155,
+    191
+  ]
 }

--- a/src/data/eips/7251.json
+++ b/src/data/eips/7251.json
@@ -61,5 +61,9 @@
     "Rewards accrue smoothly above 32 ETH",
     "Simplifies operations for large stakers"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7002,
+    7685
+  ]
 }

--- a/src/data/eips/7329.json
+++ b/src/data/eips/7329.json
@@ -8,5 +8,8 @@
   "createdDate": "2023-07-13",
   "discussionLink": "https://ethereum-magicians.org/t/proposal-forking-ercs-from-eips-repository/12804",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1
+  ]
 }

--- a/src/data/eips/7377.json
+++ b/src/data/eips/7377.json
@@ -9,5 +9,11 @@
   "createdDate": "2023-07-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-xxxx-migration-transaction/15144",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    1559,
+    2200,
+    2718
+  ]
 }

--- a/src/data/eips/747.json
+++ b/src/data/eips/747.json
@@ -9,5 +9,10 @@
   "createdDate": "2018-08-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-747-eth-watchtoken/1048",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    20,
+    1046,
+    1193
+  ]
 }

--- a/src/data/eips/7480.json
+++ b/src/data/eips/7480.json
@@ -37,5 +37,9 @@
     }
   ],
   "laymanDescription": "This introduces four new instructions for EOF contracts to access their data section: DATALOAD (loads 32-byte word), DATALOADN (optimized version with compile-time offset), DATASIZE (returns data section size), and DATACOPY (copies data to memory). These replace the deprecated CODECOPY instruction for data access in EOF contracts, enabling proper separation between code and data. The instructions follow the same pattern as existing data access instructions like those for calldata and returndata, with zero-padding for out-of-bounds access and validation to ensure safe operation.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670
+  ]
 }

--- a/src/data/eips/7495.json
+++ b/src/data/eips/7495.json
@@ -9,5 +9,8 @@
   "createdDate": "2023-08-18",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7495-ssz-progressivecontainer/15476",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7916
+  ]
 }

--- a/src/data/eips/7503.json
+++ b/src/data/eips/7503.json
@@ -9,5 +9,10 @@
   "createdDate": "2023-08-14",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7503-zero-knowledge-wormholes-private-proof-of-burn-ppob/15456",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718,
+    4844,
+    7708
+  ]
 }

--- a/src/data/eips/7516.json
+++ b/src/data/eips/7516.json
@@ -9,5 +9,9 @@
   "createdDate": "2023-09-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7516-blobbasefee-opcode/15761",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3198,
+    4844
+  ]
 }

--- a/src/data/eips/7519.json
+++ b/src/data/eips/7519.json
@@ -9,5 +9,9 @@
   "createdDate": "2023-09-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7519-atomic-storage-operations-scredit-and-sdebit/15818",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2200,
+    2929
+  ]
 }

--- a/src/data/eips/7523.json
+++ b/src/data/eips/7523.json
@@ -9,5 +9,8 @@
   "createdDate": "2023-09-19",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7523-empty-accounts-deprecation/15870",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    161
+  ]
 }

--- a/src/data/eips/7542.json
+++ b/src/data/eips/7542.json
@@ -9,5 +9,8 @@
   "createdDate": "2023-10-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-eth-70-available-blocks-extended-protocol-handshake/16188",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7642
+  ]
 }

--- a/src/data/eips/7568.json
+++ b/src/data/eips/7568.json
@@ -8,5 +8,12 @@
   "createdDate": "2023-12-01",
   "discussionLink": "https://ethereum-magicians.org/t/hardfork-meta-backfill/16923",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2070,
+    2387,
+    2982,
+    6122,
+    6953
+  ]
 }

--- a/src/data/eips/7569.json
+++ b/src/data/eips/7569.json
@@ -8,5 +8,17 @@
   "createdDate": "2023-12-01",
   "discussionLink": "https://ethereum-magicians.org/t/dencun-hardfork-meta/16924",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1153,
+    4788,
+    4844,
+    5656,
+    6780,
+    7044,
+    7045,
+    7514,
+    7516,
+    7568
+  ]
 }

--- a/src/data/eips/758.json
+++ b/src/data/eips/758.json
@@ -8,5 +8,8 @@
   "category": "Interface",
   "createdDate": "2017-11-09",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1474
+  ]
 }

--- a/src/data/eips/7594.json
+++ b/src/data/eips/7594.json
@@ -64,5 +64,8 @@
     "Foundation for competing with high-speed blockchains",
     "Paves the way for full Danksharding"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/7600.json
+++ b/src/data/eips/7600.json
@@ -8,5 +8,18 @@
   "createdDate": "2024-01-18",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-electra/18205",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2537,
+    2935,
+    6110,
+    7002,
+    7251,
+    7549,
+    7569,
+    7623,
+    7685,
+    7691,
+    7702
+  ]
 }

--- a/src/data/eips/7607.json
+++ b/src/data/eips/7607.json
@@ -8,5 +8,21 @@
   "createdDate": "2024-02-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7594,
+    7600,
+    7642,
+    7823,
+    7825,
+    7883,
+    7892,
+    7910,
+    7917,
+    7918,
+    7934,
+    7935,
+    7939,
+    7951
+  ]
 }

--- a/src/data/eips/7609.json
+++ b/src/data/eips/7609.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-02-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7609-reduce-transient-storage-pricing/18435",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1153
+  ]
 }

--- a/src/data/eips/7612.json
+++ b/src/data/eips/7612.json
@@ -9,5 +9,10 @@
   "createdDate": "2024-01-25",
   "discussionLink": "https://ethereum-magicians.org/t/ethereum-state-trie-format-change-using-an-overlay/4165",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4762,
+    6800,
+    7545
+  ]
 }

--- a/src/data/eips/7620.json
+++ b/src/data/eips/7620.json
@@ -22,5 +22,13 @@
     }
   ],
   "laymanDescription": "This introduces new contract creation instructions for EOF contracts: EOFCREATE and RETURNCODE, which replace the legacy CREATE/CREATE2 instructions. Since EOF removes code observability (the ability to inspect and manipulate code), the old creation methods don't work. EOFCREATE creates contracts using pre-validated subcontainers within the factory contract, maintaining security while enabling factory patterns. RETURNCODE allows the initialization code to specify which subcontainer becomes the deployed contract and append additional data. This preserves the factory contract use case while maintaining EOF's code non-observability guarantees.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    684,
+    2929,
+    3540,
+    3541,
+    3670
+  ]
 }

--- a/src/data/eips/7636.json
+++ b/src/data/eips/7636.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-02-25",
   "discussionLink": "https://ethereum-magicians.org/t/eip7636-extension-of-eip-778-for-client-enr-entry/18935",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    778
+  ]
 }

--- a/src/data/eips/7637.json
+++ b/src/data/eips/7637.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-02-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7637-extcodehash-optimize/18946",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1052
+  ]
 }

--- a/src/data/eips/7642.json
+++ b/src/data/eips/7642.json
@@ -68,5 +68,8 @@
     "Faster setup for new Ethereum nodes",
     "Prepares for history expiry management"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    5793
+  ]
 }

--- a/src/data/eips/7650.json
+++ b/src/data/eips/7650.json
@@ -9,5 +9,9 @@
   "createdDate": "2024-03-10",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7650-programmable-access-lists/19159",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    2930
+  ]
 }

--- a/src/data/eips/7664.json
+++ b/src/data/eips/7664.json
@@ -9,5 +9,10 @@
   "createdDate": "2024-03-27",
   "discussionLink": "https://ethereum-magicians.org/t/access-key-opcode/19395",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1153,
+    2930,
+    4844
+  ]
 }

--- a/src/data/eips/7675.json
+++ b/src/data/eips/7675.json
@@ -8,5 +8,12 @@
   "createdDate": "2024-04-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7675-retroactively-included-eips/19541",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2681,
+    3607,
+    4803,
+    7523,
+    7610
+  ]
 }

--- a/src/data/eips/7676.json
+++ b/src/data/eips/7676.json
@@ -9,5 +9,10 @@
   "createdDate": "2024-04-03",
   "discussionLink": "https://ethereum-magicians.org/t/eof-prepare-for-address-space-extension/19537",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    7069
+  ]
 }

--- a/src/data/eips/7688.json
+++ b/src/data/eips/7688.json
@@ -75,5 +75,10 @@
     "CL developers can modify fields, list capacities, or cost functions without affecting verifiers.",
     "Bundling with ePBS avoids a second re-indexing in the future."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7495,
+    7607,
+    7916
+  ]
 }

--- a/src/data/eips/7692.json
+++ b/src/data/eips/7692.json
@@ -80,5 +80,18 @@
     "Paves the way for maintaining existing toolchain while adding new capabilities",
     "Enables 'both EVM and RISC-V' rather than 'either EVM or RISC-V' approach"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    663,
+    3540,
+    3670,
+    4200,
+    4750,
+    5450,
+    6206,
+    7069,
+    7480,
+    7620,
+    7698
+  ]
 }

--- a/src/data/eips/7698.json
+++ b/src/data/eips/7698.json
@@ -22,5 +22,8 @@
     }
   ],
   "laymanDescription": "This enables deploying EOF contracts using regular creation transactions (transactions with empty 'to' field). Since legacy CREATE and CREATE2 instructions cannot deploy EOF code, creation transactions are the only way to get the first EOF contracts on-chain. The transaction data contains an EOF initcontainer followed by calldata for constructor arguments. This approach allows existing deployment tooling to work without modification - developers can deploy EOF contracts the same way they deploy legacy contracts, just by concatenating constructor arguments with the initcontainer. The execution ends with a RETURNCODE instruction that specifies which subcontainer becomes the deployed contract.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540
+  ]
 }

--- a/src/data/eips/7702.json
+++ b/src/data/eips/7702.json
@@ -58,5 +58,16 @@
     "Better UX for users with features like gasless and batched transactions",
     "Provides alternative recovery options for wallets"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2,
+    161,
+    1052,
+    2718,
+    2929,
+    2930,
+    3541,
+    3607,
+    4844
+  ]
 }

--- a/src/data/eips/7706.json
+++ b/src/data/eips/7706.json
@@ -9,5 +9,9 @@
   "createdDate": "2024-05-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7706-create-a-separate-basefee-and-gaslimit-for-calldata/19998",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    4844
+  ]
 }

--- a/src/data/eips/7707.json
+++ b/src/data/eips/7707.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-05-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7707-align-incentives-for-access-list-provisioning/20025",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2930
+  ]
 }

--- a/src/data/eips/7708.json
+++ b/src/data/eips/7708.json
@@ -72,5 +72,11 @@
     "Improves deposit handling for smart contract wallet senders.",
     "Simplifies indexing and analytics for ETH movement."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    4788,
+    6780,
+    8246
+  ]
 }

--- a/src/data/eips/7709.json
+++ b/src/data/eips/7709.json
@@ -79,5 +79,8 @@
   "tradeoffs": [
     "Significantly increases BLOCKHASH cost; may break contracts relying on previous low pricing",
     "Requires EIP-2935 active for at least 256 blocks before activation, or genesis activation"
+  ],
+  "requires": [
+    2935
   ]
 }

--- a/src/data/eips/7713.json
+++ b/src/data/eips/7713.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-05-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7713-box-types-for-eip-712-messages/20092",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    712
+  ]
 }

--- a/src/data/eips/7727.json
+++ b/src/data/eips/7727.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-06-24",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7727-evm-transaction-bundles/20322",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/7736.json
+++ b/src/data/eips/7736.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-07-05",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7736-leaf-level-state-expiry-in-verkle-trees/20474",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6800
+  ]
 }

--- a/src/data/eips/7742.json
+++ b/src/data/eips/7742.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-07-12",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7742-uncouple-blob-count-between-cl-and-el/20550",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/7745.json
+++ b/src/data/eips/7745.json
@@ -66,5 +66,8 @@
     "Reduces bandwidth for log-event discovery by orders of magnitude compared with existing per-block bloom filters.",
     "Provides precise block and transaction positions for candidate hits, minimizing unnecessary receipt fetches during log queries."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7916
+  ]
 }

--- a/src/data/eips/7748.json
+++ b/src/data/eips/7748.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-07-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7748-state-conversion-to-verkle-tree/20625",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7612
+  ]
 }

--- a/src/data/eips/7749.json
+++ b/src/data/eips/7749.json
@@ -9,5 +9,9 @@
   "createdDate": "2024-06-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7749-add-wallet-signintendedvalidatordata-method/20693",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    191,
+    712
+  ]
 }

--- a/src/data/eips/7756.json
+++ b/src/data/eips/7756.json
@@ -9,5 +9,9 @@
   "createdDate": "2024-08-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7756-eof-evm-trace-specification/20806",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3155,
+    4750
+  ]
 }

--- a/src/data/eips/7761.json
+++ b/src/data/eips/7761.json
@@ -22,5 +22,9 @@
     }
   ],
   "laymanDescription": "This adds an EXTCODETYPE instruction to EOF contracts to distinguish between different account types. EOF removes code introspection capabilities like EXTCODESIZE, but this creates problems for ERC-721 and ERC-1155 tokens that need to know whether a recipient is an EOA (externally owned account) or a contract to implement safe transfers correctly. EXTCODETYPE returns 0 for no code (EOA), 1 for legacy contracts, and 2 for EOF contracts. This enables proper implementation of token standards in EOF while also helping proxy contracts verify that their upgrade targets are safe to call with EXTDELEGATECALL.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    7692
+  ]
 }

--- a/src/data/eips/7762.json
+++ b/src/data/eips/7762.json
@@ -22,5 +22,8 @@
     }
   ],
   "laymanDescription": "This increases the minimum blob base fee from 1 wei to 2^25 wei (about 33 million times higher) to speed up blob price discovery. Currently, when blob demand exceeds supply, it takes too long for prices to climb from the extremely low minimum to actual market rates. The new minimum corresponds to about 1 cent at current ETH prices, similar to the cost of a simple transaction when gas fees are low. The change also resets excess blob gas to zero to prevent a sudden price spike when the upgrade activates. This helps blob-based rollups reach appropriate pricing faster during high-demand periods.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/7773.json
+++ b/src/data/eips/7773.json
@@ -8,5 +8,9 @@
   "createdDate": "2024-09-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-upgrade-meta-thread/21195",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7607,
+    7723
+  ]
 }

--- a/src/data/eips/7782.json
+++ b/src/data/eips/7782.json
@@ -81,5 +81,9 @@
     "Enables flywheel effects attracting more liquidity and traders to Ethereum",
     "Maintains current throughput while doubling proposer frequency per unit time"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7623,
+    7778
+  ]
 }

--- a/src/data/eips/7788.json
+++ b/src/data/eips/7788.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-10-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7788-dynamic-target-blob-count/21399",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7742
+  ]
 }

--- a/src/data/eips/779.json
+++ b/src/data/eips/779.json
@@ -7,5 +7,8 @@
   "type": "Meta",
   "createdDate": "2017-11-26",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    606
+  ]
 }

--- a/src/data/eips/7790.json
+++ b/src/data/eips/7790.json
@@ -8,5 +8,8 @@
   "createdDate": "2024-10-18",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7790-parameters-to-increase-the-gas-limit/21435",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7783
+  ]
 }

--- a/src/data/eips/7791.json
+++ b/src/data/eips/7791.json
@@ -75,5 +75,8 @@
     "Fair distribution of fees proportional to contract usage.",
     "Simple and clear UX for dapp users who can continue using their wallets with regular gas fee estimates as before."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929
+  ]
 }

--- a/src/data/eips/7792.json
+++ b/src/data/eips/7792.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-10-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7792-verifiable-logs/21424",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6466
+  ]
 }

--- a/src/data/eips/7793.json
+++ b/src/data/eips/7793.json
@@ -82,5 +82,8 @@
     "Enforces mempool ordering, preventing builder reordering and frontrunning.",
     "Provides TXINDEX opcode for onchain verification of declared conditional transaction index."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7843
+  ]
 }

--- a/src/data/eips/7799.json
+++ b/src/data/eips/7799.json
@@ -9,5 +9,12 @@
   "createdDate": "2024-10-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7799-system-logs/21497",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4895,
+    6466,
+    7708,
+    7916,
+    8115
+  ]
 }

--- a/src/data/eips/7801.json
+++ b/src/data/eips/7801.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-10-30",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7801-etha-sharded-blocks-subprotocol/21507",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7642
+  ]
 }

--- a/src/data/eips/7807.json
+++ b/src/data/eips/7807.json
@@ -86,5 +86,12 @@
   "tradeoffs": [
     "Breaks smart contracts depending on previous block header binary format",
     "Requires coordinated database and networking protocol changes across implementations"
+  ],
+  "requires": [
+    6404,
+    6465,
+    6466,
+    7495,
+    7799
   ]
 }

--- a/src/data/eips/7808.json
+++ b/src/data/eips/7808.json
@@ -8,5 +8,8 @@
   "createdDate": "2024-11-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7808-reserve-tx-type-range-for-rips/21587",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/7819.json
+++ b/src/data/eips/7819.json
@@ -81,5 +81,8 @@
     "Smaller state footprint than proxies; delegation objects are only 23 bytes.",
     "Immediate, factory-controlled upgrades or locking, reducing complexity in account factories."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7702
+  ]
 }

--- a/src/data/eips/7823.json
+++ b/src/data/eips/7823.json
@@ -59,5 +59,8 @@
     "Better compensation for computational work",
     "More consistent gas pricing"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    198
+  ]
 }

--- a/src/data/eips/7830.json
+++ b/src/data/eips/7830.json
@@ -9,5 +9,10 @@
   "createdDate": "2024-11-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7830-contract-size-limit-increase-for-eof/21927",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    3540,
+    3860
+  ]
 }

--- a/src/data/eips/7834.json
+++ b/src/data/eips/7834.json
@@ -22,5 +22,8 @@
     }
   ],
   "laymanDescription": "This adds a dedicated metadata section to EOF contracts that is completely separate from executable code and data. Currently, compilers include metadata (like compiler versions, IPFS hashes of source files) by mixing it with contract data, which creates problems for source code verification and causes different bytecode when metadata changes. The new metadata section solves these issues by being unreachable by contract execution, unchanging after deployment, and clearly separated from functional code. This makes source code verification much easier and ensures that contracts with identical logic but different metadata will have the same executable bytecode.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540
+  ]
 }

--- a/src/data/eips/7851.json
+++ b/src/data/eips/7851.json
@@ -9,5 +9,8 @@
   "createdDate": "2024-12-27",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7851-code-controlled-eoa-delegation/22344",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7702
+  ]
 }

--- a/src/data/eips/7867.json
+++ b/src/data/eips/7867.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-01-17",
   "discussionLink": "https://ethereum-magicians.org/t/wallet-sendcalls-capability-flow-control/22624",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    5792
+  ]
 }

--- a/src/data/eips/7873.json
+++ b/src/data/eips/7873.json
@@ -22,5 +22,11 @@
     }
   ],
   "laymanDescription": "This introduces a new way to deploy EOF contracts by adding a TXCREATE instruction and a special InitcodeTransaction type. The problem it solves is that EOF removes the traditional CREATE and CREATE2 instructions used to deploy contracts. With this EIP, both regular users (EOAs) and smart contracts can deploy EOF contracts by including the contract code directly in transaction data and using TXCREATE to deploy it. This works alongside the existing EOFCREATE instruction, giving developers all the contract creation capabilities they had before EOF. The TXCREATE instruction can also deploy legacy contracts, making it a universal bootstrapping mechanism for getting EOF contracts onto the blockchain.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    3860,
+    7620
+  ]
 }

--- a/src/data/eips/7877.json
+++ b/src/data/eips/7877.json
@@ -9,5 +9,10 @@
   "createdDate": "2025-01-31",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7877-new-m-s-t-rreturn-opcodes/22731",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6,
+    1153,
+    3855
+  ]
 }

--- a/src/data/eips/7880.json
+++ b/src/data/eips/7880.json
@@ -22,5 +22,10 @@
     }
   ],
   "laymanDescription": "This adds a new EXTCODEADDRESS instruction to EOF contracts that helps them work with EIP-7702 delegation accounts without breaking EOF's no-code-introspection rule. The problem it solves is that EOF removes the ability to read raw contract code, but contracts still need to know when an account is delegating execution to another address. This instruction takes an address and returns the actual address that will execute the code - for regular accounts it returns the same address, but for delegated accounts it returns the address they're delegating to. This enables important use cases like managed proxy contracts ensuring they don't delegate to unsafe addresses, sponsorship contracts verifying delegation hasn't changed during a transaction, and security-conscious contracts that only accept specific delegation targets.",
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7692,
+    7702,
+    7761
+  ]
 }

--- a/src/data/eips/7883.json
+++ b/src/data/eips/7883.json
@@ -64,5 +64,8 @@
     "Prevents potential DoS from cheap complex operations",
     "Aligns gas costs with performance benchmarks"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2565
+  ]
 }

--- a/src/data/eips/7886.json
+++ b/src/data/eips/7886.json
@@ -64,5 +64,12 @@
     "Snapshot-and-revert preserves liveness: mismatched gas used resets receipts, logs, and execution outputs without discarding blocks from the chain.",
     "Base-fee dynamics remain fair: reverted parents count as zero gas used, preventing fee-market manipulation via overdeclared usage."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    2930,
+    4844,
+    7623,
+    7702
+  ]
 }

--- a/src/data/eips/7892.json
+++ b/src/data/eips/7892.json
@@ -66,5 +66,8 @@
     "Predictable scaling roadmap for builders",
     "Safer capacity increases through smaller steps"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7840
+  ]
 }

--- a/src/data/eips/7896.json
+++ b/src/data/eips/7896.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-02-27",
   "discussionLink": "https://ethereum-magicians.org/t/eip-tbd-abi-attachment-in-wallet-sendcalls/23016",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    5792
+  ]
 }

--- a/src/data/eips/7903.json
+++ b/src/data/eips/7903.json
@@ -79,5 +79,9 @@
     "Smoother deployment of big projects, no more extra tooling needed.",
     "Developer experience is much more straightforward and follows industry standarts."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    3860
+  ]
 }

--- a/src/data/eips/7904.json
+++ b/src/data/eips/7904.json
@@ -70,5 +70,8 @@
     "Improves network throughput by reducing gas cost of compute operations.",
     "Enhances the security of the network against abuse of single bottlenecks."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7883
+  ]
 }

--- a/src/data/eips/7907.json
+++ b/src/data/eips/7907.json
@@ -83,5 +83,11 @@
     "Eliminates complex multi-contract workarounds for dapp developers",
     "Saves gas on operations that would otherwise require cross contract calls"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    170,
+    2929,
+    3860,
+    7702
+  ]
 }

--- a/src/data/eips/7915.json
+++ b/src/data/eips/7915.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-03-23",
   "discussionLink": "https://ethereum-magicians.org/t/adaptive-mean-reversion-blob-pricing/23243",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/7918.json
+++ b/src/data/eips/7918.json
@@ -64,5 +64,9 @@
     "Ensures blob consumers pay fair market price for compute",
     "Reduces dramatic fee spikes"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844,
+    7840
+  ]
 }

--- a/src/data/eips/7919.json
+++ b/src/data/eips/7919.json
@@ -93,5 +93,17 @@
     "Dramatically improves application decentralization",
     "Reduces infrastructure requirements for verified data access"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6404,
+    6465,
+    6466,
+    7495,
+    7668,
+    7708,
+    7745,
+    7799,
+    7807,
+    7916
+  ]
 }

--- a/src/data/eips/7927.json
+++ b/src/data/eips/7927.json
@@ -8,5 +8,8 @@
   "createdDate": "2025-03-28",
   "discussionLink": "https://ethereum-magicians.org/t/history-expiry-meta-eip/23359",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4444
+  ]
 }

--- a/src/data/eips/7954.json
+++ b/src/data/eips/7954.json
@@ -70,5 +70,9 @@
   "tradeoffs": [
     "Not backward compatible for contract deployments exceeding previous limits.",
     "May slightly increase denial-of-service risk from larger contract code, though limit remains conservative."
+  ],
+  "requires": [
+    170,
+    3860
   ]
 }

--- a/src/data/eips/7956.json
+++ b/src/data/eips/7956.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-05-24",
   "discussionLink": "https://ethereum-magicians.org/t/potential-eip-mev-decrease-by-deterministic-transaction-ordering-via-block-level-randomness/24084",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7998
+  ]
 }

--- a/src/data/eips/7957.json
+++ b/src/data/eips/7957.json
@@ -9,5 +9,11 @@
   "createdDate": "2025-05-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7937-64-bit-mode-evm-opcodes-evm64/23794",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    3670,
+    4200,
+    7937
+  ]
 }

--- a/src/data/eips/7958.json
+++ b/src/data/eips/7958.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-05-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7937-64-bit-mode-evm-opcodes-evm64/23794",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7937
+  ]
 }

--- a/src/data/eips/7960.json
+++ b/src/data/eips/7960.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-05-28",
   "discussionLink": "https://ethereum-magicians.org/t/eip-series-evm64/23794",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540
+  ]
 }

--- a/src/data/eips/7961.json
+++ b/src/data/eips/7961.json
@@ -9,5 +9,10 @@
   "createdDate": "2025-05-28",
   "discussionLink": "https://ethereum-magicians.org/t/eip-series-evm64/23794",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3540,
+    4750,
+    7960
+  ]
 }

--- a/src/data/eips/7971.json
+++ b/src/data/eips/7971.json
@@ -71,5 +71,8 @@
     "Encourages transient-storage patterns without persistent writes",
     "Simplifies cost reasoning for compilers and tooling"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1153
+  ]
 }

--- a/src/data/eips/7973.json
+++ b/src/data/eips/7973.json
@@ -66,5 +66,8 @@
     "Reduces disparity between multiple native ETH transfers and analogous token transfers in a single transaction.",
     "Avoids unfair gas penalties for future value-transfer opcodes that repeatedly update account balances."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2200
+  ]
 }

--- a/src/data/eips/7975.json
+++ b/src/data/eips/7975.json
@@ -63,5 +63,9 @@
   "tradeoffs": [
     "Requires coordinated client upgrade across all EL implementations",
     "Partial receipts cannot be verified until complete list received"
+  ],
+  "requires": [
+    7642,
+    7825
   ]
 }

--- a/src/data/eips/7976.json
+++ b/src/data/eips/7976.json
@@ -72,5 +72,8 @@
     "Encourages better practices for data availability within the Ethereum ecosystem.",
     "Ensures that transactions involving heavy computational requirements are not adversely affected."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7623
+  ]
 }

--- a/src/data/eips/7979.json
+++ b/src/data/eips/7979.json
@@ -67,5 +67,8 @@
     "Clients can validate that deployed code cannot execute invalid instructions, jump to invalid locations, or misuse the stack.",
     "Maintains backwards compatibility, enabling a smooth transition.  Tools and developers can take up the new features as they become available."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    3541
+  ]
 }

--- a/src/data/eips/7980.json
+++ b/src/data/eips/7980.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-06-25",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7980-adding-ed25519-as-a-signature-scheme-to-test-eip-7932/24663",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7932
+  ]
 }

--- a/src/data/eips/7981.json
+++ b/src/data/eips/7981.json
@@ -72,5 +72,10 @@
     "Encourages fairer transaction costs across users by preventing underutilization of pricing structures.",
     "Maintains compatibility with existing EIP-2930 while introducing necessary changes to the access list gas calculations."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2930,
+    7623,
+    7976
+  ]
 }

--- a/src/data/eips/7997.json
+++ b/src/data/eips/7997.json
@@ -71,5 +71,9 @@
     "Reduces the number of addresses that multi-chain applications have to distribute.",
     "Addresses limitations of fragile workarounds currently in use by developers for this need, providing a native solution instead."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    211,
+    1014
+  ]
 }

--- a/src/data/eips/7999.json
+++ b/src/data/eips/7999.json
@@ -66,5 +66,14 @@
     "Enhances resource allocation flexibility for developers, improving overall system efficiency.",
     "Facilitates future expansion into multiple resource dimensions seamlessly."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    2718,
+    4844,
+    7516,
+    7691,
+    7840,
+    7918
+  ]
 }

--- a/src/data/eips/8007.json
+++ b/src/data/eips/8007.json
@@ -8,5 +8,25 @@
   "createdDate": "2025-08-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8007-glamsterdam-gas-repricings-meta-eip/25206",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2780,
+    2926,
+    7686,
+    7778,
+    7904,
+    7923,
+    7971,
+    7973,
+    7976,
+    7981,
+    8011,
+    8032,
+    8037,
+    8038,
+    8053,
+    8057,
+    8058,
+    8059
+  ]
 }

--- a/src/data/eips/8011.json
+++ b/src/data/eips/8011.json
@@ -71,5 +71,8 @@
     "No impact to user experience.",
     "Paves the way for advanced pricing models without major protocol disruptions."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559
+  ]
 }

--- a/src/data/eips/8013.json
+++ b/src/data/eips/8013.json
@@ -66,5 +66,8 @@
     "Reduces runtime destination checks and gas.",
     "Aligns with EOF/EIP-7979 validation for immediates."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7979
+  ]
 }

--- a/src/data/eips/8015.json
+++ b/src/data/eips/8015.json
@@ -9,5 +9,9 @@
   "createdDate": "2025-08-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8015-remove-legacy-deposit-and-eth1data-fields/25401",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6110,
+    7732
+  ]
 }

--- a/src/data/eips/8016.json
+++ b/src/data/eips/8016.json
@@ -9,5 +9,9 @@
   "createdDate": "2025-08-28",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8016-ssz-compatibleunion/25275",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7495,
+    7916
+  ]
 }

--- a/src/data/eips/8030.json
+++ b/src/data/eips/8030.json
@@ -65,5 +65,9 @@
   ],
   "tradeoffs": [
     "P256 is not quantum secure"
+  ],
+  "requires": [
+    7932,
+    7951
   ]
 }

--- a/src/data/eips/8037.json
+++ b/src/data/eips/8037.json
@@ -77,5 +77,17 @@
     "Mitigates excessive state growth, enhancing Ethereum's overall scalability.",
     "Encourages developers to optimize contract designs due to increased costs."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2780,
+    6780,
+    7623,
+    7702,
+    7825,
+    7904,
+    7928,
+    7976,
+    7981,
+    8038
+  ]
 }

--- a/src/data/eips/8038.json
+++ b/src/data/eips/8038.json
@@ -65,5 +65,9 @@
     "Enhanced network performance while maintaining optimal resource usage.",
     "Encourages more efficient smart contract design by reflecting true operational costs."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7904,
+    8037
+  ]
 }

--- a/src/data/eips/8045.json
+++ b/src/data/eips/8045.json
@@ -66,5 +66,8 @@
     "Prevents wasting proposer slots on already slashed validators.",
     "Reduces prolonged degraded performance while slashed validators exit."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7917
+  ]
 }

--- a/src/data/eips/8046.json
+++ b/src/data/eips/8046.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-10-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8046-uniform-price-auction-over-inclusion-lists/25844",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7805
+  ]
 }

--- a/src/data/eips/8051.json
+++ b/src/data/eips/8051.json
@@ -74,5 +74,8 @@
     "Hardness assumptions secure against quantum adversaries",
     "Integrates with EIP-7932 algorithmic transaction framework"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7932
+  ]
 }

--- a/src/data/eips/8052.json
+++ b/src/data/eips/8052.json
@@ -53,5 +53,8 @@
     "Enables future ZK-SNARK/STARK optimizations via alternative Hash-to-Point implementations",
     "Hardness based on SIS problem over NTRU lattices, secure against quantum adversaries"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7932
+  ]
 }

--- a/src/data/eips/8057.json
+++ b/src/data/eips/8057.json
@@ -66,5 +66,9 @@
     "Improves effective L1 throughput and block execution efficiency.",
     "Enables deterministic, provable pricing from recent block data, easing stateless validation."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    7928
+  ]
 }

--- a/src/data/eips/8058.json
+++ b/src/data/eips/8058.json
@@ -67,5 +67,8 @@
     "Can yield major savings when GAS_CODE_DEPOSIT is high (e.g., under EIP-8037).",
     "Encourages bytecode reuse and efficient factory/clone patterns."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2930
+  ]
 }

--- a/src/data/eips/8061.json
+++ b/src/data/eips/8061.json
@@ -61,5 +61,8 @@
     "Separates consolidation churn into its own limit, configurable independently from activation and exit churn.",
     "Improves staking liquidity by reducing consolidation time and associated opportunity costs for validators."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7521
+  ]
 }

--- a/src/data/eips/8062.json
+++ b/src/data/eips/8062.json
@@ -66,5 +66,9 @@
     "Is easy to expand in the future if consolidation remains insufficient.",
     "Can be expanded already today to compensate for 0x02 lower capital efficiency"
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4895,
+    7251
+  ]
 }

--- a/src/data/eips/8068.json
+++ b/src/data/eips/8068.json
@@ -66,5 +66,8 @@
     "Removes hysteresis-gaming opportunities.",
     "Supports stake consolidation toward fast finality."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7251
+  ]
 }

--- a/src/data/eips/8070.json
+++ b/src/data/eips/8070.json
@@ -66,5 +66,11 @@
     "Preserves stochastic blobpool without complex sharding.",
     "Supports future BPO fork throughput increases."
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844,
+    7594,
+    7870,
+    8159
+  ]
 }

--- a/src/data/eips/8075.json
+++ b/src/data/eips/8075.json
@@ -9,5 +9,10 @@
   "createdDate": "2025-10-02",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8075-adaptive-state-cost-to-cap-growth-scale-l1/26450",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    4844,
+    8037
+  ]
 }

--- a/src/data/eips/8077.json
+++ b/src/data/eips/8077.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-11-07",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8077-eth-xx-add-nonce-and-source-to-transactions-announcement/26505",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7642
+  ]
 }

--- a/src/data/eips/8081.json
+++ b/src/data/eips/8081.json
@@ -8,5 +8,9 @@
   "createdDate": "2025-11-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8081-hegota-network-upgrade-meta-thread/26876",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7723,
+    7773
+  ]
 }

--- a/src/data/eips/8094.json
+++ b/src/data/eips/8094.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-11-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8094-eth-vhash-blob-aware-mempool/26834",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7642
+  ]
 }

--- a/src/data/eips/8096.json
+++ b/src/data/eips/8096.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-12-02",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8096-point-evaluation-precompile-gas-cost-increase/26867",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/8101.json
+++ b/src/data/eips/8101.json
@@ -9,5 +9,12 @@
   "createdDate": "2025-12-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8101-payload-chunking/27085",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844,
+    4895,
+    7732,
+    7825,
+    7928
+  ]
 }

--- a/src/data/eips/8105.json
+++ b/src/data/eips/8105.json
@@ -83,5 +83,8 @@
   "tradeoffs": [
     "Backwards-incompatible protocol changes across execution and consensus layers, increasing implementation complexity.",
     "Users must trust key providers; withheld or late keys can skip payload while envelope fees paid."
+  ],
+  "requires": [
+    7732
   ]
 }

--- a/src/data/eips/8115.json
+++ b/src/data/eips/8115.json
@@ -9,5 +9,9 @@
   "createdDate": "2025-12-30",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8115-batch-priority-fees-at-end-of-block/27358",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    4895
+  ]
 }

--- a/src/data/eips/8123.json
+++ b/src/data/eips/8123.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-01-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8123-json-rpc-method-for-transaction-gas-limit-cap/27417",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7825
+  ]
 }

--- a/src/data/eips/8125.json
+++ b/src/data/eips/8125.json
@@ -9,5 +9,9 @@
   "createdDate": "2026-01-14",
   "discussionLink": "https://ethereum-magicians.org/t/eip8125-temporary-contract-storage/27440",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2200,
+    2929
+  ]
 }

--- a/src/data/eips/8130.json
+++ b/src/data/eips/8130.json
@@ -9,5 +9,8 @@
   "createdDate": "2025-10-14",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8130-account-abstraction-by-account-configurations/25952",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2718
+  ]
 }

--- a/src/data/eips/8131.json
+++ b/src/data/eips/8131.json
@@ -9,5 +9,10 @@
   "createdDate": "2025-01-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-9999-add-auth-data-to-eip-7623-floor/12345",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7623,
+    7702,
+    7976
+  ]
 }

--- a/src/data/eips/8133.json
+++ b/src/data/eips/8133.json
@@ -8,5 +8,24 @@
   "createdDate": "2026-01-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8133-upgrade-nomenclature/27575",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    150,
+    606,
+    607,
+    608,
+    609,
+    779,
+    1013,
+    1283,
+    1679,
+    1716,
+    2387,
+    4345,
+    5133,
+    7569,
+    7600,
+    7609,
+    7892
+  ]
 }

--- a/src/data/eips/8134.json
+++ b/src/data/eips/8134.json
@@ -8,5 +8,8 @@
   "createdDate": "2026-01-24",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8134-hardfork-meta-bpo1/27582",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7892
+  ]
 }

--- a/src/data/eips/8135.json
+++ b/src/data/eips/8135.json
@@ -8,5 +8,9 @@
   "createdDate": "2026-01-24",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8135-hardfork-meta-bpo2/27605",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7892,
+    8134
+  ]
 }

--- a/src/data/eips/8136.json
+++ b/src/data/eips/8136.json
@@ -22,5 +22,8 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7594
+  ]
 }

--- a/src/data/eips/8138.json
+++ b/src/data/eips/8138.json
@@ -8,5 +8,9 @@
   "createdDate": "2026-01-27",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8138-hardfork-meta-bpo3/27606",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7892,
+    8135
+  ]
 }

--- a/src/data/eips/8141.json
+++ b/src/data/eips/8141.json
@@ -88,5 +88,13 @@
   "tradeoffs": [
     "Introduces new DoS vectors requiring ERC-7562 style mempool restrictions",
     "Changes ORIGIN opcode behavior for frame transactions"
+  ],
+  "requires": [
+    1559,
+    2718,
+    3607,
+    4844,
+    7623,
+    7702
   ]
 }

--- a/src/data/eips/8142.json
+++ b/src/data/eips/8142.json
@@ -9,5 +9,12 @@
   "createdDate": "2026-01-29",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8142-block-in-blobs-bib/27621",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844,
+    7594,
+    7732,
+    7892,
+    7928
+  ]
 }

--- a/src/data/eips/8146.json
+++ b/src/data/eips/8146.json
@@ -9,5 +9,9 @@
   "createdDate": "2026-02-03",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8146-block-access-list-sidecars/27757",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7732,
+    7928
+  ]
 }

--- a/src/data/eips/8148.json
+++ b/src/data/eips/8148.json
@@ -9,5 +9,10 @@
   "createdDate": "2026-02-05",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8148-custom-sweep-threshold-for-validators/27669",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7251,
+    7685,
+    7732
+  ]
 }

--- a/src/data/eips/8149.json
+++ b/src/data/eips/8149.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-02-06",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8149-multi-kzg-point-evaluation-precompile/27671",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4844
+  ]
 }

--- a/src/data/eips/8151.json
+++ b/src/data/eips/8151.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-02-09",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8151-ecdsa-authority-deactivation-aware-ecrecover/27690",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7851
+  ]
 }

--- a/src/data/eips/8159.json
+++ b/src/data/eips/8159.json
@@ -63,5 +63,9 @@
   "tradeoffs": [
     "Requires BAL storage during weak subjectivity period (~2 weeks)",
     "Archive nodes may need to store BALs indefinitely for full historical serving"
+  ],
+  "requires": [
+    7928,
+    7975
   ]
 }

--- a/src/data/eips/8163.json
+++ b/src/data/eips/8163.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-02-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8163-reserve-0xae-extension-opcode/27756",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    141
+  ]
 }

--- a/src/data/eips/8164.json
+++ b/src/data/eips/8164.json
@@ -9,5 +9,14 @@
   "createdDate": "2026-02-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8164-native-key-delegation/27770",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2,
+    2718,
+    2929,
+    3541,
+    3607,
+    4844,
+    7702
+  ]
 }

--- a/src/data/eips/8175.json
+++ b/src/data/eips/8175.json
@@ -9,5 +9,10 @@
   "createdDate": "2026-02-26",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8175-composable-transaction/27850",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2,
+    1559,
+    2718
+  ]
 }

--- a/src/data/eips/8182.json
+++ b/src/data/eips/8182.json
@@ -29,5 +29,8 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    20
+  ]
 }

--- a/src/data/eips/8184.json
+++ b/src/data/eips/8184.json
@@ -89,5 +89,9 @@
     "Adds one-slot execution latency as transactions execute in the following block",
     "Introduces trust assumptions around decryptors for key release timing",
     "Substantial cross-layer implementation complexity touching both consensus and execution clients"
+  ],
+  "requires": [
+    2718,
+    7805
   ]
 }

--- a/src/data/eips/8188.json
+++ b/src/data/eips/8188.json
@@ -29,5 +29,10 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2929,
+    2930,
+    8037
+  ]
 }

--- a/src/data/eips/8189.json
+++ b/src/data/eips/8189.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-03-06",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8189-snap-2-bal-based-state-healing/27953",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7928
+  ]
 }

--- a/src/data/eips/8197.json
+++ b/src/data/eips/8197.json
@@ -9,5 +9,12 @@
   "createdDate": "2025-03-04",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8197-cryptographically-agile-transactions-catx/28003",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    2718,
+    2930,
+    4844,
+    7702
+  ]
 }

--- a/src/data/eips/8198.json
+++ b/src/data/eips/8198.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-03-17",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8198-quick-slots/28057",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7892
+  ]
 }

--- a/src/data/eips/8200.json
+++ b/src/data/eips/8200.json
@@ -9,5 +9,12 @@
   "createdDate": "2026-03-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8200-evmification/28036",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    152,
+    2537,
+    7666,
+    7823,
+    7883
+  ]
 }

--- a/src/data/eips/8202.json
+++ b/src/data/eips/8202.json
@@ -9,5 +9,15 @@
   "createdDate": "2026-03-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8202-schemed-transaction/28044",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    2,
+    155,
+    1559,
+    2718,
+    2780,
+    4844,
+    7702,
+    7976
+  ]
 }

--- a/src/data/eips/8205.json
+++ b/src/data/eips/8205.json
@@ -30,5 +30,11 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    4788,
+    6110,
+    7685,
+    7732
+  ]
 }

--- a/src/data/eips/8209.json
+++ b/src/data/eips/8209.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-04-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8209-commit-reveal-transaction-frames/28105",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    8141
+  ]
 }

--- a/src/data/eips/8237.json
+++ b/src/data/eips/8237.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-04-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8237-independent-cl-el-sync/28331",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7732
+  ]
 }

--- a/src/data/eips/8246.json
+++ b/src/data/eips/8246.json
@@ -22,5 +22,9 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    161,
+    6780
+  ]
 }

--- a/src/data/eips/8250.json
+++ b/src/data/eips/8250.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-04-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8250-keyed-nonces-for-frame-transactions/28437",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    8141
+  ]
 }

--- a/src/data/eips/8253.json
+++ b/src/data/eips/8253.json
@@ -30,5 +30,9 @@
     }
   ],
   "tradeoffs": null,
-  "discussionLink": "https://ethereum-magicians.org/t/eip-8253-upgrade-pre-spurious-dragon-accounts/28505"
+  "discussionLink": "https://ethereum-magicians.org/t/eip-8253-upgrade-pre-spurious-dragon-accounts/28505",
+  "requires": [
+    161,
+    684
+  ]
 }

--- a/src/data/eips/8254.json
+++ b/src/data/eips/8254.json
@@ -22,5 +22,8 @@
       ]
     }
   ],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    6110
+  ]
 }

--- a/src/data/eips/8261.json
+++ b/src/data/eips/8261.json
@@ -9,5 +9,10 @@
   "createdDate": "2026-05-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8261-gas-limit-schedule/28494",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    1559,
+    7840,
+    7892
+  ]
 }

--- a/src/data/eips/8266.json
+++ b/src/data/eips/8266.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-05-15",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8266-expiring-nonces-for-frame-transactions/28575",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    8141
+  ]
 }

--- a/src/data/eips/8268.json
+++ b/src/data/eips/8268.json
@@ -9,5 +9,8 @@
   "createdDate": "2026-05-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8268-storage-roots-in-block-access-lists/28585",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    7928
+  ]
 }

--- a/src/data/eips/868.json
+++ b/src/data/eips/868.json
@@ -9,5 +9,9 @@
   "createdDate": "2018-02-02",
   "discussionLink": "https://github.com/ethereum/devp2p/issues/44",
   "forkRelationships": [],
-  "tradeoffs": null
+  "tradeoffs": null,
+  "requires": [
+    8,
+    778
+  ]
 }

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -46,6 +46,7 @@ export interface EIP {
   reviewer?: string;
   layer?: 'EL' | 'CL';
   collection?: string;
+  requires?: number[];
   /** Override for EIPs not yet merged into ethereum/EIPs (default URL would 404). */
   specificationUrl?: string;
   forkRelationships: ForkRelationship[];

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -172,6 +172,19 @@ export const getEipIdFromHash = (hash: string): number | null => {
   return Number.isSafeInteger(eipId) ? eipId : null;
 };
 
+export const buildDependentsMap = (eips: EIP[]): Map<number, EIP[]> => {
+  const map = new Map<number, EIP[]>();
+  for (const eip of eips) {
+    if (eip.requires) {
+      for (const reqId of eip.requires) {
+        if (!map.has(reqId)) map.set(reqId, []);
+        map.get(reqId)!.push(eip);
+      }
+    }
+  }
+  return map;
+};
+
 export interface UpgradeAnchorExpansionState {
   declined: boolean;
   headlinerProposals: boolean;


### PR DESCRIPTION
- feature: add a "Dependents" tab on EIP pages to view what's being built on top of a given EIP
- eip fetch workflow now tracks "requires" eip numbers
- in the metadata, eip's also now display the eips they require