### PR TITLE
eips: record EIP-8148 PFI for Hegota at ACDC 179

### DIFF
--- a/public/artifacts/acdc/2026-05-28_179/key_decisions.json
+++ b/public/artifacts/acdc/2026-05-28_179/key_decisions.json
@@ -2,6 +2,19 @@
   "meeting": "ACDC #179 - May 28, 2026",
   "key_decisions": [
     {
+      "original_text": "EIP-8148 (custom sweep threshold for validators) presented and proposed for Hegota by Greg K",
+      "timestamp": "00:38:09",
+      "type": "stage_change",
+      "eips": [
+        8148
+      ],
+      "stage_change": {
+        "to": "Proposed"
+      },
+      "fork": "Hegota",
+      "context": "clients to review details before next ACDC"
+    },
+    {
       "original_text": "Adopt Marius's SSZ engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota",
       "timestamp": "00:29:07",
       "type": "other",

--- a/public/artifacts/acdc/2026-05-28_179/tldr.json
+++ b/public/artifacts/acdc/2026-05-28_179/tldr.json
@@ -87,6 +87,10 @@
   ],
   "decisions": [
     {
+      "timestamp": "00:38:09",
+      "decision": "EIP-8148 (custom sweep threshold for validators) presented and proposed for Hegota (PFI); clients to review details before next ACDC"
+    },
+    {
       "timestamp": "00:29:07",
       "decision": "Adopt Marius's SSZ engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota"
     },

--- a/src/data/eips/8148.json
+++ b/src/data/eips/8148.json
@@ -8,7 +8,27 @@
   "category": "Core",
   "createdDate": "2026-02-05",
   "discussionLink": "https://ethereum-magicians.org/t/eip-8148-custom-sweep-threshold-for-validators/27669",
-  "forkRelationships": [],
+  "forkRelationships": [
+    {
+      "forkName": "Hegota",
+      "statusHistory": [
+        {
+          "status": "Proposed",
+          "call": "acdc/179",
+          "date": "2026-05-28",
+          "timestamp": 2068
+        }
+      ],
+      "presentationHistory": [
+        {
+          "type": "presentation",
+          "call": "acdc/179",
+          "date": "2026-05-28",
+          "timestamp": 2068
+        }
+      ]
+    }
+  ],
   "tradeoffs": null,
   "requires": [
     7251,


### PR DESCRIPTION
EIP-8148 (custom sweep threshold for validators) was presented by Greg K and **proposed for Hegota** at ACDC 179, but the PFI never made it into the call's decisions or the EIP's fork history. This records it.

### Changes
- **`src/data/eips/8148.json`** — add a `Hegota` fork relationship with a `Proposed` `statusHistory` entry + a `presentation` `presentationHistory` entry.
  - `call: acdc/179`, `date: 2026-05-28`, `timestamp: 2068` (video seconds). The presentation is at transcript `00:38:09`; mapped through the call's sync offset (transcriptStart `00:06:31` / videoStart `00:02:50` → −221s) that's video second 2068.
- **`key_decisions.json`** — add the `EIP-8148 → Proposed` (PFI) `stage_change` decision for Hegota.
- **`tldr.json`** — mirror the PFI into the decisions summary.

Forkcast-only (the EIP data model and `key_decisions.json` don't exist upstream in `ethereum/pm`). `npm run compile-eips` (Ajv schema validation) passes.