### PR TITLE
Add ACDT 82 breakout assets

### DIFF
--- a/public/artifacts/acdt-breakouts/2026-06-08_082/cl/chat.txt
+++ b/public/artifacts/acdt-breakouts/2026-06-08_082/cl/chat.txt
@@ -1,0 +1,76 @@
+10:46:15	 From terence : Is it by root or by roots?
+10:46:45	 From terence : Replying to "Is it by root or by ..."
+
+By root would be very slow
+10:49:24	 From Nico Flaig : isn't that what Manu wanted for prysm too? I remember there was a PR
+10:49:47	 From Justin Traglia : Reacted to "isn't that what Manu..." with 🤷
+10:50:38	 From Nico Flaig : https://github.com/ethereum/consensus-specs/pull/4394  this one
+10:52:20	 From Nico Flaig : :D
+10:52:24	 From Barnabas : This again
+10:52:26	 From Barnabas : 😂
+10:52:26	 From terence : What’s the next step with regard to this?
+10:52:47	 From Barnabas : Potuz should have been more opinionated when it was time to decide it
+10:54:04	 From Barnabas : Nico, this feels like a massive change so late again
+10:56:00	 From Justin Traglia : Replying to "Nico, this feels lik..."
+
+I agree. By default I am against changing this right now. But the idea is interesting. I wish we had considered this earlier.
+10:56:13	 From Justin Traglia : Reacted to "Potuz should have be..." with 👍
+10:56:52	 From Barnabas : New deposit contract would need to be audited
+10:57:37	 From Parithosh Jayanthi : +1 for massive change and really late
+10:57:57	 From pk910 : If we open up the floor for a new operator deposit contract, we could check BLS sigs in the EVM as well.   But yea, I agree it's too late :/
+10:58:07	 From NC : Next fork perhaps?
+10:58:13	 From Potuz : Replying to "Potuz should have be..."
+
+Never again championing any EIP
+10:59:30	 From marc | wolovim : Reacted to "Never again champion..." with 😭
+10:59:37	 From terence : Anyone implemented builder api?
+11:00:09	 From Barnabas : Replying to "Anyone implemented b..."
+
+Bro, just one more deposit contract first 😂
+11:00:14	 From Justin Traglia : Reacted to "Bro, just one more d..." with 😄
+11:00:22	 From terence : Replying to "Anyone implemented b..."
+
+Really think that should be the priority now
+11:00:23	 From Parithosh Jayanthi : Reacted to "Never again championing any EIP" with 😭
+11:00:32	 From Parithosh Jayanthi : Reacted to "Bro, just one more deposit contract first 😂" with 😄
+11:00:34	 From Potuz : Reacted to "Bro, just one more deposit contract first 😂" with 😄
+11:00:52	 From Parithosh Jayanthi : we
+11:00:55	 From Parithosh Jayanthi : We’re at time btw
+11:01:02	 From Nico Flaig : Reacted to "Bro, just one more d..." with 😄
+11:01:05	 From Parithosh Jayanthi : Im fine to stay on!
+11:01:21	 From Justin Traglia : Replying to "Im fine to stay on!"
+
+Same for me
+11:01:25	 From terence : Kurtosis?
+11:02:28	 From Barnabas : Let’s get stuff merged and mod it later if something is bad?
+11:02:36	 From Justin Traglia : Reacted to "Let’s get stuff merg..." with 👍
+11:02:38	 From Nico Flaig : Replying to "Next fork perhaps?"
+
+while this is possible it would be ugly becasue we have to deal with the whole mess in gloas anyways and implement all the mitigations to not allow someone to easily dos the chain
+11:02:41	 From Justin Traglia : Replying to "Let’s get stuff merg..."
+
+Yes. Merge & iterate.
+11:02:44	 From Barnabas : I think endlessly waiting on builder feedback is a bad feedback loop
+11:02:52	 From Justin Traglia : Reacted to "I think endlessly wa..." with 👍
+11:03:38	 From Bharath : Reacted to "I think endlessly wa..." with 👍
+11:03:49	 From Barnabas : Deadline EOD 😂
+11:04:20	 From pawan : Replying to "Next fork perhaps?"
+
+I think the mitigations are pretty contained in lighthouse. Shouldn’t be too hard
+11:04:42	 From terence : I have
+11:06:34	 From Justin Traglia : @Bharath can you share a link to the PR here?
+11:06:45	 From terence : https://github.com/ethereum/builder-specs/pull/138
+11:06:53	 From Justin Traglia : Reacted to "https://github.com/e..." with 🙏
+11:07:26	 From Justin Traglia : @Parithosh Jayanthi do you know if the EL breakout has ended? Just curious.
+11:08:01	 From Justin Traglia : Replying to "@Parithosh Jayanthi ..."
+
+Ah it’s empty.
+11:08:54	 From terence : Take away: everyone should go study the builder api spec and provide feedback
+11:09:01	 From Justin Traglia : Reacted to "Take away: everyone ..." with 👍
+11:09:03	 From Potuz : Yeah it’s important
+11:09:10	 From Potuz : Dustin wanted to get rid of registrations
+11:09:17	 From Potuz : And now we have them back as mandatory it seems
+11:09:25	 From Parithosh Jayanthi : Replying to "@Parithosh Jayanthi ..."
+
+Yeah sorry, its ended 😄
+11:09:33	 From Bharath : Will put the link in epbs

