### PR TITLE
consume composed recording sync offsets

### DIFF
--- a/.agents/skills/sync-offsets/SKILL.md
+++ b/.agents/skills/sync-offsets/SKILL.md
@@ -17,8 +17,9 @@ This skill walks the user through setting video/transcript sync offsets for newl
 
 ### Step 2: Identify what needs sync
 
-- **Livestreamed calls** (acdc, acde, acdt): config will have `null` offsets. These always need manual sync — the video and transcript start at different times.
-- **Non-livestreamed calls** (all others): config defaults to `"00:00:00"`. These may need sync if there's dead air at the start — both offsets will be the same value since video and transcript are from the same recording.
+- **Livestreamed calls** (acdc, acde): config will have `null` offsets. These always need manual sync — the video and transcript start at different times.
+- **Composed Zoom calls** (acdt): config should have non-null PM-provided offsets. These offsets account for the bumper and transcript-based Zoom trim, and `videoStartTime` may be before or after `transcriptStartTime`. Missing PM sync is a pipeline error, not a raw-Zoom zero-sync case. If manual sync is needed to skip beginning chatter, preserve the exact generated `videoStartTime - transcriptStartTime` delta.
+- **Raw Zoom calls** (all others): config defaults to `"00:00:00"`. These may need sync if there's dead air at the start — both offsets will be the same value since video and transcript are from the same recording.
 
 ### Step 3: Get timestamps from the user
 
@@ -26,14 +27,16 @@ This skill walks the user through setting video/transcript sync offsets for newl
 2. Give the user Forkcast call page links using the actual port: `http://localhost:{port}/calls/{type}/{number}` (zero-pad the number to 3 digits)
 3. For each call, ask the user to provide:
    - **Livestreamed**: video timestamp AND transcript timestamp where the host first speaks
-   - **Non-livestreamed**: single timestamp where speech begins (or confirm `00:00:00` is fine)
+   - **Composed Zoom**: single transcript timestamp where speech should begin; calculate the video timestamp by adding the generated `videoStartTime - transcriptStartTime` difference
+   - **Raw Zoom**: single timestamp where speech begins (or confirm `00:00:00` is fine)
 4. Do NOT pre-read the transcript or suggest timestamps. Let the user match video and transcript using the call page UI.
 
 ### Step 4: Apply offsets
 
 Update each call's `config.json`:
 - **Livestreamed**: set `transcriptStartTime` and `videoStartTime` to the user's values (format: `HH:MM:SS`)
-- **Non-livestreamed**: set both `transcriptStartTime` and `videoStartTime` to the same value
+- **Composed Zoom**: set `transcriptStartTime` to the user's transcript timestamp and set `videoStartTime` to that timestamp plus the generated video/transcript difference
+- **Raw Zoom**: set both `transcriptStartTime` and `videoStartTime` to the same value
 
 ### Step 5: Verify
 

--- a/docs/acdbot-forkcast-asset-pipeline.md
+++ b/docs/acdbot-forkcast-asset-pipeline.md
@@ -76,7 +76,7 @@ Two scripts run sequentially via `sync-call-assets.yml` (scheduled cron). Both l
 2. **Maps** PM series names to Forkcast short codes (i.e. `glamsterdamrepricings` → `price`, `rpcstandards` → `rpc`). Core series like `acdc`, `acde`, `acdt` pass through unchanged. The full mapping is defined in `SERIES_TO_TYPE` in `sync-call-assets.mjs` — series not in `KNOWN_TYPES` are skipped with a console warning.
 3. **Filters** — only syncs calls that have a `videoUrl` AND at least one of `tldr`, `transcript`, or `transcript_corrected`.
 4. **Downloads** new assets to `forkcast/public/artifacts/{type}/{date}_{number}/`. Skips files that already exist locally unless `--force` is passed.
-5. **Generates `config.json`** for each call — stores the issue number, video URL, and sync offsets. For livestreamed types (`acdc`, `acde`, `acdt`), sync times start as `null` (manual sync required). For all others, they default to `"00:00:00"`.
+5. **Generates `config.json`** for each call — stores the issue number, video URL, and sync offsets. For livestreamed types (`acdc`, `acde`), sync times start as `null` (manual sync required). For composed Zoom recordings (`acdt`), sync is required from PM's manifest. For all others, offsets default to `"00:00:00"`.
 6. **Updates `src/data/protocol-calls.generated.json`** — the frontend's call index, sorted by type then date. This file is additive — entries are never pruned automatically, so removing a call requires a manual edit.
 
 ### Step 2: Extract key decisions (`extract-key-decisions.mjs`)
