### PR TITLE
Restore live calls freshness

### DIFF
--- a/src/components/CallsIndexPage.tsx
+++ b/src/components/CallsIndexPage.tsx
@@ -2,7 +2,11 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { useSearchParams, useNavigate } from './navigation';
 import { protocolCalls, callTypeNames, isOneOffCall, type CallType } from '../data/calls';
 import { timelineEvents } from '../data/events';
-import { upcomingCalls } from '../domain/calls/upcomingCalls';
+import {
+  fetchUpcomingCallsIfAvailable,
+  upcomingCalls as upcomingCallsSnapshot,
+  type UpcomingCall
+} from '../domain/calls/upcomingCalls';
 import GlobalCallSearch from './GlobalCallSearch';
 import { SearchTriggerButton } from './search/SearchUi';
 import { isSearchHotkey } from './search/searchShortcuts';
@@ -35,6 +39,8 @@ const CallsIndexPage: React.FC<CallsIndexPageProps> = ({ scope }) => {
   // query filter. Aggregate filters (acd, breakouts) only ever live in the query.
   const selectedFilter = scope ?? (searchParams.get('filter') || 'all');
   const selectedBreakoutType = scope ? '' : (searchParams.get('breakoutType') || '');
+  const [upcomingCalls, setUpcomingCalls] = useState<UpcomingCall[]>(upcomingCallsSnapshot);
+  const [upcomingCallsLoading, setUpcomingCallsLoading] = useState(true);
   const [searchOpen, setSearchOpen] = useState(false);
   const [breakoutDropdownOpen, setBreakoutDropdownOpen] = useState(false);
   const breakoutDropdownRef = useRef<HTMLDivElement>(null);
@@ -52,6 +58,22 @@ const CallsIndexPage: React.FC<CallsIndexPageProps> = ({ scope }) => {
     if (breakoutType) params.set('breakoutType', breakoutType);
     navigate(`/calls?${params.toString()}`);
   };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadUpcomingCalls = async () => {
+      const upcoming = await fetchUpcomingCallsIfAvailable();
+      if (!cancelled && upcoming) setUpcomingCalls(upcoming);
+      if (!cancelled) setUpcomingCallsLoading(false);
+    };
+
+    loadUpcomingCalls();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -84,7 +106,7 @@ const CallsIndexPage: React.FC<CallsIndexPageProps> = ({ scope }) => {
   const breakoutTypes = useMemo(() => Array.from(new Set([
     ...protocolCalls.filter(call => !ACD_TYPES.includes(call.type) && !isOneOffCall(call.type)).map(call => call.type),
     ...upcomingCalls.filter(call => !ACD_TYPES.includes(call.type) && !isOneOffCall(call.type)).map(call => call.type),
-  ])).sort((a, b) => (callTypeNames[a as CallType] || a).localeCompare(callTypeNames[b as CallType] || b)), []);
+  ])).sort((a, b) => (callTypeNames[a as CallType] || a).localeCompare(callTypeNames[b as CallType] || b)), [upcomingCalls]);
 
   const hasOneOffCalls = useMemo(() => protocolCalls.some(call => isOneOffCall(call.type)), []);
 
