### PR TITLE
Refine pending EIP PR sync

### DIFF
--- a/scripts/eip-record-sync.mjs
+++ b/scripts/eip-record-sync.mjs
@@ -1,0 +1,118 @@
+// Official metadata fields that are synced from upstream.
+// All other fields (forkRelationships, laymanDescription, benefits, etc.) are preserved.
+export const METADATA_FIELDS = [
+  'title',
+  'description',
+  'author',
+  'status',
+  'category',
+  'createdDate',
+  'type',
+  'discussionLink',
+  'requires',
+];
+
+export const OPTIONAL_METADATA_FIELDS = new Set([
+  'category',
+  'discussionLink',
+  'requires',
+]);
+
+// EIPs with status "Moved" (e.g., ERCs moved to their own repo) are excluded.
+export const EXCLUDED_STATUSES = new Set(['Moved']);
+
+export function eipPullRequestUrl(prNumber) {
+  return `https://github.com/ethereum/EIPs/pull/${prNumber}`;
+}
+
+export function pendingPullRequest(prNumber) {
+  return {
+    number: prNumber,
+    url: eipPullRequestUrl(prNumber),
+  };
+}
+
+export function getPendingPullRequestNumber(eip) {
+  return eip?.pendingPullRequest?.number ?? null;
+}
+
+export function buildNewEipJson(eipNumber, mapped, options = {}) {
+  return {
+    id: eipNumber,
+    title: `EIP-${eipNumber}: ${mapped.title || ''}`,
+    status: mapped.status || 'Unknown',
+    description: mapped.description || '',
+    author: mapped.author || '',
+    type: mapped.type || 'Standards Track',
+    ...(mapped.category && { category: mapped.category }),
+    createdDate: mapped.createdDate || '',
+    ...(mapped.discussionLink && { discussionLink: mapped.discussionLink }),
+    ...(mapped.requires?.length && { requires: mapped.requires }),
+    ...(options.pendingPullRequest && {
+      pendingPullRequest: options.pendingPullRequest,
+    }),
+    forkRelationships: [],
+    tradeoffs: null,
+  };
+}
+
+function normalize(str) {
+  if (!str) return '';
+  return str.toString().trim().replace(/\s+/g, ' ');
+}
+
+function officialMetadataValue(field, eipNumber, mapped) {
+  if (field === 'title') {
+    return `EIP-${eipNumber}: ${mapped.title || ''}`;
+  }
+
+  return mapped[field];
+}
+
+function sameJson(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function updateExistingEip(eipNumber, existing, mapped, options = {}) {
+  const updated = { ...existing };
+  let changed = false;
+
+  for (const field of METADATA_FIELDS) {
+    const officialValue = officialMetadataValue(field, eipNumber, mapped);
+
+    if (officialValue === undefined || officialValue === null) {
+      if (OPTIONAL_METADATA_FIELDS.has(field) && field in updated) {
+        delete updated[field];
+        changed = true;
+      }
+      continue;
+    }
+
+    if (normalize(existing[field]) !== normalize(officialValue)) {
+      updated[field] = officialValue;
+      changed = true;
+    }
+  }
+
+  if (options.pendingPullRequest) {
+    if (!sameJson(updated.pendingPullRequest, options.pendingPullRequest)) {
+      updated.pendingPullRequest = options.pendingPullRequest;
+      changed = true;
+    }
+    if (updated.specificationUrl?.includes('/ethereum/EIPs/pull/')) {
+      delete updated.specificationUrl;
+      changed = true;
+    }
+  } else if (options.clearPendingPullRequest) {
+    if (updated.pendingPullRequest) {
+      delete updated.pendingPullRequest;
+      changed = true;
+    }
+    if (updated.specificationUrl?.includes('/ethereum/EIPs/pull/')) {
+      delete updated.specificationUrl;
+      changed = true;
+    }
+  }
+
+  return { updated, changed };
+}

--- a/scripts/eip-record-sync.test.mjs
+++ b/scripts/eip-record-sync.test.mjs
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildNewEipJson,
+  getPendingPullRequestNumber,
+  pendingPullRequest,
+  updateExistingEip,
+} from './eip-record-sync.mjs';
+
+describe('EIP sync transitions', () => {
+  it('builds pending PR EIPs with explicit pending metadata', () => {
+    const pendingPr = pendingPullRequest(11726);
+    const eip = buildNewEipJson(
+      8272,
+      {
+        title: 'Recent Roots for Frame Transactions',
+        status: 'Draft',
+        description: 'Frame transactions can declare verified recent roots',
+        author: 'Example Author',
+        type: 'Standards Track',
+        category: 'Core',
+        createdDate: '2026-05-15',
+        requires: [7843, 8141],
+      },
+      { pendingPullRequest: pendingPr },
+    );
+
+    expect(eip.pendingPullRequest).toEqual(pendingPr);
+    expect(getPendingPullRequestNumber(eip)).toBe(11726);
+  });
+
+  it('updates official metadata through one transition while preserving local fields', () => {
+    const existing = {
+      id: 8272,
+      title: 'EIP-8272: Old title',
+      status: 'Draft',
+      description: 'Old description',
+      author: 'Old Author',
+      type: 'Standards Track',
+      category: 'Core',
+      createdDate: '2026-05-15',
+      discussionLink: 'https://ethereum-magicians.org/t/old',
+      requires: [8141],
+      pendingPullRequest: pendingPullRequest(11726),
+      forkRelationships: [],
+      laymanDescription: 'Keep local analysis',
+      tradeoffs: null,
+    };
+
+    const { updated, changed } = updateExistingEip(
+      8272,
+      existing,
+      {
+        title: 'Recent Roots for Frame Transactions',
+        status: 'Draft',
+        description: 'New description',
+        author: 'New Author',
+        type: 'Standards Track',
+        createdDate: '2026-05-20',
+      },
+      { pendingPullRequest: pendingPullRequest(11726) },
+    );
+
+    expect(changed).toBe(true);
+    expect(updated).toMatchObject({
+      title: 'EIP-8272: Recent Roots for Frame Transactions',
+      description: 'New description',
+      author: 'New Author',
+      createdDate: '2026-05-20',
+      laymanDescription: 'Keep local analysis',
+      pendingPullRequest: pendingPullRequest(11726),
+    });
+    expect(updated).not.toHaveProperty('category');
+    expect(updated).not.toHaveProperty('discussionLink');
+    expect(updated).not.toHaveProperty('requires');
+  });
+
+  it('promotes a pending EIP to canonical data when fetched from master', () => {
+    const { updated, changed } = updateExistingEip(
+      8272,
+      {
+        id: 8272,
+        title: 'EIP-8272: Recent Roots for Frame Transactions',
+        status: 'Draft',
+        description: 'Description',
+        author: 'Author',
+        type: 'Standards Track',
+        createdDate: '2026-05-15',
+        pendingPullRequest: pendingPullRequest(11726),
+        forkRelationships: [],
+        tradeoffs: null,
+      },
+      {
+        title: 'Recent Roots for Frame Transactions',
+        status: 'Draft',
+        description: 'Description',
+        author: 'Author',
+        type: 'Standards Track',
+        createdDate: '2026-05-15',
+      },
+      { clearPendingPullRequest: true },
+    );
+
+    expect(changed).toBe(true);
+    expect(updated).not.toHaveProperty('pendingPullRequest');
+  });
+});

