### PR TITLE
sync: set video/transcript offsets for ACDT 83 and RPC 28

### DIFF
--- a/public/artifacts/acdt/2026-06-15_083/config.json
+++ b/public/artifacts/acdt/2026-06-15_083/config.json
@@ -2,7 +2,7 @@
   "issue": 2116,
   "videoUrl": "https://www.youtube.com/watch?v=3OjZPPkrFq0",
   "sync": {
-    "transcriptStartTime": "00:05:25",
-    "videoStartTime": "00:00:55"
+    "transcriptStartTime": "00:07:17",
+    "videoStartTime": "00:02:47"
   }
 }

--- a/public/artifacts/rpc/2026-06-15_028/config.json
+++ b/public/artifacts/rpc/2026-06-15_028/config.json
@@ -2,7 +2,7 @@
   "issue": 2120,
   "videoUrl": "https://www.youtube.com/watch?v=c7ARopGl95s",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:03:39",
+    "videoStartTime": "00:03:39"
   }
 }


### PR DESCRIPTION
Sets video/transcript sync offsets for two newly synced calls.

## ACDT 83 (composed Zoom)
- `transcriptStartTime`: `00:05:25` → `00:07:17`
- `videoStartTime`: `00:00:55` → `00:02:47`

Anchored on the formal open ("Alright, I think we can get started" → "welcome to ACDT… issue number 83"), skipping the good-morning / waiting-for-attendees chatter. Preserves the PM-generated −4:30 video/transcript delta.

## RPC 28 (raw Zoom)
- `transcriptStartTime`: `00:00:00` → `00:03:39`
- `videoStartTime`: `00:00:00` → `00:03:39`

Anchored on Boma's welcome ("good afternoon everybody… Welcome to ROPC Core Standard 28"), skipping ~3.5 min of logistics and screen-share checks.

Both verified locally on the dev server.