--- a/public/artifacts/acdt-breakouts/2026-06-08_082/el/chat.txt
+++ b/public/artifacts/acdt-breakouts/2026-06-08_082/el/chat.txt
@@ -1,0 +1,72 @@
+10:43:41	 From jochem-brouwer : you can mine the tx though
+10:44:46	 From Mario Vega : The only problem is 8037, so chains have to be cognizant of this and deploy option 2 before forking to 8037
+10:45:05	 From jochem-brouwer : want to echo frangio's point we can use (2) to deploy (3)
+10:45:30	 From Marius Van Der Wijden (M) : Which doc are we talking about?
+10:45:46	 From kclowes : https://nerolation.github.io/hegota-eip-presentations/eip-7997.html
+10:45:47	 From Toni Wahrstätter : https://nerolation.github.io/hegota-eip-presentations/eip-7997.html
+10:46:04	 From raxhvl : Also archnaids factory is hardcoded in tooling like foundry
+10:46:21	 From Łukasz Rozmej : ok maybe I don't have the context then
+10:46:35	 From Toni Wahrstätter : Replying to "Also archnaids facto..."
+
+yess, and it's the default even
+10:46:50	 From raxhvl : Replying to "ok maybe I don't hav..." 
+
+ Here is a write up on this context: Here is a write up on this: https://happychain.notion.site/xchain-deterministic-deploy
+10:47:04	 From Łukasz Rozmej : ok the downside is that if you forget abouit it you f-uped your chain
+10:47:18	 From frangio : Replying to "ok the downside is..."
+
+cant this be added in a hard fork?
+10:48:53	 From Mario Vega : Replying to "ok the downside is t..."
+
+This is why I think retaining an EIP for this is important, it signals other chains that this contract has to be deployed before forking
+10:49:21	 From jochem-brouwer : Heeft gereageerd op "This is why I thin..." met ➕
+10:49:24	 From kevaundray wedderburn : Reacted to "This is why I think retaining an EIP for this is important, it signals other chains that this contract has to be deployed before forking" with ➕
+10:49:45	 From kevaundray wedderburn : Replying to "ok the downside is that if you forget abouit it you f-uped your chain"
+
+Might be good to also signal to other chains explicitly via some announcement
+10:50:02	 From frangio : i didn't understand mario's point, can someone explain that again?
+10:50:13	 From Toni Wahrstätter : Replying to "i didn't understand ..."
+
+@Mario Vega 
+10:50:25	 From Marius Van Der Wijden (M) : Replying to "ok the downside is t..." 
+
+ Ethereum.org blog post
+10:50:26	 From kevaundray wedderburn : Replying to "i didn't understand mario's point, can someone explain that again?"
+
+Just that with an eip, we have an explicit signal to other chains
+10:50:32	 From Toni Wahrstätter : Replying to "i didn't understand ..."
+
+I understood it as, no matter where we land, we have to ship it in an eip in glam
+10:50:55	 From frangio : Replying to "i didn't understan..."
+
+it being option 2, right?
+10:51:11	 From Mario Vega : Replying to "i didn't understand ..."
+
+The EIP being in the meta Amsterdam EIP means that anyone implemeting thefork, after looking at the EIP numbers included, will look at this EIP and know that this contract has to be deployed before forking
+10:51:16	 From Mario Vega : Replying to "i didn't understand ..."
+
+Yes option 2
+10:51:17	 From Toni Wahrstätter : Replying to "i didn't understand ..."
+
+even if it's a no-op, we at least specify it in the genesis file. Draft here:
+https://github.com/nerolation/EIPs/blob/eaee46304d8c46c2c02fad963f7295d10396c6d8/EIPS/eip-8269.md
+10:51:20	 From frangio : Reacted to "The EIP being in t..." with 👍
+10:51:21	 From kevaundray wedderburn : Replying to "i didn't understand mario's point, can someone explain that again?"
+
+So before updating to glamsterdam, other chains should look at the eip and become aware that they should do option 2
+10:51:23	 From Maria Silva : ethereum/EIPs#11715
+10:51:28	 From Luis Pinto | Besu : Reviewed Gary’s PR, opened a few points but looks good to me generally
+10:51:29	 From frangio : Replying to "i didn't understan..."
+
+thanks
+10:51:30	 From kevaundray wedderburn : Reacted to "The EIP being in the meta Amsterdam EIP means that anyone implemeting thefork, after looking at the EIP numbers included, will look at this EIP and know that this contract has to be deployed before forking" with 👍
+10:51:44	 From Mario Vega : Reacted to "So before updating t..." with 👍🏼
+10:52:46	 From Maria Silva : https://hackmd.io/@bFEBbZiVSAO0IURh9qzEFg/BJmFYqCeGl
+10:55:12	 From Luis Pinto | Besu : Did not look into this either
+10:55:31	 From jochem-brouwer : I think for explicitness in the spec it should describe the gas charge order (which is rather complex) after we decide what this order actually is
+10:56:54	 From Stefan Starflinger : LGTM
+10:56:55	 From Stefan Starflinger : ship it
+10:57:44	 From raxhvl : https://github.com/ethereum/execution-specs/pull/2900
+11:00:15	 From Toni Wahrstätter : https://discord.com/channels/595666850260713488/1506543443172921464/1513542339971514499
+11:00:41	 From Toni Wahrstätter : https://github.com/ethereum/execution-specs/pull/2900
+11:01:07	 From jochem-brouwer : the situations also seem to apply the eip-8037 point we just had