--- a/scripts/eip-schema.json
+++ b/scripts/eip-schema.json
@@ -18,6 +18,7 @@
     "layer": { "type": "string" },
     "collection": { "type": "string" },
     "specificationUrl": { "type": "string" },
+    "pendingPullRequest": { "$ref": "#/$defs/PendingPullRequest" },
     "requires": { "type": "array", "items": { "type": "integer" } },
     "laymanDescription": { "type": "string" },
     "northStars": {
@@ -42,6 +43,15 @@
     "stakeholderImpacts": { "$ref": "#/$defs/StakeholderImpacts" }
   },
   "$defs": {
+    "PendingPullRequest": {
+      "type": "object",
+      "required": ["number", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "number": { "type": "integer" },
+        "url": { "type": "string" }
+      }
+    },
     "ForkRelationship": {
       "type": "object",
       "required": ["forkName", "statusHistory"],

--- a/scripts/fetch-all-eips.mjs
+++ b/scripts/fetch-all-eips.mjs
@@ -3,6 +3,11 @@ import path from 'path';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { parseFrontmatter, mapOfficialToLocal } from './lib/eip-parsing.mjs';
+import {
+  buildNewEipJson,
+  EXCLUDED_STATUSES,
+  updateExistingEip,
+} from './eip-record-sync.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,14 +17,6 @@ const EIPS_MD_DIR = path.join(__dirname, '../public/eips');
 const MANIFEST_PATH = path.join(EIPS_MD_DIR, 'manifest.json');
 const BATCH_SIZE = 5;
 const BATCH_DELAY = 200;
-
-// Official metadata fields that are synced from upstream.
-// All other fields (forkRelationships, laymanDescription, benefits, etc.) are preserved.
-const METADATA_FIELDS = ['title', 'description', 'author', 'status', 'category', 'createdDate', 'type', 'discussionLink', 'requires'];
-const OPTIONAL_METADATA_FIELDS = new Set(['category', 'discussionLink', 'requires']);
-
-// EIPs with status "Moved" (e.g., ERCs moved to their own repo) are excluded
-const EXCLUDED_STATUSES = new Set(['Moved']);
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -74,77 +71,6 @@ async function fetchEipContent(eipNumber) {
     return { error: `HTTP ${response.status}` };
   }
   return { content: await response.text() };
-}
-
-/**
- * Build a new EIP JSON object for a brand-new EIP.
- */
-function buildNewEipJson(eipNumber, mapped) {
-  return {
-    id: eipNumber,
-    title: `EIP-${eipNumber}: ${mapped.title || ''}`,
-    status: mapped.status || 'Unknown',
-    description: mapped.description || '',
-    author: mapped.author || '',
-    type: mapped.type || 'Standards Track',
-    ...(mapped.category && { category: mapped.category }),
-    createdDate: mapped.createdDate || '',
-    ...(mapped.discussionLink && { discussionLink: mapped.discussionLink }),
-    ...(mapped.requires?.length && { requires: mapped.requires }),
-    forkRelationships: [],
-    tradeoffs: null,
-  };
-}
-
-/**
- * Normalize strings for comparison (trim, collapse whitespace).
- */
-function normalize(str) {
-  if (!str) return '';
-  return str.toString().trim().replace(/\s+/g, ' ');
-}
-
-function officialMetadataValue(field, eipNumber, mapped) {
-  if (field === 'title') {
-    return `EIP-${eipNumber}: ${mapped.title || ''}`;
-  }
-
-  return mapped[field];
-}
-
-/**
- * Update an existing EIP's official metadata fields, preserving all other fields.
- * Returns true if any field changed.
- */
-function updateExistingEip(eipNumber, existing, mapped) {
-  const updated = { ...existing };
-  let changed = false;
-
-  for (const field of METADATA_FIELDS) {
-    const officialValue = officialMetadataValue(field, eipNumber, mapped);
-
-    // Optional upstream metadata should be removed locally when upstream omits it.
-    if (officialValue === undefined || officialValue === null) {
-      if (OPTIONAL_METADATA_FIELDS.has(field) && field in updated) {
-        delete updated[field];
-        changed = true;
-      }
-      continue;
-    }
-
-    if (normalize(existing[field]) !== normalize(officialValue)) {
-      updated[field] = officialValue;
-      changed = true;
-    }
-  }
-
-  // Clean up specificationUrl when EIP is now on master
-  if (updated.specificationUrl?.includes('/ethereum/EIPs/pull/')) {
-    delete updated.specificationUrl;
-    changed = true;
-  }
-
-  return { updated, changed };
 }
 
 async function main() {
@@ -229,7 +155,9 @@ Options:
           jsonChanged = true;
         } else {
           const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-          const { updated, changed } = updateExistingEip(eipNumber, existing, mapped);
+          const { updated, changed } = updateExistingEip(eipNumber, existing, mapped, {
+            clearPendingPullRequest: true,
+          });
           if (changed) {
             fs.writeFileSync(filePath, JSON.stringify(updated, null, 2) + '\n');
             jsonChanged = true;

--- a/scripts/fetch-eip-prs.mjs
+++ b/scripts/fetch-eip-prs.mjs
@@ -2,6 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parseFrontmatter, mapOfficialToLocal } from './lib/eip-parsing.mjs';
+import {
+  buildNewEipJson,
+  getPendingPullRequestNumber,
+  pendingPullRequest,
+  updateExistingEip,
+} from './eip-record-sync.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -41,7 +47,8 @@ function loadPrManifest() {
     return { lastRun: null, prs: {} };
   }
   try {
-    return JSON.parse(fs.readFileSync(PR_MANIFEST_PATH, 'utf8'));
+    const manifest = JSON.parse(fs.readFileSync(PR_MANIFEST_PATH, 'utf8'));
+    return { lastRun: manifest.lastRun ?? null, prs: manifest.prs ?? {} };
   } catch {
     return { lastRun: null, prs: {} };
   }
@@ -98,16 +105,46 @@ async function fetchOpenPrs(headers, lastRun) {
   return allPrs;
 }
 
+async function fetchPrState(prNumber, headers) {
+  const url = `https://api.github.com/repos/ethereum/EIPs/pulls/${prNumber}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PR #${prNumber}: HTTP ${response.status}`);
+  }
+
+  const pr = await response.json();
+  return {
+    number: pr.number,
+    state: pr.state,
+    updatedAt: pr.updated_at,
+  };
+}
+
 /**
  * Fetch file list for a PR and return added EIP filenames.
  */
 async function fetchPrEipFiles(prNumber, headers) {
-  const url = `https://api.github.com/repos/ethereum/EIPs/pulls/${prNumber}/files?per_page=100`;
-  const response = await fetch(url, { headers });
-  if (!response.ok) return [];
+  const allFiles = [];
+  let page = 1;
 
-  const files = await response.json();
-  return files
+  while (true) {
+    const url = `https://api.github.com/repos/ethereum/EIPs/pulls/${prNumber}/files?per_page=100&page=${page}`;
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch files for PR #${prNumber}: HTTP ${response.status}`,
+      );
+    }
+
+    const files = await response.json();
+    allFiles.push(...files);
+    if (files.length < 100) break;
+
+    page++;
+    await sleep(BATCH_DELAY);
+  }
+
+  return allFiles
     .filter(
       (f) =>
         f.status === 'added' && /^EIPS\/eip-\d+\.md$/.test(f.filename),
@@ -124,29 +161,12 @@ async function fetchPrEipFiles(prNumber, headers) {
 async function fetchEipFromPrBranch(prNumber, eipNumber, headers) {
   const url = `https://raw.githubusercontent.com/ethereum/EIPs/refs/pull/${prNumber}/head/EIPS/eip-${eipNumber}.md`;
   const response = await fetch(url, { headers });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch EIP-${eipNumber} from PR #${prNumber}: HTTP ${response.status}`,
+    );
+  }
   return await response.text();
-}
-
-/**
- * Build a new EIP JSON object for an EIP from a PR.
- */
-function buildNewEipJson(eipNumber, mapped, prNumber) {
-  return {
-    id: eipNumber,
-    title: `EIP-${eipNumber}: ${mapped.title || ''}`,
-    status: mapped.status || 'Unknown',
-    description: mapped.description || '',
-    author: mapped.author || '',
-    type: mapped.type || 'Standards Track',
-    ...(mapped.category && { category: mapped.category }),
-    createdDate: mapped.createdDate || '',
-    ...(mapped.discussionLink && { discussionLink: mapped.discussionLink }),
-    ...(mapped.requires?.length && { requires: mapped.requires }),
-    specificationUrl: `https://github.com/ethereum/EIPs/pull/${prNumber}`,
-    forkRelationships: [],
-    tradeoffs: null,
-  };
 }
 
 /**
@@ -154,16 +174,19 @@ function buildNewEipJson(eipNumber, mapped, prNumber) {
  */
 async function processPr(prNumber, headers, trackedEipIds, requiresFilter) {
   const eipNumbers = await fetchPrEipFiles(prNumber, headers);
-  if (eipNumbers.length === 0) return [];
+  if (eipNumbers.length === 0) return { eipNumbers: [] };
 
-  const processed = [];
+  const candidates = [];
 
   for (const eipNumber of eipNumbers) {
     const content = await fetchEipFromPrBranch(prNumber, eipNumber, headers);
-    if (!content) continue;
 
     const frontmatter = parseFrontmatter(content);
-    if (!frontmatter) continue;
+    if (!frontmatter) {
+      throw new Error(
+        `Could not parse frontmatter for EIP-${eipNumber} in PR #${prNumber}`,
+      );
+    }
 
     // Skip non-numeric EIP numbers (TBD, XXXX, etc.)
     const eipField = frontmatter.eip;
@@ -180,40 +203,87 @@ async function processPr(prNumber, headers, trackedEipIds, requiresFilter) {
       if (!referencesTracked) continue;
     }
 
-    // Create or update the EIP JSON
+    candidates.push({ eipNumber, mapped });
+    await sleep(200);
+  }
+
+  const actions = [];
+  const processed = [];
+  const pendingPr = pendingPullRequest(prNumber);
+
+  for (const { eipNumber, mapped } of candidates) {
     const filePath = path.join(EIPS_DIR, `${eipNumber}.json`);
-    const prUrl = `https://github.com/ethereum/EIPs/pull/${prNumber}`;
 
     if (fs.existsSync(filePath)) {
       const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-      // Only update if it doesn't already exist on master (no specificationUrl means it's merged)
-      if (!existing.specificationUrl) {
+      const existingPrNumber = getPendingPullRequestNumber(existing);
+
+      if (!existingPrNumber) {
         console.log(
           `  EIP-${eipNumber}: already exists on master, skipping PR update`,
         );
         continue;
       }
-      // Update specificationUrl and metadata
-      existing.specificationUrl = prUrl;
-      if (mapped.title)
-        existing.title = `EIP-${eipNumber}: ${mapped.title}`;
-      if (mapped.status) existing.status = mapped.status;
-      if (mapped.description) existing.description = mapped.description;
-      if (mapped.author) existing.author = mapped.author;
-      if (mapped.requires?.length) existing.requires = mapped.requires;
-      fs.writeFileSync(filePath, JSON.stringify(existing, null, 2) + '\n');
-      console.log(`  Updated EIP-${eipNumber} from PR #${prNumber}`);
+
+      const { updated, changed } = updateExistingEip(eipNumber, existing, mapped, {
+        pendingPullRequest: pendingPr,
+      });
+      if (changed) {
+        actions.push({ type: 'update', eipNumber, filePath, eip: updated });
+      }
     } else {
-      const eipJson = buildNewEipJson(eipNumber, mapped, prNumber);
-      fs.writeFileSync(filePath, JSON.stringify(eipJson, null, 2) + '\n');
-      console.log(`  Created EIP-${eipNumber} from PR #${prNumber}`);
+      const eipJson = buildNewEipJson(eipNumber, mapped, {
+        pendingPullRequest: pendingPr,
+      });
+      actions.push({ type: 'create', eipNumber, filePath, eip: eipJson });
     }
 
     processed.push(eipNumber);
-    await sleep(200);
   }
 
-  return processed;
+  for (const action of actions) {
+    fs.writeFileSync(action.filePath, JSON.stringify(action.eip, null, 2) + '\n');
+    const verb = action.type === 'create' ? 'Created' : 'Updated';
+    console.log(`  ${verb} EIP-${action.eipNumber} from PR #${prNumber}`);
+  }
+
+  return { eipNumbers: processed };
+}
+
+function removePendingEipFilesForPr(prNumber, eipNumbers, reason) {
+  let removed = 0;
+
+  for (const eipNumber of eipNumbers) {
+    const filePath = path.join(EIPS_DIR, `${eipNumber}.json`);
+    if (!fs.existsSync(filePath)) continue;
+
+    const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (getPendingPullRequestNumber(existing) !== Number(prNumber)) {
+      console.log(
+        `  Preserving EIP-${eipNumber}; it is no longer pending on PR #${prNumber}`,
+      );
+      continue;
+    }
+
+    fs.unlinkSync(filePath);
+    removed++;
+    console.log(`  Removed EIP-${eipNumber} from PR #${prNumber} (${reason})`);
+  }
+
+  return removed;
+}
+
+function removePendingEipsForPr(manifest, prNumber, reason) {
+  const entry = manifest.prs[prNumber];
+  if (!entry) return 0;
+
+  const removed = removePendingEipFilesForPr(
+    prNumber,
+    entry.eipNumbers,
+    reason,
+  );
+  delete manifest.prs[prNumber];
+  return removed;
 }
 
 async function main() {
@@ -247,13 +317,8 @@ Environment:
   // Single PR mode: skip requires filter, skip manifest
   if (options.singlePr) {
     console.log(`Fetching EIPs from PR #${options.singlePr}...`);
-    const eipNumbers = await processPr(
-      options.singlePr,
-      headers,
-      null,
-      false,
-    );
-    if (eipNumbers.length === 0) {
+    const result = await processPr(options.singlePr, headers, null, false);
+    if (result.eipNumbers.length === 0) {
       console.log('No new EIP files found in this PR.');
     }
     console.log('\nDone! Run "npm run compile-eips" to rebuild the EIP data.');
@@ -273,8 +338,10 @@ Environment:
   const openPrs = await fetchOpenPrs(headers, manifest.lastRun);
   console.log(`Found ${openPrs.length} PRs to check.`);
 
-  const openPrNumbers = new Set(openPrs.map((pr) => pr.number));
+  const updatedOpenPrNumbers = new Set(openPrs.map((pr) => pr.number));
   let created = 0;
+  let removed = 0;
+  let processingErrors = 0;
 
   // Process PRs in batches
   for (let i = 0; i < openPrs.length; i += BATCH_SIZE) {
@@ -282,27 +349,57 @@ Environment:
     const results = await Promise.all(
       batch.map(async (pr) => {
         try {
-          const eipNumbers = await processPr(
+          const result = await processPr(
             pr.number,
             headers,
             trackedEipIds,
             true,
           );
-          return { prNumber: pr.number, updatedAt: pr.updatedAt, eipNumbers };
+          return {
+            prNumber: pr.number,
+            updatedAt: pr.updatedAt,
+            eipNumbers: result.eipNumbers,
+          };
         } catch (err) {
           console.error(`  Error processing PR #${pr.number}: ${err.message}`);
-          return { prNumber: pr.number, updatedAt: pr.updatedAt, eipNumbers: [] };
+          processingErrors++;
+          return {
+            prNumber: pr.number,
+            updatedAt: pr.updatedAt,
+            eipNumbers: [],
+            error: true,
+          };
         }
       }),
     );
 
     for (const r of results) {
+      if (r.error) continue;
+
       if (r.eipNumbers.length > 0) {
+        const previousEntry = manifest.prs[r.prNumber];
+        if (previousEntry) {
+          const currentEipNumbers = new Set(r.eipNumbers);
+          const staleEipNumbers = (previousEntry.eipNumbers ?? []).filter(
+            (eipNumber) => !currentEipNumbers.has(eipNumber),
+          );
+          removed += removePendingEipFilesForPr(
+            r.prNumber,
+            staleEipNumbers,
+            'no longer qualifies',
+          );
+        }
         manifest.prs[r.prNumber] = {
           updatedAt: r.updatedAt,
           eipNumbers: r.eipNumbers,
         };
         created += r.eipNumbers.length;
+      } else {
+        removed += removePendingEipsForPr(
+          manifest,
+          r.prNumber,
+          'no longer references tracked EIPs',
+        );
       }
     }
 
@@ -315,14 +412,31 @@ Environment:
     }
   }
 
-  // Cleanup: warn about PRs in manifest that are no longer open
+  if (processingErrors > 0) {
+    throw new Error(
+      `Failed to process ${processingErrors} PR(s); refusing to update ${path.basename(PR_MANIFEST_PATH)}.`,
+    );
+  }
+
+  // Reconcile manifest entries that may have closed since the last run.
   for (const prNumber of Object.keys(manifest.prs)) {
-    if (!openPrNumbers.has(parseInt(prNumber, 10))) {
-      const entry = manifest.prs[prNumber];
-      console.warn(
-        `\nWarning: PR #${prNumber} (EIPs: ${entry.eipNumbers.join(', ')}) is no longer in the open PR list. It may have been merged or closed.`,
-      );
+    const numericPrNumber = Number(prNumber);
+    if (updatedOpenPrNumbers.has(numericPrNumber)) continue;
+
+    try {
+      const state = await fetchPrState(numericPrNumber, headers);
+      if (state.state !== 'open') {
+        removed += removePendingEipsForPr(
+          manifest,
+          numericPrNumber,
+          `PR is ${state.state}`,
+        );
+      }
+    } catch (err) {
+      console.warn(`\nWarning: ${err.message}`);
     }
+
+    await sleep(BATCH_DELAY);
   }
 
   // Save manifest
@@ -332,7 +446,8 @@ Environment:
   console.log('\n');
   console.log('Done!');
   if (created > 0) console.log(`  EIPs created/updated from PRs: ${created}`);
-  else console.log('  No new EIPs found in open PRs.');
+  if (removed > 0) console.log(`  Stale PR EIPs removed: ${removed}`);
+  if (created === 0 && removed === 0) console.log('  No new EIPs found in open PRs.');
 }
 
 main().catch((err) => {

--- a/scripts/generate-static-pages.mjs
+++ b/scripts/generate-static-pages.mjs
@@ -38,6 +38,10 @@ const protocolCalls = getProtocolCalls();
 const eips = getEips();
 const devnetSpecs = getDevnetSpecs();
 
+function isPendingEip(eip) {
+  return Boolean(eip.pendingPullRequest);
+}
+
 // Define standalone pages with their metadata
 const standalonePages = [
   {
@@ -315,7 +319,8 @@ function generateAllPages() {
   console.log(`🔗 Generated ${issuePages} issue-number alias pages`);
 
   // Generate individual EIP pages (skip PR-only EIPs)
-  eips.filter(eip => !eip.specificationUrl?.includes('/pull/')).forEach(eip => {
+  const staticEips = eips.filter(eip => !isPendingEip(eip));
+  staticEips.forEach(eip => {
     const fullPath = `eips/${eip.id}`;
     const eipPath = path.join(distDir, 'eips', String(eip.id));
 
@@ -333,7 +338,7 @@ function generateAllPages() {
     fs.writeFileSync(outputPath, html);
     sitemapRoutes.push(fullPath);
   });
-  console.log(`📋 Generated ${eips.length} EIP pages`);
+  console.log(`📋 Generated ${staticEips.length} EIP pages`);
 
   // Generate devnet spec pages
   if (devnetSpecs.length > 0) {

--- a/scripts/validate-eip-metadata.mjs
+++ b/scripts/validate-eip-metadata.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parseFrontmatter, mapOfficialToLocal } from './lib/eip-parsing.mjs';
+import { getPendingPullRequestNumber } from './eip-record-sync.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -98,15 +99,6 @@ function filterEips(eips, options) {
 }
 
 /**
- * Extract PR number from a GitHub PR URL
- */
-function extractPrNumber(url) {
-  if (!url) return null;
-  const match = url.match(/github\.com\/ethereum\/EIPs\/pull\/(\d+)/);
-  return match ? match[1] : null;
-}
-
-/**
  * Fetch official EIP from GitHub (master branch, falling back to open PR)
  */
 async function fetchOfficialEIP(eipNumber, localEip) {
@@ -115,8 +107,8 @@ async function fetchOfficialEIP(eipNumber, localEip) {
     const response = await fetch(url);
     if (!response.ok) {
       if (response.status === 404) {
-        // Try fetching from an open PR if the local EIP has a specificationUrl
-        const prNumber = extractPrNumber(localEip?.specificationUrl);
+        // Try fetching from an open PR if the local EIP is still pending.
+        const prNumber = getPendingPullRequestNumber(localEip);
         if (prNumber) {
           return fetchEIPFromPR(eipNumber, prNumber);
         }

--- a/src/components/EipsIndexPage.tsx
+++ b/src/components/EipsIndexPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { eipsData } from '../data/eips';
-import { getProposalPrefix, getLaymanTitle, getInclusionStage, isHeadlinerInAnyFork, wasHeadlinerCandidateInAnyFork, getEipLayer } from '../utils/eip';
+import { getProposalPrefix, getLaymanTitle, getInclusionStage, isHeadlinerInAnyFork, wasHeadlinerCandidateInAnyFork, getEipLayer, isPendingEip } from '../utils/eip';
 import { EipSearch } from './eip/EipSearch';
 import EipSearchModal from './eip/EipSearchModal';
 import { isSearchHotkey } from './search/searchShortcuts';
@@ -46,7 +46,7 @@ const EipsIndexPage: React.FC = () => {
     const stageSet = new Set<string>();
     const layerSet = new Set<string>();
 
-    eipsData.filter(eip => !eip.specificationUrl?.includes('/pull/')).forEach(eip => {
+    eipsData.filter(eip => !isPendingEip(eip)).forEach(eip => {
       if (eip.status) statusSet.add(eip.status);
       // Add category or type since we display category || type
       const typeValue = eip.category || eip.type;
@@ -113,7 +113,7 @@ const EipsIndexPage: React.FC = () => {
 
   // Filter and sort EIPs
   const filteredAndSortedEips = useMemo(() => {
-    let filtered = eipsData.filter(eip => !eip.specificationUrl?.includes('/pull/'));
+    let filtered = eipsData.filter(eip => !isPendingEip(eip));
 
     // Apply status filter
     if (statusFilters.size > 0) {

--- a/src/components/eip/EipDependents.tsx
+++ b/src/components/eip/EipDependents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { EIP } from '../../types/eip';
-import { getProposalPrefix, getLaymanTitle } from '../../utils';
+import { getProposalPrefix, getLaymanTitle, getSpecificationUrl, isPendingEip } from '../../utils';
 
 interface EipDependentsProps {
   dependents: EIP[];
@@ -17,7 +17,7 @@ export const EipDependents: React.FC<EipDependentsProps> = ({ dependents }) => {
       </p>
       <div className="space-y-2">
         {sorted.map((eip) => {
-          const isPr = eip.specificationUrl?.includes('/pull/');
+          const isPr = isPendingEip(eip);
           const cardClasses = "block bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg p-4 hover:border-purple-400 dark:hover:border-purple-500 transition-colors";
           const content = (
             <>
@@ -49,7 +49,7 @@ export const EipDependents: React.FC<EipDependentsProps> = ({ dependents }) => {
           return isPr ? (
             <a
               key={eip.id}
-              href={eip.specificationUrl}
+              href={getSpecificationUrl(eip)}
               target="_blank"
               rel="noopener noreferrer"
               className={cardClasses}

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -14,6 +14,7 @@ import {
   parseAuthors,
   getEipLayer,
   buildDependentsMap,
+  isPendingEip,
 } from '../../utils';
 import { Tooltip } from '../ui';
 import { EipTimeline } from './EipTimeline';
@@ -392,7 +393,7 @@ export const EipPage: React.FC = () => {
   }, [viewMode, specContent, specLoading]);
 
   // PR-only EIPs don't have a meaningful local page — redirect to the PR
-  const prRedirectUrl = eip?.specificationUrl?.includes('/pull/') ? eip.specificationUrl : null;
+  const prRedirectUrl = eip && isPendingEip(eip) ? getSpecificationUrl(eip) : null;
   useEffect(() => {
     if (prRedirectUrl) {
       window.location.href = prRedirectUrl;

--- a/src/data/eips/8272.json
+++ b/src/data/eips/8272.json
@@ -12,7 +12,10 @@
     7843,
     8141
   ],
-  "specificationUrl": "https://github.com/ethereum/EIPs/pull/11726",
+  "pendingPullRequest": {
+    "number": 11726,
+    "url": "https://github.com/ethereum/EIPs/pull/11726"
+  },
   "forkRelationships": [],
   "tradeoffs": null
 }

--- a/src/types/eip.ts
+++ b/src/types/eip.ts
@@ -39,6 +39,11 @@ export interface Champion {
   email?: string;
 }
 
+export interface PendingPullRequest {
+  number: number;
+  url: string;
+}
+
 export interface EIP {
   id: number;
   title: string;
@@ -53,8 +58,9 @@ export interface EIP {
   layer?: 'EL' | 'CL';
   collection?: string;
   requires?: number[];
-  /** Override for EIPs not yet merged into ethereum/EIPs (default URL would 404). */
+  /** Override for non-standard specification URLs. */
   specificationUrl?: string;
+  pendingPullRequest?: PendingPullRequest;
   forkRelationships: ForkRelationship[];
   laymanDescription?: string;
   northStars?: string[];

--- a/src/utils/eip.test.ts
+++ b/src/utils/eip.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   getEipIdFromHash,
   getInclusionStageSortRank,
+  getSpecificationUrl,
   getStageAbbreviation,
   getSummaryDescription,
   getUpgradeAnchorExpansionState,
+  isPendingEip,
 } from './eip';
 import type { EIP } from '../types';
 
@@ -28,6 +30,31 @@ describe('getSummaryDescription', () => {
     });
 
     expect(getSummaryDescription(eip)).toBe('The EIP description');
+  });
+});
+
+describe('pending EIP pull request', () => {
+  it('uses the explicit pending pull request as the specification URL', () => {
+    const eip = makeEip({
+      pendingPullRequest: {
+        number: 11726,
+        url: 'https://github.com/ethereum/EIPs/pull/11726',
+      },
+    });
+
+    expect(isPendingEip(eip)).toBe(true);
+    expect(getSpecificationUrl(eip)).toBe(
+      'https://github.com/ethereum/EIPs/pull/11726',
+    );
+  });
+
+  it('keeps canonical EIP URLs separate from pending pull request state', () => {
+    const eip = makeEip({ id: 8141, title: 'EIP-8141: Frame Transactions' });
+
+    expect(isPendingEip(eip)).toBe(false);
+    expect(getSpecificationUrl(eip)).toBe(
+      'https://eips.ethereum.org/EIPS/eip-8141',
+    );
   });
 });
 

--- a/src/utils/eip.ts
+++ b/src/utils/eip.ts
@@ -124,10 +124,18 @@ export const getProposalPrefix = (eip: EIP): ProposalType => {
 export const getSummaryDescription = (eip: EIP): string =>
   eip.description;
 
+export const isPendingEip = (
+  eip: EIP,
+): eip is EIP & { pendingPullRequest: NonNullable<EIP['pendingPullRequest']> } =>
+  Boolean(eip.pendingPullRequest);
+
 /**
  * Get the specification URL for an EIP
  */
 export const getSpecificationUrl = (eip: EIP): string => {
+  if (isPendingEip(eip)) {
+    return eip.pendingPullRequest.url;
+  }
   if (eip.specificationUrl) {
     return eip.specificationUrl;
   }


### PR DESCRIPTION
## Summary

This follow-up keeps pending EIP pull-request discovery, but routes EIP JSON creation and metadata updates through the same transition used by the canonical EIP fetch path.

## Changes

- Extract shared EIP sync logic into `scripts/lib/eip-sync.mjs`.
- Use explicit `source: { type: "pullRequest", prNumber, url }` metadata for pending EIPs instead of inferring pending state from `specificationUrl`.
- Reconcile the pending PR manifest by deleting generated pending EIP records when a PR closes or no longer references tracked EIPs, while preserving records that have already been promoted to canonical EIPs.
- Update UI/static-page checks to use the explicit pending marker.
- Add focused tests for pending-source URL behavior and the shared EIP sync transition.

## Original blocking feedback
```
I’d leave **two blocking direction comments** and avoid smaller nits.

**Blocking Feedback**

1. `scripts/fetch-eip-prs.mjs:134` / `scripts/fetch-eip-prs.mjs:155`

This PR creates a second EIP processing path instead of extending the existing `fetch-all-eips` path. The new path duplicates `buildNewEipJson` and only partially updates existing records, so PR-backed EIPs can drift from canonical EIPs. For example, existing PR entries never update `category`, `type`, `createdDate`, or `discussionLink`, and optional fields like `requires` are never removed if upstream removes them.

Suggested direction: extract the shared “official frontmatter -> local EIP JSON” creation/update logic from `fetch-all-eips.mjs` into a small domain module, then have both the master fetcher and PR fetcher feed different sources into the same transition. The PR fetcher should mostly discover candidate PRs and pass their markdown through the existing mapping/update behavior.

2. `scripts/fetch-eip-prs.mjs:176` / `scripts/fetch-eip-prs.mjs:318`

The PR-only records are append/update-only. If an upstream EIP PR is closed, or if it stops requiring a tracked EIP, this script skips or warns but leaves the generated `src/data/eips/<id>.json` in place. That means the dependent list can keep showing a stale pending EIP indefinitely.

Suggested direction: make pending PR EIPs explicitly reconciled. The manifest should drive deletion of generated pending entries when the PR is no longer open or no longer qualifies, but only when the local file still points at that same pending PR. That guard matters so a merged EIP that `fetch-all-eips` has promoted into a normal canonical EIP is preserved.

**Architectural Note**

I’d also ask them not to infer PR-only state from `specificationUrl.includes('/pull/')` across UI/build code. That leaks lifecycle state through a URL convention. A small explicit domain marker would be simpler to maintain, for example `source: { kind: 'canonical' | 'pullRequest', prNumber?, url? }`, or a helper like `isPendingEip(eip)` backed by typed data.

Checks passed on PR head `2e2cdfd4`: `npm run lint` and `npm test`.
```