@@ -104,7 +126,7 @@ const CallsIndexPage: React.FC<CallsIndexPageProps> = ({ scope }) => {
     : selectedFilter === 'breakouts'
     ? upcomingCalls.filter(call => !ACD_TYPES.includes(call.type) && matchesSelectedBreakoutType(call.type, selectedBreakoutType))
     : upcomingCalls.filter(call => call.type === selectedFilter),
-  [selectedFilter, selectedBreakoutType]);
+  [upcomingCalls, selectedFilter, selectedBreakoutType]);
 
   const timelineItems = useMemo(() => {
     return [
@@ -118,8 +140,8 @@ const CallsIndexPage: React.FC<CallsIndexPageProps> = ({ scope }) => {
   const todayDateString = getTodayDateString(new Date(), viewerTimeZone);
 
   const dateSections = useMemo(
-    () => buildTimelineDateSections(timelineItems, todayDateString, false, viewerTimeZone),
-    [timelineItems, todayDateString, viewerTimeZone]
+    () => buildTimelineDateSections(timelineItems, todayDateString, upcomingCallsLoading, viewerTimeZone),
+    [timelineItems, todayDateString, upcomingCallsLoading, viewerTimeZone]
   );
 
   const breakoutLabel = selectedBreakoutType === 'one-off'

--- a/src/domain/calls/upcomingCalls.test.ts
+++ b/src/domain/calls/upcomingCalls.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { isUpcomingCallStillRelevant, hasUpcomingWatchPage } from './upcomingCalls';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchUpcomingCallsIfAvailable,
+  isUpcomingCallStillRelevant,
+  createUpcomingWatchPagePredicate,
+  hasUpcomingVideo,
+  type UpcomingCall,
+} from './upcomingCalls';
 import {
   resolveUpcomingCallSchedule,
   resolveUpcomingCallSeries,
@@ -8,6 +14,11 @@ import {
   parseUpcomingCallFromIssue,
   extractYouTubeUrl
 } from './upcomingCallParsing';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('resolveUpcomingCallSchedule', () => {
   it('parses date and time from the body UTC Date & Time section', () => {
@@ -146,13 +157,58 @@ describe('extractYouTubeUrl', () => {
   });
 });
 
-describe('hasUpcomingWatchPage', () => {
-  // Shared predicate that keeps getStaticPaths() and the call index's internal-vs-external
-  // link decision in agreement: an internal /calls/{type}/{number} page exists only when
-  // there's a video to watch.
+describe('hasUpcomingVideo', () => {
   it('is true only when the call has a video', () => {
-    expect(hasUpcomingWatchPage({ youtubeUrl: 'https://youtu.be/x' })).toBe(true);
-    expect(hasUpcomingWatchPage({ youtubeUrl: undefined })).toBe(false);
+    expect(hasUpcomingVideo({ youtubeUrl: 'https://youtu.be/x' })).toBe(true);
+    expect(hasUpcomingVideo({ youtubeUrl: undefined })).toBe(false);
+  });
+});
+
+describe('createUpcomingWatchPagePredicate', () => {
+  const upcomingCall = (call: Partial<UpcomingCall> & Pick<UpcomingCall, 'type' | 'number'>): UpcomingCall => ({
+    title: `${call.type} ${call.number}`,
+    date: '2026-03-11',
+    githubUrl: `https://github.com/ethereum/pm/issues/${call.issueNumber ?? 1}`,
+    issueNumber: call.issueNumber ?? 1,
+    ...call,
+  });
+
+  it('is true only for calls that had a video in the build-time snapshot', () => {
+    const hasWatchPage = createUpcomingWatchPagePredicate([
+      upcomingCall({ type: 'acdc', number: '166', youtubeUrl: 'https://youtu.be/x' }),
+      upcomingCall({ type: 'acde', number: '222' }),
+    ]);
+
+    expect(hasWatchPage({ type: 'acdc', number: '166' })).toBe(true);
+    expect(hasWatchPage({ type: 'acde', number: '222' })).toBe(false);
+    expect(hasWatchPage({ type: 'acdt', number: '082' })).toBe(false);
+  });
+
+  it('does not treat a live-fetched video as proof that a static route exists', () => {
+    const hasWatchPage = createUpcomingWatchPagePredicate([]);
+
+    expect(hasWatchPage({ type: 'acdc', number: '166' })).toBe(false);
+  });
+});
+
+describe('fetchUpcomingCallsIfAvailable', () => {
+  it('returns an empty list for a successful GitHub response with no upcoming calls', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    }));
+
+    await expect(fetchUpcomingCallsIfAvailable()).resolves.toEqual([]);
+  });
+
+  it('returns undefined when the live GitHub fetch fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    }));
+
+    await expect(fetchUpcomingCallsIfAvailable()).resolves.toBeUndefined();
   });
 });
 

--- a/src/domain/calls/upcomingCalls.ts
+++ b/src/domain/calls/upcomingCalls.ts
@@ -21,22 +21,34 @@ export interface UpcomingCall {
 
 /**
  * Build-time snapshot of upcoming calls (refreshed by snapshot-runtime-routes.mjs).
- * Islands and Astro's getStaticPaths() both read this so the call index only links
- * to upcoming-call watch pages the static build actually emitted. `fetchUpcomingCalls`
- * below is the live read used for the "next call" hints on the agenda/EIP pages
- * (external links only — see hasUpcomingWatchPage), not for routing.
+ * Islands and Astro's getStaticPaths() both read this so static routes and the
+ * initial call index agree. `fetchUpcomingCalls` below is the live read used for
+ * per-visit freshness; see hasUpcomingWatchPage for the static-route guard that
+ * keeps live data from linking to pages the build did not emit.
  */
 export const upcomingCalls: UpcomingCall[] = upcomingCallsSnapshot as UpcomingCall[];
 
-/**
- * Whether an upcoming call has an internal watch page. The build emits a
- * `/calls/{type}/{number}` watch page only when there is a video to watch, and
- * the call index links such calls internally; calls without one link out to the
- * GitHub issue. This single predicate keeps getStaticPaths() and the island's
- * internal-vs-external link decision in agreement.
- */
-export const hasUpcomingWatchPage = (call: Pick<UpcomingCall, 'youtubeUrl'>): boolean =>
+const upcomingCallId = (call: Pick<UpcomingCall, 'type' | 'number'>): string =>
+  `${call.type}-${call.number}`;
+
+export const hasUpcomingVideo = (call: Pick<UpcomingCall, 'youtubeUrl'>): boolean =>
   Boolean(call.youtubeUrl);
+
+/**
+ * Build a predicate for whether an upcoming call has a static internal watch
+ * page. The page exists only when that call was in the build-time snapshot with
+ * a video URL. Live-fetched calls may also have videos, but they must link out
+ * unless the current static build emitted their `/calls/{type}/{number}` page.
+ */
+export const createUpcomingWatchPagePredicate = (
+  snapshot: ReadonlyArray<UpcomingCall>
+): ((call: Pick<UpcomingCall, 'type' | 'number'>) => boolean) => {
+  const watchPageIds = new Set(snapshot.filter(hasUpcomingVideo).map(upcomingCallId));
+
+  return (call) => watchPageIds.has(upcomingCallId(call));
+};
+
+export const hasUpcomingWatchPage = createUpcomingWatchPagePredicate(upcomingCalls);
 
 interface GitHubIssue {
   title: string;
@@ -82,42 +94,54 @@ export const isUpcomingCallStillRelevant = (
   timeZone?: string
 ): boolean => getUpcomingCallBucketDate(call, timeZone) >= getTodayDateString(now, timeZone);
 
+const fetchUpcomingCallsFromGitHub = async (): Promise<UpcomingCall[]> => {
+  const response = await fetch('https://api.github.com/repos/ethereum/pm/issues?state=open&per_page=20');
+
+  if (!response.ok) {
+    throw new Error(`GitHub issues fetch failed: ${response.status}`);
+  }
+
+  const issues: GitHubIssue[] = await response.json();
+  const completedCallIds = new Set(protocolCalls.map(call => `${call.type}-${call.number}`));
+  const foundTypes = new Set<string>();
+  const parsedCalls: ParsedUpcomingCall[] = [];
+
+  for (const issue of issues) {
+    const call = parseUpcomingCallFromIssue(issue as UpcomingCallIssue);
+    if (!call) continue;
+    if (!isUpcomingCallStillRelevant(call)) continue;
+    if (foundTypes.has(call.type)) continue;
+    if (completedCallIds.has(`${call.type}-${call.number}`)) continue;
+
+    parsedCalls.push(call);
+    foundTypes.add(call.type);
+  }
+
+  const youtubeUrls = await Promise.all(
+    parsedCalls.map(call => fetchYouTubeFromIssue(call.issueNumber))
+  );
+
+  return parsedCalls
+    .map((call, index): UpcomingCall => ({ ...call, youtubeUrl: youtubeUrls[index] }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+};
+
 // Fetch upcoming ACD calls from GitHub issues. Shares the parsing rules with the
 // build snapshot via parseUpcomingCallFromIssue (upcomingCallParsing.ts).
 export async function fetchUpcomingCalls(): Promise<UpcomingCall[]> {
   try {
-    const response = await fetch('https://api.github.com/repos/ethereum/pm/issues?state=open&per_page=20');
-
-    if (!response.ok) {
-      console.warn('Failed to fetch GitHub issues:', response.status);
-      return [];
-    }
-
-    const issues: GitHubIssue[] = await response.json();
-    const completedCallIds = new Set(protocolCalls.map(call => `${call.type}-${call.number}`));
-    const foundTypes = new Set<string>();
-    const parsedCalls: ParsedUpcomingCall[] = [];
-
-    for (const issue of issues) {
-      const call = parseUpcomingCallFromIssue(issue as UpcomingCallIssue);
-      if (!call) continue;
-      if (!isUpcomingCallStillRelevant(call)) continue;
-      if (foundTypes.has(call.type)) continue;
-      if (completedCallIds.has(`${call.type}-${call.number}`)) continue;
-
-      parsedCalls.push(call);
-      foundTypes.add(call.type);
-    }
-
-    const youtubeUrls = await Promise.all(
-      parsedCalls.map(call => fetchYouTubeFromIssue(call.issueNumber))
-    );
-
-    return parsedCalls
-      .map((call, index): UpcomingCall => ({ ...call, youtubeUrl: youtubeUrls[index] }))
-      .sort((a, b) => a.date.localeCompare(b.date));
+    return await fetchUpcomingCallsFromGitHub();
   } catch (error) {
     console.error('Error fetching upcoming calls:', error);
     return [];
+  }
+}
+
+export async function fetchUpcomingCallsIfAvailable(): Promise<UpcomingCall[] | undefined> {
+  try {
+    return await fetchUpcomingCallsFromGitHub();
+  } catch (error) {
+    console.warn('Live upcoming calls refresh failed:', error);
+    return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- restore per-visit GitHub freshness for the protocol calendar by starting from the build snapshot and refreshing upcoming calls on mount
- keep the static snapshot as the fallback when the live GitHub request fails
- separate video availability from static watch-page availability so live-fetched calls do not link to routes that were not emitted at build time

## Root Cause

The Astro migration moved the calls index to the build-time upcoming-call snapshot to keep static routes and island links consistent. That removed the previous client-side GitHub refresh, so `/calls/` was only as fresh as the latest deploy.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
