### PR TITLE
schedule: automate devnet launch dates

### DIFF
--- a/.github/workflows/scrape-devnet-specs.yml
+++ b/.github/workflows/scrape-devnet-specs.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Scrape devnet specs
         run: node scripts/scrape-all-devnet-specs.mjs
 
+      - name: Sync devnet launch dates
+        run: node scripts/sync-devnet-launches.mjs
+
       - name: Check for changes
         id: changes
         run: |
@@ -39,7 +42,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/devnets/
+          git add src/data/devnets/ src/data/generated/devnet-launches.json
           git commit -m "sync: scrape devnet specs"
           git push
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "generate-plan": "node --env-file=.env scripts/generate-plan-artifacts.mjs",
     "scrape-devnet": "node scripts/scrape-devnet-spec.mjs",
     "scrape-devnets": "node scripts/scrape-all-devnet-specs.mjs",
+    "sync-devnet-launches": "node scripts/sync-devnet-launches.mjs",
     "audit-eips": "node scripts/audit-eips.mjs",
     "fetch-test-counts": "uv run --project execution-specs python scripts/collect-test-counts.py execution-specs src/data/execution-spec-test-counts.json"
   },

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -294,11 +294,14 @@ async function main() {
     console.log(`  genesis time: ${new Date(genesisTime * 1000).toISOString()}`);
   }
 
-  // Preserve the `canceled` flag from the existing file if present
+  // Preserve flags from the existing file if present
   const outPath = join(OUTPUT_DIR, `${id}.json`);
   if (existsSync(outPath)) {
     const existing = JSON.parse(readFileSync(outPath, 'utf-8'));
     if (existing.canceled) spec.canceled = true;
+    if (!spec.genesisTime && existing.genesisTime) {
+      spec.genesisTime = existing.genesisTime;
+    }
   }
 
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });

--- a/scripts/sync-devnet-launches.mjs
+++ b/scripts/sync-devnet-launches.mjs
@@ -29,6 +29,11 @@ function formatDate(unixSeconds) {
   });
 }
 
