### PR TITLE
upgrade: add hegota complexity scores, polish

### DIFF
--- a/scripts/generate-static-pages.mjs
+++ b/scripts/generate-static-pages.mjs
@@ -113,6 +113,11 @@ const upgrades = [
     title: 'Hegotá Upgrade - Forkcast',
     description: 'Post-Glamsterdam network upgrade in early planning.',
   },
+  {
+    path: 'upgrade/hegota/test-complexity',
+    title: 'Hegotá Test Complexity - Forkcast',
+    description: 'Analyze STEEL test complexity assessments for EIPs proposed for Hegotá.',
+  },
 ];
 
 // Get full type name for calls

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import StakeholdersTab from './components/glamsterdam/StakeholdersTab';
 import EipCandidatesTab from './components/glamsterdam/EipCandidatesTab';
 import ClientPriorityTab from './components/glamsterdam/ClientPriorityTab';
 import TestComplexityTab from './components/glamsterdam/TestComplexityTab';
+import HegotaUpgradePage from './components/HegotaUpgradePage';
+import HegotaOverviewTab from './components/hegota/OverviewTab';
 import DevnetSpecPage from './components/DevnetSpecPage';
 import DecisionsPage from './components/DecisionsPage';
 import { getUpgradeById } from './data/upgrades';
