### PR TITLE
sync: set video/transcript offsets for FOCIL 36

### DIFF
--- a/public/artifacts/focil/2026-06-16_036/config.json
+++ b/public/artifacts/focil/2026-06-16_036/config.json
@@ -2,7 +2,7 @@
   "issue": 2121,
   "videoUrl": "https://www.youtube.com/watch?v=zCM0jEBK2QA",
   "sync": {
-    "transcriptStartTime": "00:00:00",
-    "videoStartTime": "00:00:00"
+    "transcriptStartTime": "00:04:53",
+    "videoStartTime": "00:04:53"
   }
 }


### PR DESCRIPTION
## Summary
- set FOCIL 36 transcript and video start offsets to 00:04:53

## Verification
- npm run check