### PR TITLE
homepage: upgrade stage badge

### DIFF
--- a/src/components/EipsIndexPage.tsx
+++ b/src/components/EipsIndexPage.tsx
@@ -5,8 +5,8 @@ import { getProposalPrefix, getLaymanTitle, getInclusionStage, isHeadlinerInAnyF
 import { EipSearch } from './eip/EipSearch';
 import EipSearchModal from './eip/EipSearchModal';
 import { isSearchHotkey } from './search/searchShortcuts';
-import { Tooltip } from './ui';
-import { networkUpgrades, getUpgradePagePath } from '../data/upgrades';
+import { Tooltip, UpgradeStageBadge } from './ui';
+import { networkUpgrades } from '../data/upgrades';
 
 type SortField = 'number' | 'date' | 'status' | 'updated' | 'headliner';
 type SortDirection = 'asc' | 'desc';
@@ -261,7 +261,7 @@ const EipsIndexPage: React.FC = () => {
   }, [mobileFiltersOpen]);
 
   // Helper to get fork upgrade path (null for forks without a public page).
-  const getForkPath = (forkName: string): string | null => getUpgradePagePath(forkName);
+
 
   // Helper to get proper fork display name with accents
   const getForkDisplayName = (forkName: string): string => {
@@ -648,9 +648,6 @@ const EipsIndexPage: React.FC = () => {
                       </button>
                     </Tooltip>
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">
-                    Stage
-                  </th>
                   <th className="px-4 py-3 text-left">
                     <button
                       onClick={() => handleSort('updated')}
@@ -713,36 +710,20 @@ const EipsIndexPage: React.FC = () => {
                         )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
-                        <span className="px-2 py-1 text-xs font-medium rounded bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300">
+                        <span className="px-2 py-0.5 text-xs font-medium rounded ring-1 ring-slate-200 dark:ring-slate-500 bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300">
                           {eip.status}
                         </span>
                       </td>
                     <td className="px-4 py-3">
-                      <div className="flex flex-wrap gap-1">
+                      <div className="flex flex-wrap gap-1.5">
                         {eip.forkRelationships.length > 0 ? (
-                          // Display forks in reverse order (newest first)
-                          [...eip.forkRelationships].reverse().map((fork, idx) => {
-                            const forkPath = getForkPath(fork.forkName);
-                            const forkColor = getForkColor(fork.forkName);
-                            const displayName = getForkDisplayName(fork.forkName);
-                            return forkPath ? (
-                              <Link
-                                key={idx}
-                                to={forkPath}
-                                onClick={(e) => e.stopPropagation()}
-                                className={`px-1.5 py-0.5 text-xs font-medium rounded transition-colors ${forkColor}`}
-                              >
-                                {displayName}
-                              </Link>
-                            ) : (
-                              <span
-                                key={idx}
-                                className={`px-1.5 py-0.5 text-xs font-medium rounded ${forkColor}`}
-                              >
-                                {displayName}
-                              </span>
-                            );
-                          })
+                          [...eip.forkRelationships].reverse().map((fork) => (
+                            <UpgradeStageBadge
+                              key={fork.forkName}
+                              forkName={fork.forkName}
+                              stage={getInclusionStage(eip, fork.forkName)}
+                            />
+                          ))
                         ) : (
                           <span className="text-xs text-slate-400 dark:text-slate-400">—</span>
                         )}
@@ -773,26 +754,6 @@ const EipsIndexPage: React.FC = () => {
                         ) : wasHeadlinerCandidateInAnyFork(eip) ? (
                           <span className="text-slate-400 dark:text-slate-400" title="Proposed headliner">☆</span>
                         ) : null}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap">
-                        {eip.forkRelationships.length > 0 ? (
-                          (() => {
-                            // Get the most recent fork (last in array)
-                            const mostRecentFork = eip.forkRelationships[eip.forkRelationships.length - 1];
-                            const stage = getInclusionStage(eip, mostRecentFork.forkName);
-                            const label = getStageLabel(stage);
-                            const stageColor = getStageColor(stage);
-                            return label ? (
-                              <span className={`px-2 py-0.5 text-xs font-medium rounded ${stageColor}`}>
-                                {label}
-                              </span>
-                            ) : (
-                              <span className="text-xs text-slate-400 dark:text-slate-400">—</span>
-                            );
-                          })()
-                        ) : (
-                          <span className="text-xs text-slate-400 dark:text-slate-400">—</span>
-                        )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         {eip.forkRelationships.length > 0 ? (
@@ -832,18 +793,13 @@ const EipsIndexPage: React.FC = () => {
         {/* Card List - Mobile */}
         <div className="md:hidden space-y-3">
           {paginatedEips.map(eip => {
-            const mostRecentFork = eip.forkRelationships.length > 0
+            const layer = getEipLayer(eip);
+            const latestFork = eip.forkRelationships.length > 0
               ? eip.forkRelationships[eip.forkRelationships.length - 1]
               : null;
-            const currentStage = mostRecentFork ? getInclusionStage(eip, mostRecentFork.forkName) : null;
-            const stageLabel = currentStage ? getStageLabel(currentStage) : null;
-            const stageColor = currentStage ? getStageColor(currentStage) : '';
-            const mostRecentForkColor = mostRecentFork ? getForkColor(mostRecentFork.forkName) : '';
-            const mostRecentForkDisplay = mostRecentFork ? getForkDisplayName(mostRecentFork.forkName) : '';
-            const statusWithDate = mostRecentFork
-              ? [...mostRecentFork.statusHistory].reverse().find(status => status.date)
+            const statusWithDate = latestFork
+              ? [...latestFork.statusHistory].reverse().find(status => status.date)
               : null;
-            const layer = getEipLayer(eip);
 
             return (
               <Link
@@ -862,11 +818,10 @@ const EipsIndexPage: React.FC = () => {
                       <span className="ml-1.5 text-slate-400 dark:text-slate-400" title="Proposed headliner">☆</span>
                     )}
                   </span>
-                  {/* Layer, Fork and Stage grouped together side-by-side */}
-                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                  <div className="flex items-center gap-1.5 flex-wrap justify-end">
                     {layer && (
                       <span
-                        className={`px-2 py-1 text-xs font-medium rounded ${
+                        className={`px-2 py-0.5 text-xs font-medium rounded ${
                           layer === 'EL'
                             ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-600'
                             : 'bg-teal-100 text-teal-700 dark:bg-teal-900/20 dark:text-teal-300 border border-teal-200 dark:border-teal-600'
@@ -875,18 +830,13 @@ const EipsIndexPage: React.FC = () => {
                         {layer}
                       </span>
                     )}
-                    {mostRecentFork && (
-                      <>
-                        <span className={`px-2 py-1 text-xs font-medium rounded ${mostRecentForkColor}`}>
-                          {mostRecentForkDisplay}
-                        </span>
-                        {stageLabel && (
-                          <span className={`px-2 py-1 text-xs font-medium rounded ${stageColor}`}>
-                            {stageLabel}
-                          </span>
-                        )}
-                      </>
-                    )}
+                    {eip.forkRelationships.map((fork) => (
+                      <UpgradeStageBadge
+                        key={fork.forkName}
+                        forkName={fork.forkName}
+                        stage={getInclusionStage(eip, fork.forkName)}
+                      />
+                    ))}
                   </div>
                 </div>
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -6,6 +6,7 @@ import { eipsData, eipById } from '../data/eips';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { getProposalPrefix, getLaymanTitle, getInclusionStage } from '../utils/eip';
 import UpgradeCard from './ui/UpgradeCard';
+import { UpgradeStageBadge } from './ui';
 import { StructuredDecisionContent, DecisionTextWithEipLinks } from './call/KeyDecisionsSection';
 import { EIP, KeyDecision } from '../types/eip';
 
@@ -97,40 +98,6 @@ const HomePage = () => {
     trackLinkClick(linkType, url);
   };
 
-  // Helper to get proper fork display name with accents
-  const getForkDisplayName = (forkName: string): string => {
-    const displayMap: Record<string, string> = {
-      'Hegota': 'Hegotá'
-    };
-    return displayMap[forkName] || forkName;
-  };
-
-  // Fork color helper
-  const getForkColor = (forkName: string) => {
-    // Look up the fork in networkUpgrades to get its status
-    const upgrade = networkUpgrades.find(u => u.name.includes(forkName) || u.id === forkName.toLowerCase());
-
-    if (!upgrade) {
-      // Default gray for unknown forks - with border
-      return 'bg-slate-50/50 text-slate-600 dark:bg-slate-900/30 dark:text-slate-400 border border-slate-200 dark:border-slate-700';
-    }
-
-    // Color based on upgrade status - using borders and lighter backgrounds to differentiate from stages
-    switch (upgrade.status) {
-      case 'Live':
-        // Green for live forks - with border
-        return 'bg-emerald-50/50 text-emerald-600 dark:bg-emerald-950/30 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800';
-      case 'Upcoming':
-        // Blue for upcoming forks - with border
-        return 'bg-blue-50/50 text-blue-600 dark:bg-blue-950/30 dark:text-blue-400 border border-blue-200 dark:border-blue-800';
-      case 'Planning':
-        // Purple for planning forks - with border
-        return 'bg-purple-50/50 text-purple-600 dark:bg-purple-950/30 dark:text-purple-400 border border-purple-200 dark:border-purple-800';
-      default:
-        return 'bg-slate-50/50 text-slate-600 dark:bg-slate-900/30 dark:text-slate-400 border border-slate-200 dark:border-slate-700';
-    }
-  };
-
   // Colors for call type badges
   const callTypeBadgeColors: Record<CallType, string> = {
     acdc: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
@@ -199,24 +166,10 @@ const HomePage = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {featuredEips.map((eip) => {
-              // Get the most recent fork (last in array)
-              const mostRecentFork = eip.forkRelationships.length > 0
-                ? eip.forkRelationships[eip.forkRelationships.length - 1]
-                : null;
-              const inclusionStage = mostRecentFork ? getInclusionStage(eip, mostRecentFork.forkName) : null;
-
-              // Get stage label
-              const getStageLabel = (stage: string) => {
-                switch (stage) {
-                  case 'Considered for Inclusion': return 'Considered';
-                  case 'Proposed for Inclusion': return 'Proposed';
-                  case 'Scheduled for Inclusion': return 'Scheduled';
-                  case 'Declined for Inclusion': return 'Declined';
-                  case 'Included': return 'Included';
-                  case 'Withdrawn': return 'Withdrawn';
-                  default: return stage;
-                }
-              };
+              const upgradeBadges = eip.forkRelationships.map((rel) => ({
+                forkName: rel.forkName,
+                stage: getInclusionStage(eip, rel.forkName),
+              }));
 
               return (
                 <Link
@@ -229,16 +182,9 @@ const HomePage = () => {
                       <span className="text-sm font-mono font-medium text-purple-600 dark:text-purple-400">
                         {getProposalPrefix(eip)}-{eip.id}
                       </span>
-                      {inclusionStage && inclusionStage !== 'Unknown' && (
-                        <span className="px-2 py-0.5 text-xs font-medium rounded bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300">
-                          {getStageLabel(inclusionStage)}
-                        </span>
-                      )}
-                      {mostRecentFork && (
-                        <span className={`px-2 py-0.5 text-xs font-medium rounded ${getForkColor(mostRecentFork.forkName)}`}>
-                          {getForkDisplayName(mostRecentFork.forkName)}
-                        </span>
-                      )}
+                      {upgradeBadges.map(({ forkName, stage }) => (
+                        <UpgradeStageBadge key={forkName} forkName={forkName} stage={stage} />
+                      ))}
                     </div>
                     <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1 leading-snug">
                       {getLaymanTitle(eip)}

--- a/src/components/eip/EipDependents.tsx
+++ b/src/components/eip/EipDependents.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from '../navigation';
-import { EIP, InclusionStage } from '../../types/eip';
-import { getProposalPrefix, getLaymanTitle, getSpecificationUrl, isPendingEip, getInclusionStage, getStageAbbreviation } from '../../utils';
-import { getInclusionStageColor } from '../../utils/colors';
+import { EIP } from '../../types/eip';
+import { getProposalPrefix, getLaymanTitle, getSpecificationUrl, isPendingEip, getInclusionStage } from '../../utils';
+import { UpgradeStageBadge } from '../ui';
 
 interface EipDependentsProps {
   dependents: EIP[];
@@ -30,14 +30,7 @@ export const EipDependents: React.FC<EipDependentsProps> = ({ dependents }) => {
           const upgradeBadgeElements = upgradeBadges.length > 0 && (
             <div className="flex items-center gap-3 flex-wrap">
               {upgradeBadges.map(({ forkName, stage }) => (
-                <span key={forkName} className="inline-flex items-center text-xs font-medium rounded overflow-hidden">
-                    <span className="px-1.5 py-0.5 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300">
-                      {forkName}
-                    </span>
-                    <span className={`px-1.5 py-0.5 ${getInclusionStageColor(stage as InclusionStage)}`}>
-                      {getStageAbbreviation(stage)}
-                    </span>
-                  </span>
+                <UpgradeStageBadge key={forkName} forkName={forkName} stage={stage} />
               ))}
             </div>
           );

--- a/src/components/ui/UpgradeStageBadge.tsx
+++ b/src/components/ui/UpgradeStageBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { InclusionStage } from '../../types/eip';
+import { getStageAbbreviation } from '../../utils';
+import { getInclusionStageColor } from '../../utils/colors';
+
+interface UpgradeStageBadgeProps {
+  forkName: string;
+  stage: string;
+}
+
+export const UpgradeStageBadge: React.FC<UpgradeStageBadgeProps> = ({ forkName, stage }) => (
+  <span className="inline-flex items-center text-xs font-medium rounded overflow-hidden ring-1 ring-slate-200 dark:ring-slate-500">
+    <span className="px-2 py-0.5 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300">
+      {forkName}
+    </span>
+    <span className={`px-2 py-0.5 ${getInclusionStageColor(stage as InclusionStage)}`}>
+      {getStageAbbreviation(stage)}
+    </span>
+  </span>
+);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export * from './Tooltip';
 export * from './CopyLinkButton';
 export * from './StatusBadge';
+export * from './UpgradeStageBadge';
 export { default as AnnouncementBanner } from './AnnouncementBanner';

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -6,15 +6,15 @@ import { InclusionStage, KeyDecision } from '../types/eip';
 export const getInclusionStageColor = (stage: InclusionStage): string => {
   switch (stage) {
     case 'Proposed for Inclusion':
-      return 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300';
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300';
     case 'Considered for Inclusion':
-      return 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300';
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300';
     case 'Scheduled for Inclusion':
-      return 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300';
+      return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300';
     case 'Declined for Inclusion':
-      return 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300';
+      return 'bg-red-100 text-red-700 dark:bg-red-900/20 dark:text-red-300';
     case 'Included':
-      return 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300';
+      return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300';
     default:
       return 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300';
   }


### PR DESCRIPTION
polish the upgrade stage badges and add to homepage and eip index page, e.g., 

home page:
<img width="939" height="324" alt="Screenshot 2026-06-17 at 2 08 35 PM" src="https://github.com/user-attachments/assets/22042531-4999-4144-ab5c-10cafdd1c63f" />

eip index page:
<img width="1249" height="548" alt="Screenshot 2026-06-17 at 2 08 45 PM" src="https://github.com/user-attachments/assets/35023639-9646-4d00-a54c-4df8b922b82e" />

eip page, dependents tab:
<img width="925" height="508" alt="Screenshot 2026-06-17 at 2 09 18 PM" src="https://github.com/user-attachments/assets/6c439fbe-2bd5-4fca-b564-d3b299908be2" />