@@ -124,7 +126,7 @@ function CallRouteLayout() {
 
 function App() {
   const fusakaUpgrade = getUpgradeById('fusaka')!;
-  const hegotaUpgrade = getUpgradeById('hegota')!;
+
   const pectraUpgrade = getUpgradeById('pectra')!;
 
   return (
@@ -170,16 +172,10 @@ function App() {
               <Route path="client-priority" element={<ClientPriorityTab />} />
               <Route path="test-complexity" element={<TestComplexityTab />} />
             </Route>
-            <Route path="/upgrade/hegota" element={
-              <PublicNetworkUpgradePage
-                forkName="Hegota"
-                displayName={hegotaUpgrade.name}
-                description={hegotaUpgrade.description}
-                status={hegotaUpgrade.status}
-                activationDate={hegotaUpgrade.activationDate}
-                metaEipLink={hegotaUpgrade.metaEipLink}
-              />
-            } />
+            <Route path="/upgrade/hegota" element={<HegotaUpgradePage />}>
+              <Route index element={<HegotaOverviewTab />} />
+              <Route path="test-complexity" element={<TestComplexityTab fork="hegota" />} />
+            </Route>
             <Route path="/rank" element={<RankPage />} />
             <Route path="/calls" element={<CallsIndexPage />} />
             <Route path="/agenda" element={<CallPlanPage />} />

--- a/src/components/HegotaUpgradePage.tsx
+++ b/src/components/HegotaUpgradePage.tsx
@@ -1,0 +1,117 @@
+import React, { useLayoutEffect, useRef } from 'react';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+import { useMetaTags } from '../hooks/useMetaTags';
+import { getUpgradeById } from '../data/upgrades';
+import { getUpgradeStatusColor } from '../utils/colors';
+import { isPathActive, normalizePathname } from '../utils/path';
+
+const upgrade = getUpgradeById('hegota')!;
+
+interface TabItem {
+  path: string;
+  label: string;
+}
+
+const tabs: TabItem[] = [
+  { path: '/upgrade/hegota', label: 'Overview' },
+  { path: '/upgrade/hegota/test-complexity', label: 'Test Complexity' },
+];
+
+const isTabActive = (pathname: string, tabPath: string) =>
+  tabPath === '/upgrade/hegota' ? pathname === tabPath : isPathActive(pathname, tabPath);
+
+const HegotaUpgradePage: React.FC = () => {
+  const location = useLocation();
+  const pathname = normalizePathname(location.pathname);
+  const activeTabRef = useRef<HTMLAnchorElement>(null);
+
+  useMetaTags({
+    title: 'Hegotá Upgrade - Forkcast',
+    description: 'Hegotá network upgrade: overview, EIP proposals, and test complexity.',
+    url: 'https://forkcast.org/upgrade/hegota',
+  });
+
+  useLayoutEffect(() => {
+    const activeEl = activeTabRef.current;
+    activeEl?.scrollIntoView({ block: 'nearest', inline: 'center' });
+  }, [pathname]);
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <Link to="/upgrades" className="text-slate-600 hover:text-slate-800 dark:text-slate-300 dark:hover:text-slate-100 mb-6 inline-block text-sm font-medium">
+            ← All Network Upgrades
+          </Link>
+
+          <div className="pb-0">
+            <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between">
+              <div className="flex-1">
+                <div className="flex items-center justify-between lg:justify-start gap-3 mb-3">
+                  <h1 className="text-3xl font-light text-slate-900 dark:text-slate-100 tracking-tight">
+                    <span className="lg:hidden">Hegotá</span>
+                    <span className="hidden lg:inline">{upgrade.name}</span>
+                  </h1>
+                  <span className={`lg:hidden px-3 py-1 text-xs font-medium rounded ${getUpgradeStatusColor(upgrade.status)}`}>
+                    {upgrade.status}
+                  </span>
+                </div>
+                <p className="text-base text-slate-600 dark:text-slate-300 mb-2 leading-relaxed max-w-2xl">{upgrade.description}</p>
+                {upgrade.metaEipLink && (
+                  <div className="mb-4">
+                    <a
+                      href={upgrade.metaEipLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 underline decoration-1 underline-offset-2 transition-colors"
+                    >
+                      View Meta EIP Discussion
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                    </a>
+                  </div>
+                )}
+              </div>
+              <div className="hidden lg:block">
+                <span className={`px-3 py-1 text-xs font-medium rounded ${getUpgradeStatusColor(upgrade.status)}`}>
+                  {upgrade.status}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="-mx-6 mt-4">
+            <div className="overflow-x-auto px-6 pb-3">
+              <div className="flex gap-6 border-b border-slate-200 dark:border-slate-700 min-w-max">
+                {tabs.map((tab) => {
+                  const active = isTabActive(pathname, tab.path);
+                  return (
+                    <Link
+                      key={tab.path}
+                      to={tab.path}
+                      ref={active ? activeTabRef : undefined}
+                      className={`pb-2 text-sm font-medium transition-colors border-b-2 -mb-px whitespace-nowrap ${
+                        active
+                          ? 'border-purple-600 dark:border-purple-400 text-purple-700 dark:text-purple-300'
+                          : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-500'
+                      }`}
+                    >
+                      {tab.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tab content */}
+        <Outlet />
+      </div>
+    </div>
+  );
+};
+
+export default HegotaUpgradePage;

--- a/src/components/glamsterdam/TestComplexityTab.tsx
+++ b/src/components/glamsterdam/TestComplexityTab.tsx
@@ -24,9 +24,12 @@ type SortField = 'eip' | 'complexity' | 'stage' | 'tests';
 type SortDirection = 'asc' | 'desc';
 type FilterTier = 'all' | 'Low' | 'Medium' | 'High' | 'unassessed';
 
-const SELECTED_FORK = 'glamsterdam';
+interface TestComplexityTabProps {
+  fork?: string;
+}
 
-const TestComplexityTab: React.FC = () => {
+const TestComplexityTab: React.FC<TestComplexityTabProps> = ({ fork = 'glamsterdam' }) => {
+  const SELECTED_FORK = fork;
   const [sortField, setSortField] = useState<SortField>('complexity');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [filterTier, setFilterTier] = useState<FilterTier>('all');
@@ -66,7 +69,7 @@ const TestComplexityTab: React.FC = () => {
         eip,
         layer: eip.layer,
       }));
-  }, []);
+  }, [SELECTED_FORK]);
 
   // Combine EIPs with complexity data
   const eipsWithComplexity = useMemo(() => {
@@ -97,7 +100,7 @@ const TestComplexityTab: React.FC = () => {
     }
 
     return result;
-  }, [eipsWithComplexity, filterTier, hideExcluded]);
+  }, [eipsWithComplexity, filterTier, hideExcluded, SELECTED_FORK]);
 
   // Apply sorting
   const sortedEips = useMemo(() => {
@@ -127,7 +130,7 @@ const TestComplexityTab: React.FC = () => {
 
       return sortDirection === 'asc' ? comparison : -comparison;
     });
-  }, [filteredEips, sortField, sortDirection]);
+  }, [filteredEips, sortField, sortDirection, SELECTED_FORK]);
 
   // Calculate summary stats
   const stats = useMemo(() => {

--- a/src/components/hegota/OverviewTab.tsx
+++ b/src/components/hegota/OverviewTab.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PublicNetworkUpgradePage from '../PublicNetworkUpgradePage';
+import { getUpgradeById } from '../../data/upgrades';
+
+const upgrade = getUpgradeById('hegota')!;
+
+const OverviewTab: React.FC = () => (
+  <PublicNetworkUpgradePage
+    forkName="Hegota"
+    displayName={upgrade.name}
+    description={upgrade.description}
+    status={upgrade.status}
+    activationDate={upgrade.activationDate}
+    metaEipLink={upgrade.metaEipLink}
+    embedded
+    skipHeader
+  />
+);
+
+export default OverviewTab;

--- a/src/components/network-upgrade/EipCard.tsx
+++ b/src/components/network-upgrade/EipCard.tsx
@@ -301,7 +301,7 @@ export const EipCard: React.FC<EipCardProps> = ({
         </div>
 
         {/* Champion Information */}
-        {forkName.toLowerCase() === 'glamsterdam' && (() => {
+        {['glamsterdam', 'hegota'].includes(forkName.toLowerCase()) && (() => {
           const champions = forkRelationship?.champions;
           const hasChampions = champions && champions.length > 0 && champions.some(c => c.name);
           const hasAnyContactInfo = champions?.some(c => c.discord || c.telegram || c.email);

--- a/src/components/network-upgrade/OverviewSection.tsx
+++ b/src/components/network-upgrade/OverviewSection.tsx
@@ -91,11 +91,11 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({
             <div>
               <h4 className="font-medium text-blue-900 dark:text-blue-100 text-sm mb-1">Headliner Selection Complete</h4>
               <p className="text-blue-800 dark:text-blue-200 text-xs leading-relaxed">
-                Headliner selection process has concluded with{' '}
+                Headliner selection has concluded with{' '}
                 <a href="#eip-7805" className="text-blue-600 dark:text-blue-300 underline decoration-1 underline-offset-2 hover:text-blue-800 dark:hover:text-blue-100">FOCIL (EIP-7805)</a>
-                {' '}being SFI'd as a headliner and{' '}
+                {' '}SFI'd and{' '}
                 <a href="#eip-8141" className="text-blue-600 dark:text-blue-300 underline decoration-1 underline-offset-2 hover:text-blue-800 dark:hover:text-blue-100">Frame Transaction (EIP-8141)</a>
-                {' '}being CFI'd. The window for non-headliner EIP proposals opens April 9th (deadline TBD). Follow updates on the{' '}
+                {' '}CFI'd. The non-headliner EIP proposal window is now open (deadline TBD). Follow updates on the{' '}
                 <a
                   href="https://ethereum-magicians.org/t/eip-8081-hegota-network-upgrade-meta-thread/26876"
                   target="_blank"

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -191,7 +191,7 @@ export const networkUpgrades: NetworkUpgrade[] = [
     description: 'Future network upgrade currently in early planning stages. Named after the combination of "Heze" (consensus layer upgrade, named after a star) and "Bogotá" (execution layer upgrade, named after a Devcon location).',
     tagline: 'Headliner selection concluded: FOCIL SFI\'d, Frame Tx CFI\'d',
     status: 'Planning',
-    activationDate: 'TBD',
+    activationDate: '2027',
     disabled: false,
     macroPhaseOverride: 'scoping',
     metaEipLink: 'https://ethereum-magicians.org/t/eip-8081-hegota-network-upgrade-meta-thread/26876'


### PR DESCRIPTION
takes the training wheels off of the hegota upgrade page and adds the complexity scores page. (the other tabs are not relevant quite yet.) context: STEEL has the FOCIL score published, but several more in PRs now.