### PR TITLE
Enable ACDT autonomous recordings

### DIFF
--- a/scripts/sync-call-assets.mjs
+++ b/scripts/sync-call-assets.mjs
@@ -74,7 +74,7 @@ function normalizeManifest(manifest) {
   return manifest.calls || {};
 }
 
-const LIVESTREAMED_TYPES = new Set(['acdc', 'acde', 'acdt']);
+const LIVESTREAMED_TYPES = new Set(['acdc', 'acde']);
 
 function generateConfig(callData, localType) {
   const needsManualSync = LIVESTREAMED_TYPES.has(localType);


### PR DESCRIPTION
## Summary

Companion change for PM's ACDT composed-recording activation.

- treats only ACDE and ACDC as manually livestreamed calls during PM asset sync
- lets newly generated ACDT call configs default transcript and video sync offsets to `00:00:00`

## Status

Keep this draft until PM has switched ACDT from scheduled livestreams to composed recording uploads. After that lands, this branch should be ready to review and merge.

## Tests

- `node --check scripts/sync-call-assets.mjs`
- `git diff --check upstream/main...HEAD`