@@ -102,7 +102,7 @@ If any files changed, the workflow commits, pushes, and triggers the `deploy.yml
 
 ### Step 4: Manual sync (livestreamed calls only)
 
-After a livestreamed call (acdc, acde, acdt) is deployed, a Forkcast engineer must manually set the sync offsets in `config.json`. The automated pipeline does not wait for this — it ships the call with `null` offsets, so the transcript and video are available but not aligned. See [Video/Transcript Sync](#videotranscript-sync) for how to set the offsets.
+After a livestreamed call (acdc, acde) is deployed, a Forkcast engineer must manually set the sync offsets in `config.json`. The automated pipeline does not wait for this — it ships the call with `null` offsets, so the transcript and video are available but not aligned. See [Video/Transcript Sync](#videotranscript-sync) for how to set the offsets.
 
 ### Forkcast artifact directory
 
@@ -125,7 +125,7 @@ Forkcast plays YouTube video alongside the VTT transcript. For playback to align
 - **`transcriptStartTime`** — when meaningful speech begins in the transcript
 - **`videoStartTime`** — the corresponding moment in the YouTube video
 
-### Livestreamed calls (acdc, acde, acdt)
+### Livestreamed calls (acdc, acde)
 
 These calls are streamed live to YouTube with intro screens, countdown timers, or pre-roll. The Zoom transcript starts recording at a different moment than the YouTube stream begins. This means the offsets must be set manually **after the call is already live on Forkcast**.
 
@@ -156,6 +156,18 @@ The call page works — you can watch the video and read the transcript — but 
    }
    ```
 4. Commit and push. The deploy workflow handles the rest.
+
+### Composed Zoom recordings (acdt)
+
+ACDT calls are uploaded from Zoom, but the published YouTube video is composed as:
+
+```text
+45s bumper + trimmed Zoom recording + 45s bumper
+```
+
+The transcript remains on the original Zoom recording clock. PM owns the composition settings, so PM publishes the generated sync offset in `manifest.json` and Forkcast copies that value into `config.json`. If an ACDT call is missing PM-provided sync metadata, the sync workflow fails instead of writing a misleading zero offset.
+
+This means `transcriptStartTime` and `videoStartTime` are expected to differ, but the sign depends on how much leading Zoom silence was trimmed. If a Forkcast engineer later adjusts the start point to skip beginning chatter, they should preserve the exact PM-generated `videoStartTime - transcriptStartTime` delta.
 
 ### Non-livestreamed calls
 

