### PR TITLE
Fix mobile EIP timeline layout

### DIFF
--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -226,7 +226,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                       {group.champions && group.champions.length > 0 && group.champions.some(c => c.name) && (
                         <Tooltip text={`${group.champions.length > 1 ? 'Champions' : 'Champion'} for ${getForkDisplayName(group.forkName)}`}>
                           <div className="flex min-w-0 max-w-full items-start gap-1 text-xs text-slate-400 dark:text-slate-400 cursor-help sm:items-center sm:shrink-0">
-                            <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg className="mt-0.5 w-3 h-3 shrink-0 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                             </svg>
                             <span className="min-w-0 break-words">{group.champions.map(c => c.name).join(' & ')}</span>
@@ -238,7 +238,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                     {/* Sub-items with dot-and-line */}
                     {allItems.length > 0 && (
                       <div className="mt-1.5 ml-2 relative">
-                        <div className="absolute left-[3px] -top-1.5 w-0.5 h-3 bg-slate-200 dark:bg-slate-700" />
+                        <div className="absolute left-[3px] -top-2 bottom-1 w-0.5 bg-slate-200 dark:bg-slate-700" />
                         {allItems.map((item, idx) => {
                           const isLastChild = idx === allItems.length - 1;
 
@@ -247,11 +247,8 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                             const entryColors = statusColors[entry.status] || statusColors.Proposed;
                             return (
                               <div key={`status-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
-                                  <div className={`w-2 h-2 rounded-full ${entryColors.dot}`} />
-                                  {!isLastChild && (
-                                    <div className="absolute left-[3px] top-2 bottom-[-10px] w-0.5 bg-slate-200 dark:bg-slate-700" />
-                                  )}
+                                <div className="relative mt-1 w-2 shrink-0">
+                                  <div className={`relative z-10 w-2 h-2 rounded-full ${entryColors.dot}`} />
                                 </div>
                                 <div className="min-w-0 flex-1 leading-tight">
                                   <span className={`text-xs ${entryColors.text}`}>
@@ -309,11 +306,8 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
 
                             return (
                               <div key={`pres-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
-                                  <div className="w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />
-                                  {!isLastChild && (
-                                    <div className="absolute left-[3px] top-2 bottom-[-10px] w-0.5 bg-slate-200 dark:bg-slate-700" />
-                                  )}
+                                <div className="relative mt-1 w-2 shrink-0">
+                                  <div className="relative z-10 w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />
                                 </div>
                                 <div className="min-w-0 flex-1 leading-tight">
                                   <span className="text-xs text-slate-500 dark:text-slate-400">

--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -240,7 +240,6 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                     {/* Sub-items with dot-and-line */}
                     {allItems.length > 0 && (
                       <div className="mt-1.5 ml-2 relative">
-                        <div className={`absolute left-[3px] ${hasVisibleChampions ? 'top-0.5' : '-top-1.5'} bottom-1 w-0.5 bg-slate-200 dark:bg-slate-700`} />
                         {allItems.map((item, idx) => {
                           const isLastChild = idx === allItems.length - 1;
 
@@ -249,8 +248,11 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                             const entryColors = statusColors[entry.status] || statusColors.Proposed;
                             return (
                               <div key={`status-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative mt-1 w-2 shrink-0">
+                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
                                   <div className={`relative z-10 w-2 h-2 rounded-full ${entryColors.dot}`} />
+                                  {!isLastChild && (
+                                    <div className="absolute left-[3px] top-2 bottom-[-18px] w-0.5 bg-slate-200 dark:bg-slate-700" />
+                                  )}
                                 </div>
                                 <div className="min-w-0 flex-1 leading-tight">
                                   <span className={`text-xs ${entryColors.text}`}>
@@ -308,8 +310,11 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
 
                             return (
                               <div key={`pres-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative mt-1 w-2 shrink-0">
+                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
                                   <div className="relative z-10 w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />
+                                  {!isLastChild && (
+                                    <div className="absolute left-[3px] top-2 bottom-[-18px] w-0.5 bg-slate-200 dark:bg-slate-700" />
+                                  )}
                                 </div>
                                 <div className="min-w-0 flex-1 leading-tight">
                                   <span className="text-xs text-slate-500 dark:text-slate-400">

--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -171,7 +171,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
         Timeline
       </h3>
       <div className="bg-slate-50 dark:bg-slate-700/30 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
-        <div className="px-4 py-3.5 bg-white dark:bg-slate-800">
+        <div className="px-3 py-3.5 sm:px-4 bg-white dark:bg-slate-800">
           <div className="relative">
             {forkGroups.map((group, groupIndex) => {
               const isLastNode = !hasCreatedDate && groupIndex === forkGroups.length - 1;
@@ -202,7 +202,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
               });
 
               return (
-                <div key={group.forkName} className="relative flex gap-3">
+                <div key={group.forkName} className="relative flex gap-2.5 sm:gap-3">
                   {/* Main timeline dot and line */}
                   <div className="relative w-2.5 shrink-0 flex flex-col items-center pt-1">
                     <div className="w-2.5 h-2.5 rounded-full shrink-0 bg-slate-400 dark:bg-slate-500" />
@@ -216,20 +216,20 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                   {/* Content */}
                   <div className={`min-w-0 flex-1 ${isLastNode ? '' : 'pb-4'}`}>
                     {/* Fork header with bordered badge */}
-                    <div className="flex items-center justify-between gap-2">
+                    <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
                       <Link
                         to={`/upgrade/${group.forkName.toLowerCase()}`}
-                        className="text-xs font-mono font-medium px-2 py-0.5 rounded border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-purple-400 dark:hover:border-purple-500 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+                        className="shrink-0 text-xs font-mono font-medium px-2 py-0.5 rounded border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-purple-400 dark:hover:border-purple-500 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
                       >
                         {getForkDisplayName(group.forkName)}
                       </Link>
                       {group.champions && group.champions.length > 0 && group.champions.some(c => c.name) && (
                         <Tooltip text={`${group.champions.length > 1 ? 'Champions' : 'Champion'} for ${getForkDisplayName(group.forkName)}`}>
-                          <div className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 cursor-help shrink-0">
-                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <div className="flex min-w-0 max-w-full items-start gap-1 text-xs text-slate-400 dark:text-slate-400 cursor-help sm:items-center sm:shrink-0">
+                            <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                             </svg>
-                            <span>{group.champions.map(c => c.name).join(' & ')}</span>
+                            <span className="min-w-0 break-words">{group.champions.map(c => c.name).join(' & ')}</span>
                           </div>
                         </Tooltip>
                       )}
@@ -238,8 +238,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                     {/* Sub-items with dot-and-line */}
                     {allItems.length > 0 && (
                       <div className="mt-1.5 ml-2 relative">
-                        {/* Connecting line from fork header - hidden on mobile */}
-                        <div className="hidden md:block absolute left-[3px] -top-1.5 w-0.5 h-3 bg-slate-200 dark:bg-slate-700" />
+                        <div className="absolute left-[3px] -top-1.5 w-0.5 h-3 bg-slate-200 dark:bg-slate-700" />
                         {allItems.map((item, idx) => {
                           const isLastChild = idx === allItems.length - 1;
 
@@ -247,14 +246,14 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                             const entry = item.entry;
                             const entryColors = statusColors[entry.status] || statusColors.Proposed;
                             return (
-                              <div key={`status-${idx}`} className={`relative flex items-center gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative w-2 shrink-0">
+                              <div key={`status-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
+                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
                                   <div className={`w-2 h-2 rounded-full ${entryColors.dot}`} />
                                   {!isLastChild && (
-                                    <div className="hidden md:block absolute left-[3px] top-2 w-0.5 h-[20px] bg-slate-200 dark:bg-slate-700" />
+                                    <div className="absolute left-[3px] top-2 bottom-[-10px] w-0.5 bg-slate-200 dark:bg-slate-700" />
                                   )}
                                 </div>
-                                <div className="min-w-0 flex-1 leading-none">
+                                <div className="min-w-0 flex-1 leading-tight">
                                   <span className={`text-xs ${entryColors.text}`}>
                                     {statusLabels[entry.status]}
                                   </span>
@@ -309,14 +308,14 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                             }[presentation.type] || 'Presented';
 
                             return (
-                              <div key={`pres-${idx}`} className={`relative flex items-center gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
-                                <div className="relative w-2 shrink-0">
+                              <div key={`pres-${idx}`} className={`relative flex items-start gap-2.5 ${isLastChild ? '' : 'pb-2.5'}`}>
+                                <div className="relative mt-1 w-2 shrink-0 self-stretch">
                                   <div className="w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />
                                   {!isLastChild && (
-                                    <div className="hidden md:block absolute left-[3px] top-2 w-0.5 h-[20px] bg-slate-200 dark:bg-slate-700" />
+                                    <div className="absolute left-[3px] top-2 bottom-[-10px] w-0.5 bg-slate-200 dark:bg-slate-700" />
                                   )}
                                 </div>
-                                <div className="min-w-0 flex-1 leading-none">
+                                <div className="min-w-0 flex-1 leading-tight">
                                   <span className="text-xs text-slate-500 dark:text-slate-400">
                                     {label}
                                   </span>
@@ -395,13 +394,13 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
 
             {/* EIP Created node */}
             {hasCreatedDate && (
-              <div className="relative flex gap-3">
+              <div className="relative flex gap-2.5 sm:gap-3">
                 <div className="relative w-2.5 shrink-0 flex flex-col items-center pt-1">
                   <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${statusColors.created.dot}`} />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-mono font-medium px-2 py-0.5 rounded border border-indigo-300 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400">
+                  <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2">
+                    <span className="shrink-0 text-xs font-mono font-medium px-2 py-0.5 rounded border border-indigo-300 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400">
                       EIP Created
                     </span>
                     <span className="text-xs text-slate-500 dark:text-slate-400">

--- a/src/components/eip/EipTimeline.tsx
+++ b/src/components/eip/EipTimeline.tsx
@@ -175,6 +175,8 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
           <div className="relative">
             {forkGroups.map((group, groupIndex) => {
               const isLastNode = !hasCreatedDate && groupIndex === forkGroups.length - 1;
+              const visibleChampions = group.champions?.filter(c => c.name) ?? [];
+              const hasVisibleChampions = visibleChampions.length > 0;
 
               // Merge and sort status history and presentations chronologically
               const allItems = [
@@ -210,7 +212,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                       <div className="w-0.5 flex-1 bg-slate-200 dark:bg-slate-700 mb-[-4px]" />
                     )}
                     {/* Horizontal line to fork badge */}
-                    <div className="absolute left-2.5 top-[9px] w-3 h-0.5 bg-slate-200 dark:bg-slate-700" />
+                    <div className="absolute left-2.5 top-[9px] w-2 h-0.5 bg-slate-200 dark:bg-slate-700" />
                   </div>
 
                   {/* Content */}
@@ -223,13 +225,13 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                       >
                         {getForkDisplayName(group.forkName)}
                       </Link>
-                      {group.champions && group.champions.length > 0 && group.champions.some(c => c.name) && (
-                        <Tooltip text={`${group.champions.length > 1 ? 'Champions' : 'Champion'} for ${getForkDisplayName(group.forkName)}`}>
+                      {hasVisibleChampions && (
+                        <Tooltip text={`${visibleChampions.length > 1 ? 'Champions' : 'Champion'} for ${getForkDisplayName(group.forkName)}`}>
                           <div className="flex min-w-0 max-w-full items-start gap-1 text-xs text-slate-400 dark:text-slate-400 cursor-help sm:items-center sm:shrink-0">
                             <svg className="mt-0.5 w-3 h-3 shrink-0 sm:mt-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                             </svg>
-                            <span className="min-w-0 break-words">{group.champions.map(c => c.name).join(' & ')}</span>
+                            <span className="min-w-0 break-words">{visibleChampions.map(c => c.name).join(' & ')}</span>
                           </div>
                         </Tooltip>
                       )}
@@ -238,7 +240,7 @@ export const EipTimeline: React.FC<EipTimelineProps> = ({ eip }) => {
                     {/* Sub-items with dot-and-line */}
                     {allItems.length > 0 && (
                       <div className="mt-1.5 ml-2 relative">
-                        <div className="absolute left-[3px] -top-2 bottom-1 w-0.5 bg-slate-200 dark:bg-slate-700" />
+                        <div className={`absolute left-[3px] ${hasVisibleChampions ? 'top-0.5' : '-top-1.5'} bottom-1 w-0.5 bg-slate-200 dark:bg-slate-700`} />
                         {allItems.map((item, idx) => {
                           const isLastChild = idx === allItems.length - 1;
 


### PR DESCRIPTION
## What changed

- Keeps EIP timeline child event connector lines visible on mobile instead of hiding them below the medium breakpoint.
- Stacks narrow timeline headers and created-date rows so champion names and badges do not clip or squeeze on small screens.
- Aligns child timeline dots with the first line of each event and lets connector lines span only between neighboring child dot centers.
- Shortens the fork badge connector so it stops cleanly before labels and badges.

## Why

The EIP timeline could look disconnected and cramped on mobile, especially for EIP-2780 where the champion row and created-date row competed for limited horizontal space.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: EIP-2780 mobile timeline with clipped champion text and disconnected child dots](https://raw.githubusercontent.com/ethereum/forkcast/34b7f1ee2a2922eade322e8771dbf7a58fbc67d2/screenshots/pr-292/eip-2780-timeline-before.jpg) | ![After: EIP-2780 mobile timeline with wrapped text and exact child rail endpoints](https://raw.githubusercontent.com/ethereum/forkcast/34b7f1ee2a2922eade322e8771dbf7a58fbc67d2/screenshots/pr-292/eip-2780-timeline-after.jpg) |

Review polish case:

![EIP-8184 mobile timeline after exact connector polish](https://raw.githubusercontent.com/ethereum/forkcast/34b7f1ee2a2922eade322e8771dbf7a58fbc67d2/screenshots/pr-292/eip-8184-timeline-polished.jpg)

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- Measured EIP-2780 child segment endpoints in-browser: the segment ends at the Proposed dot center with no trailing line.
- Checked EIP-2780 in the browser at narrow mobile width.
- Checked EIP-8184 in the browser at iPhone 12 Pro width for the review feedback case.