### PR TITLE
decisions: hover eip previews on all decisions

### DIFF
--- a/src/components/DecisionsPage.tsx
+++ b/src/components/DecisionsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { protocolCalls, Call } from '../data/calls';
 import { KeyDecision } from '../types/eip';
 import { eipById } from '../data/eips';
-import { StructuredDecisionContent } from './call/KeyDecisionsSection';
+import { StructuredDecisionContent, DecisionTextWithEipLinks } from './call/KeyDecisionsSection';
 import { useMetaTags } from '../hooks/useMetaTags';
 
 interface MeetingDecisions {
@@ -102,15 +102,15 @@ const DecisionsPage: React.FC = () => {
         </div>
 
         {/* Filter pills */}
-        <div className="flex flex-wrap gap-2 mb-4">
+        <div className="flex flex-wrap items-center gap-1.5 mt-4 mb-4">
           {FILTER_OPTIONS.map(opt => (
             <button
               key={opt.value}
               onClick={() => setFilter(opt.value)}
-              className={`px-3 py-1.5 text-sm font-medium rounded-full transition-colors ${
+              className={`cursor-pointer whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
                 filter === opt.value
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700 hover:border-purple-300 dark:hover:border-purple-600'
+                  ? 'bg-purple-600 dark:bg-purple-500 text-white dark:text-white'
+                  : 'bg-purple-50 dark:bg-purple-950/30 text-purple-700 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-purple-900/30'
               }`}
             >
               {opt.label}
@@ -161,7 +161,7 @@ const DecisionsPage: React.FC = () => {
                       >
                         {isStructured
                           ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                          : decision.original_text
+                          : <DecisionTextWithEipLinks decision={decision} eipMap={eipById} />
                         }
                       </li>
                     );

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -6,7 +6,7 @@ import { eipsData, eipById } from '../data/eips';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { getProposalPrefix, getLaymanTitle, getInclusionStage } from '../utils/eip';
 import UpgradeCard from './ui/UpgradeCard';
-import { StructuredDecisionContent } from './call/KeyDecisionsSection';
+import { StructuredDecisionContent, DecisionTextWithEipLinks } from './call/KeyDecisionsSection';
 import { EIP, KeyDecision } from '../types/eip';
 
 const ACD_TYPES: CallType[] = ['acdc', 'acde', 'acdt'];
@@ -357,7 +357,7 @@ const HomePage = () => {
                       >
                         {isStructured
                           ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                          : decision.original_text}
+                          : <DecisionTextWithEipLinks decision={decision} eipMap={eipById} />}
                       </li>
                     );
                   })}

--- a/src/components/call/CallPlanPage.tsx
+++ b/src/components/call/CallPlanPage.tsx
@@ -7,7 +7,7 @@ import { eipsData, eipById as eipMap } from '../../data/eips';
 import { networkUpgrades } from '../../data/upgrades';
 import { getPendingProposalsForFork, type PendingProposal } from '../../data/pending-proposals';
 import { fetchUpcomingCalls, type UpcomingCall } from '../../domain/calls/upcomingCalls';
-import { StructuredDecisionContent, EipLinkWithTooltip } from './KeyDecisionsSection';
+import { StructuredDecisionContent, EipLinkWithTooltip, DecisionTextWithEipLinks } from './KeyDecisionsSection';
 
 interface TldrData {
   meeting: string;
@@ -1030,7 +1030,7 @@ const CallPlanPage: React.FC = () => {
                                             >
                                               {isStructured
                                                 ? <StructuredDecisionContent decision={decision} eipMap={eipMap} />
-                                                : decision.original_text
+                                                : <DecisionTextWithEipLinks decision={decision} eipMap={eipMap} />
                                               }
                                             </li>
                                           );

--- a/src/components/call/KeyDecisionsSection.tsx
+++ b/src/components/call/KeyDecisionsSection.tsx
@@ -148,6 +148,62 @@ export const EipLinkWithTooltip: React.FC<{
 };
 
 /**
+ * Render decision text with EIP references replaced by hoverable links.
+ *
+ * Uses decision.eips as the source of truth. For each known EIP, replaces
+ * "EIP-XXXX" or bare "XXXX" occurrences in the text with a linked preview.
+ * Any EIPs in the array that don't appear in the text at all are appended
+ * as links after the text.
+ */
+export const DecisionTextWithEipLinks: React.FC<{
+  decision: KeyDecision;
+  eipMap: Map<number, EIP>;
+}> = ({ decision, eipMap }) => {
+  const { original_text: text, eips } = decision;
+
+  if (eips.length === 0) return <>{text}</>;
+
+  // Build a regex that matches "EIP-XXXX" or bare "XXXX" for each known EIP id
+  const eipSet = new Set(eips);
+  const idPattern = eips.map(id => `EIP-${id}\\b|\\b${id}\\b`).join('|');
+  const regex = new RegExp(`(${idPattern})`, 'g');
+
+  const linkedIds = new Set<number>();
+  const parts = text.split(regex);
+
+  const rendered = parts.map((part, i) => {
+    // Check if this part matches any known EIP
+    const bareMatch = part.match(/^(?:EIP-)?(\d+)$/);
+    if (bareMatch) {
+      const id = Number(bareMatch[1]);
+      if (eipSet.has(id)) {
+        linkedIds.add(id);
+        return <EipLinkWithTooltip key={i} eipId={id} eipMap={eipMap} />;
+      }
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>;
+  });
+
+  // Append links for any EIPs not found in the text
+  const unlinked = eips.filter(id => !linkedIds.has(id));
+  if (unlinked.length === 0) return <>{rendered}</>;
+
+  return (
+    <>
+      {rendered}
+      {' ('}
+      {unlinked.map((id, i) => (
+        <React.Fragment key={id}>
+          {i > 0 && ', '}
+          <EipLinkWithTooltip eipId={id} eipMap={eipMap} />
+        </React.Fragment>
+      ))}
+      {')'}
+    </>
+  );
+};
+
+/**
  * Build the decision as a readable sentence with inline colored tag.
  *
  * Examples:
@@ -162,9 +218,9 @@ export const StructuredDecisionContent: React.FC<{
   const tagColor = getKeyDecisionTagColor(decision);
   const tagLabel = getTagLabel(decision);
 
-  // Fallback: no EIPs resolved, show original text
-  if (decision.eips.length === 0) {
-    return <>{decision.original_text}</>;
+  // For 'other' type or no EIPs, render original_text with inline EIP links
+  if (decision.type === 'other' || decision.eips.length === 0) {
+    return <DecisionTextWithEipLinks decision={decision} eipMap={eipMap} />;
   }
 
   const eipLinks = decision.eips.map((eipId, i) => (
@@ -286,7 +342,7 @@ const KeyDecisionsSection: React.FC<KeyDecisionsSectionProps> = ({
             }`}>
               {isStructured
                 ? <StructuredDecisionContent decision={decision} eipMap={eipById} />
-                : decision.original_text
+                : <DecisionTextWithEipLinks decision={decision} eipMap={eipById} />
               }
             </span>
             <span className="text-xs text-slate-400 dark:text-slate-500 ml-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/calls-index/CallsIndexFilters.tsx
+++ b/src/components/calls-index/CallsIndexFilters.tsx
@@ -131,7 +131,7 @@ export const CallsIndexFilters = ({
               <button
                 key={option.value}
                 onClick={() => onSelectFilter(option.value)}
-                className={`flex-shrink-0 whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
+                className={`cursor-pointer flex-shrink-0 whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
                   selectedFilter === option.value
                     ? FILTER_ACTIVE_COLORS[option.value]
                     : FILTER_INACTIVE_COLORS[option.value]


### PR DESCRIPTION
eip hover previews only exist on two types of key decisions: stage changes and devnet inclusions. this PR extends the functionality to all decision types and renders them wherever they show up: home, call, agenda pages. finally, updates the out-of-place decision page filter button styles.