### PR TITLE
sync: set video/transcript offsets for PQTS 9, PRICE 8 and PQI 41

### DIFF
--- a/public/artifacts/pqi/2026-05-27_041/config.json
+++ b/public/artifacts/pqi/2026-05-27_041/config.json
@@ -2,7 +2,7 @@
   "issue": 2081,
   "videoUrl": "https://www.youtube.com/watch?v=bIKIeq-l_HU",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:07:25",
+    "videoStartTime": "00:07:25"
   }
 }

--- a/public/artifacts/pqts/2026-05-27_009/config.json
+++ b/public/artifacts/pqts/2026-05-27_009/config.json
@@ -2,7 +2,7 @@
   "issue": 2078,
   "videoUrl": "https://www.youtube.com/watch?v=Dziegq_gsZo",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:16:34",
+    "videoStartTime": "00:16:34"
   }
 }

--- a/public/artifacts/price/2026-05-27_008/config.json
+++ b/public/artifacts/price/2026-05-27_008/config.json
@@ -2,7 +2,7 @@
   "issue": 2082,
   "videoUrl": "https://www.youtube.com/watch?v=lp8R-UNSCag",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:03:31",
+    "videoStartTime": "00:03:31"
   }
 }


### PR DESCRIPTION
Sets video/transcript sync offsets for three newly synced calls (dead air at the start trimmed):

- **PQTS 9** → `00:16:34`
- **PRICE 8** → `00:03:31`
- **PQI 41** → `00:07:25`

All non-livestreamed, so video and transcript share the same offset.