### PR TITLE
sync: set video/transcript offsets for ACDC 179

### DIFF
--- a/public/artifacts/acdc/2026-05-28_179/config.json
+++ b/public/artifacts/acdc/2026-05-28_179/config.json
@@ -2,7 +2,7 @@
   "issue": 2061,
   "videoUrl": "https://youtube.com/watch?v=6rx9Vo7QcJg",
   "sync": {
-    "transcriptStartTime": null,
-    "videoStartTime": null
+    "transcriptStartTime": "00:06:31",
+    "videoStartTime": "00:02:50"
   }
 }


### PR DESCRIPTION
## Summary

Sets the video/transcript sync offsets for ACDC 179 using the manually confirmed start timestamps.

## Validation

- `git diff --cached --check`
- `npx prettier --check public/artifacts/acdc/2026-05-28_179/config.json`