### PR TITLE
fix ACDC 179 SSZ engine API typo

### DIFF
--- a/public/artifacts/acdc/2026-05-28_179/key_decisions.json
+++ b/public/artifacts/acdc/2026-05-28_179/key_decisions.json
@@ -2,11 +2,11 @@
   "meeting": "ACDC #179 - May 28, 2026",
   "key_decisions": [
     {
-      "original_text": "Adopt Marius's SSE engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota",
+      "original_text": "Adopt Marius's SSZ engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota",
       "timestamp": "00:29:07",
       "type": "other",
       "eips": [],
-      "context": "SSE engine API implementation choice"
+      "context": "SSZ engine API implementation choice"
     },
     {
       "original_text": "Deposit limit: no change now; wait for stable containers; bump constant only if stable containers are DFI'd",

--- a/public/artifacts/acdc/2026-05-28_179/tldr.json
+++ b/public/artifacts/acdc/2026-05-28_179/tldr.json
@@ -26,7 +26,7 @@
       },
       {
         "timestamp": "00:26:39",
-        "highlight": "EL PR 764 closed in favor of 793 (Marius's SSE engine API rethink); all teams asked to implement 793"
+        "highlight": "EL PR 764 closed in favor of 793 (Marius's SSZ engine API rethink); all teams asked to implement 793"
       }
     ],
     "testing_progress": [
@@ -88,7 +88,7 @@
   "decisions": [
     {
       "timestamp": "00:29:07",
-      "decision": "Adopt Marius's SSE engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota"
+      "decision": "Adopt Marius's SSZ engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota"
     },
     {
       "timestamp": "00:24:52",

--- a/public/artifacts/acdc/2026-05-28_179/transcript_corrected.vtt
+++ b/public/artifacts/acdc/2026-05-28_179/transcript_corrected.vtt
@@ -622,11 +622,11 @@ Parithosh Jayanthi: Cool. Okay, the next, anything else on this topic? If not, w
 
 156
 00:25:41.830 --> 00:25:55.429
-Parithosh Jayanthi: Okay, the next one is, about the SSE-ing of the engine API. As always, we had these two proposals. First one is, just adding
+Parithosh Jayanthi: Okay, the next one is, about the SSZ-ing of the engine API. As always, we had these two proposals. First one is, just adding
 
 157
 00:25:55.890 --> 00:26:03.039
-Parithosh Jayanthi: SSE-ing the existing engine API from Barnabas, and the other ones from Marius, which kind of rethinks everything.
+Parithosh Jayanthi: SSZ-ing the existing engine API from Barnabas, and the other ones from Marius, which kind of rethinks everything.
 
 158
 00:26:04.000 --> 00:26:15.659
@@ -666,7 +666,7 @@ Parithosh Jayanthi: Casey, do you maybe want to talk about the Prysm trade-off?
 
 167
 00:27:55.300 --> 00:28:11.610
-kasey: Yeah, just that we already have a JSON RPC client, and it might be easier to, wedge SSE into that, but I think that being able to drop, JSON RPC at Hegota is a pretty huge advantage to jumping straight into what Marius is proposing.
+kasey: Yeah, just that we already have a JSON RPC client, and it might be easier to, wedge SSZ into that, but I think that being able to drop, JSON RPC at Hegota is a pretty huge advantage to jumping straight into what Marius is proposing.
 
 168
 00:28:22.200 --> 00:28:29.970


### PR DESCRIPTION
Follow-up to #295. The engine-API discussion on ACDC 179 (PRs #764/#793, dropping JSON-RPC) is about **SSZ-encoding** the engine API, but the pipeline left the ASR's `SSE` / `SSE-ing` uncorrected.

Fixed all occurrences across the artifacts:
- `transcript_corrected.vtt` — `SSE-ing` → `SSZ-ing` (×2), `wedge SSE` → `wedge SSZ`
- `tldr.json`, `key_decisions.json` — `SSE engine API` → `SSZ engine API`

**Not** added to the global vocab: `SSE` (Server-Sent Events) is a legitimate term elsewhere (e.g. beacon API event streams), so a global `SSE`→`SSZ` replace would corrupt other calls. The upstream copy is fixed in ethereum/pm#2092.