### PR TITLE
Bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,12 +45,12 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload dist directory (Vite build output)
           path: dist
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/fetch-eips.yml
+++ b/.github/workflows/fetch-eips.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Trigger deploy
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/fetch-test-counts.yml
+++ b/.github/workflows/fetch-test-counts.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Trigger deploy
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/generate-plan-artifacts.yml
+++ b/.github/workflows/generate-plan-artifacts.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Trigger deploy
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/scrape-devnet-specs.yml
+++ b/.github/workflows/scrape-devnet-specs.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Trigger deploy
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/sync-call-assets.yml
+++ b/.github/workflows/sync-call-assets.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Trigger deploy
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
## Summary
- Update Pages deployment actions to current majors so they run on Node 24.
- Bump `actions/github-script` in all deploy-triggering workflows to remove the Node 20 deprecation warning.
- Update `astral-sh/setup-uv` to a Node 24-compatible release in the test-count workflow.

## Testing
- Verified the workflow YAML parses cleanly.
- Checked the updated action metadata against upstream releases.
- Ran Prettier formatting checks on `.github/workflows/*.yml`.