--- a/scripts/sync-call-assets.mjs
+++ b/scripts/sync-call-assets.mjs
@@ -7,6 +7,7 @@
 import { writeFileSync, readFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { generateConfig, normalizeManifest, updateConfig } from './sync-call-config.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -43,49 +44,6 @@ async function fetchManifest() {
   const response = await fetch(MANIFEST_URL);
   if (!response.ok) throw new Error(`Failed to fetch manifest: ${response.status}`);
   return response.json();
-}
-
-function normalizeManifest(manifest) {
-  if (manifest?.series && typeof manifest.series === 'object') {
-    const normalized = {};
-    for (const [series, seriesData] of Object.entries(manifest.series)) {
-      const calls = {};
-      for (const call of seriesData.calls || []) {
-        const callId = call?.path?.split('/')?.[1];
-        if (!callId) continue;
-        const resources = call.resources || {};
-        calls[callId] = {
-          has_tldr: Boolean(resources.tldr),
-          has_transcript: Boolean(resources.transcript),
-          has_corrected_transcript: Boolean(resources.transcript_corrected),
-          has_chat: Boolean(resources.chat),
-          has_transcript_changelog: Boolean(resources.changelog),
-          last_updated: call.updated || call.date || null,
-          // Metadata for config.json generation
-          issue: call.issue || null,
-          videoUrl: call.videoUrl || null
-        };
-      }
-      normalized[series] = calls;
-    }
-    return normalized;
-  }
-
-  return manifest.calls || {};
-}
-
-const LIVESTREAMED_TYPES = new Set(['acdc', 'acde']);
-
-function generateConfig(callData, localType) {
-  const needsManualSync = LIVESTREAMED_TYPES.has(localType);
-  return {
-    issue: callData.issue,
-    videoUrl: callData.videoUrl,
-    sync: {
-      transcriptStartTime: needsManualSync ? null : '00:00:00',
-      videoStartTime: needsManualSync ? null : '00:00:00'
-    }
-  };
 }
 
 async function downloadFile(url, destPath) {
@@ -131,23 +89,30 @@ async function syncCall(remoteSeries, localType, callId, callData, force = false
   // Handle config.json
   const configPath = join(localDir, 'config.json');
   if (!existsSync(configPath)) {
-    // Create new config from manifest data
     console.log('  Generating config.json');
     const config = generateConfig(callData, localType);
     writeFileSync(configPath, JSON.stringify(config, null, 2));
     changesMade = true;
   } else if (callData.videoUrl) {
-    // Update videoUrl if existing config has null and manifest has a value
+    let existingConfig;
     try {
-      const existingConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
-      if (existingConfig.videoUrl !== callData.videoUrl) {
-        console.log('  Updating config.json videoUrl');
-        existingConfig.videoUrl = callData.videoUrl;
-        writeFileSync(configPath, JSON.stringify(existingConfig, null, 2));
-        changesMade = true;
-      }
+      existingConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
     } catch (e) {
       console.log(`  Warning: Could not update config.json: ${e.message}`);
+      return changesMade;
+    }
+
+    const { config: updatedConfig, changed: configChanged } = updateConfig(existingConfig, callData, localType);
+    if (configChanged) {
+      if (existingConfig.videoUrl !== updatedConfig.videoUrl) {
+        console.log('  Updating config.json videoUrl');
+      }
+      if (existingConfig.sync !== updatedConfig.sync) {
+        console.log('  Updating config.json sync from manifest');
+      }
+
+      writeFileSync(configPath, JSON.stringify(updatedConfig, null, 2));
+      changesMade = true;
     }
   }
 

--- a/scripts/sync-call-assets.test.mjs
+++ b/scripts/sync-call-assets.test.mjs
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateConfig, normalizeManifest, updateConfig } from './sync-call-config.mjs';
+
+describe('call asset sync offsets', () => {
+  it('preserves PM-provided sync metadata from the normalized manifest', () => {
+    const manifest = {
+      series: {
+        acdt: {
+          calls: [
+            {
+              path: 'acdt/2026-06-08_082',
+              date: '2026-06-08',
+              resources: {
+                transcript: 'transcript.vtt',
+              },
+              issue: 2103,
+              videoUrl: 'https://www.youtube.com/watch?v=sample',
+              sync: {
+                transcriptStartTime: '00:00:43',
+                videoStartTime: '00:00:54',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(normalizeManifest(manifest).acdt['2026-06-08_082'].sync).toEqual({
+      transcriptStartTime: '00:00:43',
+      videoStartTime: '00:00:54',
+    });
+  });
+
+  it('uses PM-provided sync when generating config', () => {
+    const sync = {
+      transcriptStartTime: '00:04:47',
+      videoStartTime: '00:00:55',
+    };
+
+    expect(generateConfig({ issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample', sync }, 'acdt').sync).toEqual(sync);
+  });
+
+  it('keeps livestreamed calls manual when PM does not provide sync', () => {
+    expect(generateConfig({ issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample' }, 'acde').sync).toEqual({
+      transcriptStartTime: null,
+      videoStartTime: null,
+    });
+  });
+
+  it('requires PM-provided sync for composed Zoom calls', () => {
+    expect(() => generateConfig({ issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample' }, 'acdt')).toThrow(
+      'Missing PM-provided sync metadata',
+    );
+  });
+
+  it('rejects existing zero-sync config for composed Zoom calls without PM-provided sync', () => {
+    const existingConfig = {
+      issue: 2103,
+      videoUrl: 'https://www.youtube.com/watch?v=sample',
+      sync: {
+        transcriptStartTime: '00:00:00',
+        videoStartTime: '00:00:00',
+      },
+    };
+
+    expect(() =>
+      updateConfig(existingConfig, { issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample' }, 'acdt'),
+    ).toThrow('Missing PM-provided sync metadata');
+  });
+
+  it('updates missing config sync from PM-provided sync', () => {
+    const sync = {
+      transcriptStartTime: '00:00:43',
+      videoStartTime: '00:00:54',
+    };
+
+    expect(
+      updateConfig(
+        { issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample' },
+        { issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample', sync },
+        'acdt',
+      ),
+    ).toEqual({
+      config: {
+        issue: 2103,
+        videoUrl: 'https://www.youtube.com/watch?v=sample',
+        sync,
+      },
+      changed: true,
+    });
+  });
+
+  it('keeps raw Zoom calls zero synced when PM does not provide sync', () => {
+    expect(generateConfig({ issue: 2103, videoUrl: 'https://www.youtube.com/watch?v=sample' }, 'bal').sync).toEqual({
+      transcriptStartTime: '00:00:00',
+      videoStartTime: '00:00:00',
+    });
+  });
+});

--- a/scripts/sync-call-config.mjs
+++ b/scripts/sync-call-config.mjs
@@ -1,0 +1,88 @@
+const LIVESTREAMED_TYPES = new Set(['acdc', 'acde']);
+const COMPOSED_ZOOM_TYPES = new Set(['acdt']);
+
+export function normalizeManifest(manifest) {
+  if (manifest?.series && typeof manifest.series === 'object') {
+    const normalized = {};
+    for (const [series, seriesData] of Object.entries(manifest.series)) {
+      const calls = {};
+      for (const call of seriesData.calls || []) {
+        const callId = call?.path?.split('/')?.[1];
+        if (!callId) continue;
+        const resources = call.resources || {};
+        calls[callId] = {
+          has_tldr: Boolean(resources.tldr),
+          has_transcript: Boolean(resources.transcript),
+          has_corrected_transcript: Boolean(resources.transcript_corrected),
+          has_chat: Boolean(resources.chat),
+          has_transcript_changelog: Boolean(resources.changelog),
+          last_updated: call.updated || call.date || null,
+          // Metadata for config.json generation
+          issue: call.issue || null,
+          videoUrl: call.videoUrl || null,
+          sync: call.sync || null
+        };
+      }
+      normalized[series] = calls;
+    }
+    return normalized;
+  }
+
+  return manifest.calls || {};
+}
+
+function generatedSync(callData, localType) {
+  if (callData.sync) return callData.sync;
+
+  if (COMPOSED_ZOOM_TYPES.has(localType)) {
+    throw new Error(`Missing PM-provided sync metadata for composed Zoom recording type: ${localType}`);
+  }
+
+  const needsManualSync = LIVESTREAMED_TYPES.has(localType);
+  if (needsManualSync) {
+    return {
+      transcriptStartTime: null,
+      videoStartTime: null
+    };
+  }
+
+  return {
+    transcriptStartTime: '00:00:00',
+    videoStartTime: '00:00:00'
+  };
+}
+
+function isZeroSync(sync) {
+  return sync?.transcriptStartTime === '00:00:00' && sync?.videoStartTime === '00:00:00';
+}
+
+function needsGeneratedSync(sync) {
+  return !sync || isZeroSync(sync);
+}
+
+export function generateConfig(callData, localType) {
+  return {
+    issue: callData.issue,
+    videoUrl: callData.videoUrl,
+    sync: generatedSync(callData, localType)
+  };
+}
+
+export function updateConfig(existingConfig, callData, localType) {
+  const nextConfig = { ...existingConfig };
+  let configChanged = false;
+
+  if (callData.videoUrl && nextConfig.videoUrl !== callData.videoUrl) {
+    nextConfig.videoUrl = callData.videoUrl;
+    configChanged = true;
+  }
+
+  if (callData.sync && needsGeneratedSync(nextConfig.sync)) {
+    nextConfig.sync = callData.sync;
+    configChanged = true;
+  } else if (COMPOSED_ZOOM_TYPES.has(localType) && needsGeneratedSync(nextConfig.sync)) {
+    throw new Error(`Missing PM-provided sync metadata for composed Zoom recording type: ${localType}`);
+  }
+
+  return { config: nextConfig, changed: configChanged };
+}


### PR DESCRIPTION
## Summary

- consume PM-provided sync metadata from the call asset manifest
- generate composed recording config sync from manifest data instead of deriving it in Forkcast
- require PM-provided sync for composed Zoom calls instead of silently writing zero offsets
- keep livestreamed calls manual and raw Zoom calls zero-synced when the manifest does not provide sync
- keep the existing Forkcast pull path: repository dispatch wakes the workflow, then Forkcast pulls PM manifest/assets from raw GitHub

## Tests

- npm test -- scripts/sync-call-assets.test.mjs
- npm test
- npx eslint scripts/sync-call-assets.mjs scripts/sync-call-config.mjs scripts/sync-call-assets.test.mjs
- npx eslint . --ignore-pattern '.claude/**'
- npx prettier --check scripts/sync-call-assets.mjs scripts/sync-call-config.mjs scripts/sync-call-assets.test.mjs docs/acdbot-forkcast-asset-pipeline.md .agents/skills/sync-offsets/SKILL.md

Note: local `npm run lint` walks unrelated `.claude/worktrees/**` files in this checkout; the branch-scoped lint commands above pass.
