### PR TITLE
Fix call search request replay

### DIFF
--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -382,6 +382,7 @@ const CallPage: React.FC<CallPageProps> = ({ isSearchOpen, setIsSearchOpen, sear
   const [selectedSearchResult, setSelectedSearchResult] = useState<{timestamp: string, text: string, type: string} | null>(null);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
+  const handledSearchRequestIdRef = useRef(0);
   const [isLargeScreen, setIsLargeScreen] = useState(
     () => window.matchMedia('(min-width: 1024px)').matches
   );
@@ -527,7 +528,8 @@ const CallPage: React.FC<CallPageProps> = ({ isSearchOpen, setIsSearchOpen, sear
   }, [handlePauseVideo, setIsSearchOpen]);
 
   useEffect(() => {
-    if (searchRequestId === 0) return;
+    if (searchRequestId === 0 || searchRequestId === handledSearchRequestIdRef.current) return;
+    handledSearchRequestIdRef.current = searchRequestId;
     setIsSearchOpen(true);
     handlePauseVideo();
   }, [searchRequestId, handlePauseVideo, setIsSearchOpen]);


### PR DESCRIPTION
## Summary

Fixes a call-page search state replay where opening search from the call nav could be handled again after the YouTube player changed state.

Root cause: `CallPage` re-opened search in an effect keyed by `searchRequestId`, but the same effect also depended on `handlePauseVideo`. When the player started playing, `isPlaying` changed, `handlePauseVideo` changed identity, and the effect handled the previous nav search request again.

The fix records the last handled search request id and only opens search when the nav sends a new request.

## Verification

- Reproduced on production at `/calls/acde/235#t=3756`: open search, close it, click the YouTube player; the search modal reappears.
- Verified the fixed production preview keeps the modal closed after the same sequence.
- `npm test`
- `npm run build`

## Recordings

I captured Playwright `.webm` recordings for the production reproduction and local fixed preview, but the available GitHub CLI/API path in this environment does not expose PR body binary attachment uploads. I left them out of the repository rather than committing binary artifacts.