--- a/src/data/breakouts.ts
+++ b/src/data/breakouts.ts
@@ -2,7 +2,7 @@
 // (BAL, ePBS, etc.) in protocolCalls — those are standalone call series;
 // these only exist as sub-calls to their parent ACDT call.
 
-export type BreakoutKind = 'bal' | 'epbs';
+export type BreakoutKind = 'bal' | 'epbs' | 'el' | 'cl';
 
 export interface Breakout {
   parentPath: string;   // e.g. 'acdt/078'
@@ -14,6 +14,8 @@ export interface Breakout {
 export const breakoutLabels: Record<BreakoutKind, string> = {
   bal: 'BAL',
   epbs: 'ePBS',
+  el: 'EL',
+  cl: 'CL',
 };
 
 export const breakouts: Breakout[] = [
@@ -23,4 +25,6 @@ export const breakouts: Breakout[] = [
   { parentPath: 'acdt/077', kind: 'epbs', artifactDir: 'acdt-breakouts/2026-04-13_077/epbs', videoUrl: 'https://youtu.be/-lHgAxinfIo' },
   { parentPath: 'acdt/078', kind: 'bal',  artifactDir: 'acdt-breakouts/2026-04-20_078/bal',  videoUrl: 'https://youtu.be/Cx0PSZkVtmM' },
   { parentPath: 'acdt/078', kind: 'epbs', artifactDir: 'acdt-breakouts/2026-04-20_078/epbs', videoUrl: 'https://youtu.be/BvLC4AE3cyY' },
+  { parentPath: 'acdt/082', kind: 'el',   artifactDir: 'acdt-breakouts/2026-06-08_082/el',   videoUrl: 'https://youtu.be/GZ8EHWnUx_k' },
+  { parentPath: 'acdt/082', kind: 'cl',   artifactDir: 'acdt-breakouts/2026-06-08_082/cl',   videoUrl: 'https://youtu.be/WYVjX_QuIQo' },
 ];

--- a/src/domain/chat/zoomChat.test.ts
+++ b/src/domain/chat/zoomChat.test.ts
@@ -76,4 +76,30 @@ describe('parseChatTranscript', () => {
       { speaker: 'Chris', emoji: '👍' },
     ]);
   });
+
+  it('accepts raw Zoom chat export lines with From speaker markers', () => {
+    const { messages, reactions } = parseChatTranscript([
+      '10:46:15\t From terence : Is it by root or by roots?',
+      '10:46:45\t From terence : Replying to "Is it by root or by ..."',
+      '',
+      'By root would be very slow',
+      '10:49:47\t From Justin Traglia : Reacted to "isn\'t that what Manu..." with 🤷',
+    ].join('\n'));
+
+    expect(messages).toEqual([
+      {
+        timestamp: '10:46:15',
+        speaker: 'terence',
+        message: 'Is it by root or by roots?',
+      },
+      {
+        timestamp: '10:46:45',
+        speaker: 'terence',
+        message: 'Replying to "Is it by root or by ..." → By root would be very slow',
+      },
+    ]);
+    expect(reactions.get("isn't that what Manu...")).toEqual([
+      { speaker: 'Justin Traglia', emoji: '🤷' },
+    ]);
+  });
 });

