### PR TITLE
ci: stagger and queue fetch jobs

### DIFF
--- a/.github/workflows/fetch-eips.yml
+++ b/.github/workflows/fetch-eips.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6,18 * * *' # twice daily at 06:00 and 18:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/fetch-test-counts.yml
+++ b/.github/workflows/fetch-test-counts.yml
@@ -2,8 +2,12 @@ name: Fetch Test Counts
 
 on:
   schedule:
-    - cron: '0 6 * * *' # once daily at 06:00 UTC
+    - cron: '10 6 * * *' # once daily at 06:10 UTC (staggered to avoid conflicts)
   workflow_dispatch:
+
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
 
 jobs:
   collect:

--- a/.github/workflows/generate-plan-artifacts.yml
+++ b/.github/workflows/generate-plan-artifacts.yml
@@ -15,6 +15,10 @@ on:
         type: string
         default: 'all'
 
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/scrape-devnet-specs.yml
+++ b/.github/workflows/scrape-devnet-specs.yml
@@ -2,9 +2,13 @@ name: Scrape Devnet Specs
 
 on:
   schedule:
-    # Run twice daily at 06:00 and 18:00 UTC
-    - cron: '0 6,18 * * *'
+    # Run twice daily, staggered to avoid conflicts with other sync workflows
+    - cron: '20 6,18 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
 
 jobs:
   scrape:

--- a/.github/workflows/sync-call-assets.yml
+++ b/.github/workflows/sync-call-assets.yml
@@ -6,6 +6,10 @@ on:
     types: [pm-assets-updated]
   workflow_dispatch:
 
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
bug: scheduled fetch actions are regularly failing at the commit phase; multiple fetch jobs are triggered at the same time. resolved by staggering the cron jobs and queueing them when they do overlap.