### PR TITLE
Show fork notices on upgrade EIP cards

### DIFF
--- a/src/components/network-upgrade/EipCard.tsx
+++ b/src/components/network-upgrade/EipCard.tsx
@@ -14,6 +14,7 @@ import {
   getForkRelationship,
 } from '../../utils';
 import { Tooltip, CopyLinkButton } from '../ui';
+import { EipNotice } from '../eip/EipNotice';
 // Butterfly view disabled — data is stale. Uncomment to re-enable.
 // import { useButterflyData } from '../../hooks/useButterflyData';
 // import { ClientTestingProgress } from './ClientTestingProgress';
@@ -38,6 +39,7 @@ export const EipCard: React.FC<EipCardProps> = ({
   const [showChampionDetails, setShowChampionDetails] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const forkRelationship = getForkRelationship(eip, forkName);
+  const notice = forkRelationship?.notice;
 
   // Butterfly view disabled — data is stale. Uncomment to re-enable.
   // const { data: butterflyData, loading: butterflyLoading, error: butterflyError } = useButterflyData(eip.id, forkName);
@@ -188,6 +190,8 @@ export const EipCard: React.FC<EipCardProps> = ({
 
       {/* Description */}
       <div className="">
+        {notice && <EipNotice notice={notice} className="mb-4" />}
+
         <p className="text-slate-700 dark:text-slate-300 text-sm leading-relaxed">
           {parseMarkdownLinks(getSummaryDescription(eip))}
         </p>


### PR DESCRIPTION
## Summary

Restores fork-scoped EIP notice banners on the individual EIP cards within upgrade pages, while keeping the existing upgrade overview and standalone EIP page notices.

## Changes

- Reuses the existing shared `EipNotice` component in `EipCard`.
- Reads the notice from the current EIP's relationship to the displayed fork.
- Keeps the notice metadata on the EIP fork relationship, so all three placements are driven by the same source.

## Validation

- `npm run lint`
- `npx tsc -b`
- `npm run test`
- Local browser check confirmed the EIP-7904 notice appears in the Glamsterdam overview, the Glamsterdam EIP card, and `/eips/7904`.