--- a/src/domain/chat/zoomChat.ts
+++ b/src/domain/chat/zoomChat.ts
@@ -58,6 +58,14 @@ const normalizeReplyHeaderLine = (line: string): string | null => {
   return null;
 };
 
+const normalizeZoomExportLine = (line: string): string => {
+  const match = line.match(/^(\d{2}:\d{2}:\d{2})\t\s*From\s+(.+?)\s:\s?([\s\S]*)$/);
+  if (!match) return line;
+
+  const [, timestamp, speaker, message] = match;
+  return `${timestamp}\t${speaker.trim()}:\t${message}`;
+};
+
 export const isReplyMessage = (message: string): boolean =>
   message.startsWith(CANONICAL_REPLY_PREFIX);
 
@@ -121,8 +129,10 @@ export const parseChatTranscript = (text: string): ParsedChatTranscript => {
   const processedLines: string[] = [];
 
   for (const line of rawLines) {
-    if (/^\d{2}:\d{2}:\d{2}\t/.test(line)) {
-      processedLines.push(line);
+    const normalizedLine = normalizeZoomExportLine(line);
+
+    if (/^\d{2}:\d{2}:\d{2}\t/.test(normalizedLine)) {
+      processedLines.push(normalizedLine);
     } else if (line.trim()) {
       let targetIndex = processedLines.length - 1;
       while (targetIndex >= 0 && !processedLines[targetIndex].trim()) {


### PR DESCRIPTION
## Summary

Adds the June 8 ACDT breakout recordings and chat logs as sub-call tabs on the existing ACDT parent call.

## Changes

- Adds EL and CL ACDT breakout kinds and labels.
- Registers the June 8 EL and CL breakout video links.
- Adds the EL and CL Zoom chat exports under the ACDT breakout artifact tree.
- Extends the Zoom chat parser to accept raw exports that use `From <speaker> : <message>` lines, including multiline reply bodies.

## Validation

- `npm test -- src/domain/chat/zoomChat.test.ts`
- `npx tsc --noEmit`
- `npm run build`