### PR TITLE
sync: set video/transcript offsets for FCR 8

### DIFF
--- a/public/artifacts/fcr/2026-05-26_008/config.json
+++ b/public/artifacts/fcr/2026-05-26_008/config.json
@@ -2,7 +2,7 @@
   "issue": 2053,
   "videoUrl": "https://www.youtube.com/watch?v=uKk5UMlvzIw",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:05:26",
+    "videoStartTime": "00:05:26"
   }
 }


### PR DESCRIPTION
Sets sync offsets for FCR 8 (speech begins at 05:26).