### PR TITLE
sync: set video/transcript offsets for FOCIL 35 and RPC 27

### DIFF
--- a/public/artifacts/focil/2026-06-02_035/config.json
+++ b/public/artifacts/focil/2026-06-02_035/config.json
@@ -2,7 +2,7 @@
   "issue": 2098,
   "videoUrl": "https://www.youtube.com/watch?v=bZ3L7E7a5Gw",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:05:28",
+    "videoStartTime": "00:05:28"
   }
 }

--- a/public/artifacts/rpc/2026-06-01_027/config.json
+++ b/public/artifacts/rpc/2026-06-01_027/config.json
@@ -2,7 +2,7 @@
   "issue": 2075,
   "videoUrl": "https://www.youtube.com/watch?v=iwiTvdoZfn8",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:03:02",
+    "videoStartTime": "00:03:02"
   }
 }


### PR DESCRIPTION
Sets video/transcript sync offsets for newly synced breakout calls.

- **FOCIL 35** (`focil/2026-06-02_035`): `00:05:28` for both transcript and video start
- **RPC 27** (`rpc/2026-06-01_027`): `00:03:02` for both transcript and video start

Both are non-livestreamed calls (video and transcript from the same recording), so each offset is the single point where speech begins after the dead air at the start.