+function formatDateISO(unixSeconds) {
+  const d = new Date(unixSeconds * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
 const result = {};
 
 for (const series of SERIES) {
@@ -45,7 +50,7 @@ for (const series of SERIES) {
     if (spec.genesisTime * 1000 > Date.now()) continue;
 
     const version = parseInt(file.replace(prefix, '').replace('.json', ''), 10);
-    launches.push({ version, date: formatDate(spec.genesisTime) });
+    launches.push({ version, date: formatDate(spec.genesisTime), dateISO: formatDateISO(spec.genesisTime) });
   }
 
   launches.sort((a, b) => a.version - b.version);

--- a/scripts/sync-devnet-launches.mjs
+++ b/scripts/sync-devnet-launches.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Generate devnet-launches.json from scraped devnet spec files.
+ * Reads all {series}-devnet-*.json files and extracts launch dates
+ * from the genesisTime field for devnets that have already launched.
+ *
+ * Usage: node scripts/sync-devnet-launches.mjs
+ */
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEVNETS_DIR = join(__dirname, '..', 'src/data/devnets');
+const OUTPUT_DIR = join(__dirname, '..', 'src/data/generated');
+const OUTPUT_PATH = join(OUTPUT_DIR, 'devnet-launches.json');
+
+// Series to track — add new fork names here as they start devnets
+const SERIES = ['glamsterdam', 'hegota'];
+
+function formatDate(unixSeconds) {
+  const d = new Date(unixSeconds * 1000);
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+const result = {};
+
+for (const series of SERIES) {
+  const prefix = `${series}-devnet-`;
+  const files = readdirSync(DEVNETS_DIR).filter(
+    (f) => f.startsWith(prefix) && f.endsWith('.json'),
+  );
+
+  const launches = [];
+  for (const file of files) {
+    const spec = JSON.parse(readFileSync(join(DEVNETS_DIR, file), 'utf-8'));
+    if (!spec.genesisTime) continue;
+    // Only include devnets that have already launched
+    if (spec.genesisTime * 1000 > Date.now()) continue;
+
+    const version = parseInt(file.replace(prefix, '').replace('.json', ''), 10);
+    launches.push({ version, date: formatDate(spec.genesisTime) });
+  }
+
+  launches.sort((a, b) => a.version - b.version);
+  if (launches.length) {
+    result[series] = launches;
+  }
+}
+
+if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
+writeFileSync(OUTPUT_PATH, JSON.stringify(result, null, 2) + '\n');
+console.log(`Wrote ${OUTPUT_PATH} (${Object.keys(result).length} series)`);

--- a/src/constants/timeline-phases.ts
+++ b/src/constants/timeline-phases.ts
@@ -364,7 +364,7 @@ function enrichDevnetDates(progress: ForkProgress, forkKey: string): ForkProgres
         devnets: phase.devnets.map(devnet => {
           const version = parseInt(devnet.name.replace('Devnet-', ''), 10);
           const launch = launches.find(l => l.version === version);
-          if (launch && devnet.status !== 'completed') {
+          if (launch) {
             return { ...devnet, status: 'completed' as const, date: launch.date };
           }
           return devnet;

--- a/src/constants/timeline-phases.ts
+++ b/src/constants/timeline-phases.ts
@@ -4,6 +4,7 @@ import type {
   ForkProgress,
   MacroPhaseConfig
 } from '../types/timeline';
+import devnetLaunches from '../data/generated/devnet-launches.json';
 
 export const GLAMSTERDAM_TIMELINE_PHASES: TimelinePhase[] = [
   {
@@ -200,7 +201,7 @@ export const FUSAKA_PROGRESS: ForkProgress = {
 };
 
 // Glamsterdam progress with actual dates for completed milestones
-export const GLAMSTERDAM_PROGRESS: ForkProgress = {
+const RAW_GLAMSTERDAM_PROGRESS: ForkProgress = {
   forkName: 'Glamsterdam',
   phases: [
     {
@@ -276,7 +277,7 @@ export const GLAMSTERDAM_PROGRESS: ForkProgress = {
   ]
 };
 
-export const HEGOTA_PROGRESS: ForkProgress = {
+const RAW_HEGOTA_PROGRESS: ForkProgress = {
   forkName: 'Hegota',
   phases: [
     {
@@ -349,6 +350,32 @@ export const HEGOTA_PROGRESS: ForkProgress = {
     }
   ]
 };
+
+function enrichDevnetDates(progress: ForkProgress, forkKey: string): ForkProgress {
+  const launches = (devnetLaunches as Record<string, { version: number; date: string }[]>)[forkKey] ?? [];
+  if (!launches.length) return progress;
+
+  return {
+    ...progress,
+    phases: progress.phases.map(phase => {
+      if (phase.phaseId !== 'development' || !phase.devnets) return phase;
+      return {
+        ...phase,
+        devnets: phase.devnets.map(devnet => {
+          const version = parseInt(devnet.name.replace('Devnet-', ''), 10);
+          const launch = launches.find(l => l.version === version);
+          if (launch && devnet.status !== 'completed') {
+            return { ...devnet, status: 'completed' as const, date: launch.date };
+          }
+          return devnet;
+        }),
+      };
+    }),
+  };
+}
+
+export const GLAMSTERDAM_PROGRESS = enrichDevnetDates(RAW_GLAMSTERDAM_PROGRESS, 'glamsterdam');
+export const HEGOTA_PROGRESS = enrichDevnetDates(RAW_HEGOTA_PROGRESS, 'hegota');
 
 export const UPGRADE_PROCESS_PHASES: ProcessPhase[] = [
   {

--- a/src/data/devnets/glamsterdam-devnet-0.json
+++ b/src/data/devnets/glamsterdam-devnet-0.json
@@ -251,5 +251,6 @@
       "version": "bal@v5.6.1",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
-  }
+  },
+  "genesisTime": 1776988800
 }

--- a/src/data/devnets/glamsterdam-devnet-1.json
+++ b/src/data/devnets/glamsterdam-devnet-1.json
@@ -96,5 +96,6 @@
       "version": "bal@v5.6.1",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
-  }
+  },
+  "genesisTime": 1777420800
 }

--- a/src/data/devnets/glamsterdam-devnet-2.json
+++ b/src/data/devnets/glamsterdam-devnet-2.json
@@ -103,5 +103,6 @@
       "version": "bal@v5.6.1",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
-  }
+  },
+  "genesisTime": 1777507200
 }

--- a/src/data/devnets/glamsterdam-devnet-3.json
+++ b/src/data/devnets/glamsterdam-devnet-3.json
@@ -102,5 +102,6 @@
       "version": "bal@v5.6.1",
       "url": "https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v5.6.1"
     }
-  }
+  },
+  "genesisTime": 1778025600
 }

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1,3 +1,5 @@
+import devnetLaunches from './generated/devnet-launches.json';
+
 export interface TimelineEvent {
   type: 'event';
   date: string; // YYYY-MM-DD format for sorting/display
@@ -5,6 +7,22 @@ export interface TimelineEvent {
   title: string;
   category: 'mainnet' | 'testnet' | 'milestone' | 'announcement' | 'devnet';
 }
+
+const FORK_DISPLAY_NAMES: Record<string, string> = {
+  glamsterdam: 'Glamsterdam',
+  hegota: 'Hegotá',
+};
+
+const generatedDevnetEvents: TimelineEvent[] = Object.entries(
+  devnetLaunches as Record<string, { version: number; date: string; dateISO: string }[]>,
+).flatMap(([fork, launches]) =>
+  launches.map((l) => ({
+    type: 'event' as const,
+    date: l.dateISO,
+    title: `${FORK_DISPLAY_NAMES[fork] ?? fork} Devnet-${l.version} Launches`,
+    category: 'devnet' as const,
+  })),
+);
 
 export const timelineEvents: TimelineEvent[] = [
   {
@@ -128,6 +146,7 @@ export const timelineEvents: TimelineEvent[] = [
     datetime: '2026-01-07 01:01:11',
     title: 'BPO2 on Mainnet (14/21 blobs)',
     category: 'mainnet'
-  }
+  },
+  ...generatedDevnetEvents,
 ];
 

--- a/src/data/generated/devnet-launches.json
+++ b/src/data/generated/devnet-launches.json
@@ -2,23 +2,28 @@
   "glamsterdam": [
     {
       "version": 0,
-      "date": "Apr 24, 2026"
+      "date": "Apr 24, 2026",
+      "dateISO": "2026-04-24"
     },
     {
       "version": 1,
-      "date": "Apr 29, 2026"
+      "date": "Apr 29, 2026",
+      "dateISO": "2026-04-29"
     },
     {
       "version": 2,
-      "date": "Apr 30, 2026"
+      "date": "Apr 30, 2026",
+      "dateISO": "2026-04-30"
     },
     {
       "version": 3,
-      "date": "May 6, 2026"
+      "date": "May 6, 2026",
+      "dateISO": "2026-05-06"
     },
     {
       "version": 4,
-      "date": "May 22, 2026"
+      "date": "May 22, 2026",
+      "dateISO": "2026-05-22"
     }
   ]
 }

--- a/src/data/generated/devnet-launches.json
+++ b/src/data/generated/devnet-launches.json
@@ -1,0 +1,24 @@
+{
+  "glamsterdam": [
+    {
+      "version": 0,
+      "date": "Apr 24, 2026"
+    },
+    {
+      "version": 1,
+      "date": "Apr 29, 2026"
+    },
+    {
+      "version": 2,
+      "date": "Apr 30, 2026"
+    },
+    {
+      "version": 3,
+      "date": "May 6, 2026"
+    },
+    {
+      "version": 4,
+      "date": "May 22, 2026"
+    }
+  ]
+}


### PR DESCRIPTION
glam-devnet-4 went live on may 22. `/schedule` and `/calls` pages currently require manual update of devnet launch dates, but this PR automates that.