### PR TITLE
Fix EIP markdown links and stable ordering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          # Upload dist directory (Vite build output)
+          # Upload dist directory (Astro build output)
           path: dist
       - name: Deploy to GitHub Pages
         id: deployment

--- a/scripts/snapshot-runtime-routes.mjs
+++ b/scripts/snapshot-runtime-routes.mjs
@@ -105,7 +105,7 @@ async function buildUpcomingCalls() {
   const youtubeUrls = await Promise.all(parsed.map((call) => fetchYouTubeUrl(call.issueNumber)));
   return parsed
     .map((call, index) => ({ ...call, youtubeUrl: youtubeUrls[index] }))
-    .sort((a, b) => a.date.localeCompare(b.date));
+    .sort((a, b) => a.date.localeCompare(b.date) || a.issueNumber - b.issueNumber);
 }
 
 // --- Snapshot helpers ----------------------------------------------------------

--- a/src/components/eip/EipPage.tsx
+++ b/src/components/eip/EipPage.tsx
@@ -24,6 +24,7 @@ import { EipDependents } from './EipDependents';
 import { EipFaq } from './EipFaq';
 import { useEipHistory } from '../../hooks/useEipHistory';
 import { isSearchHotkey } from '../search/searchShortcuts';
+import { resolveEipMarkdownLink } from '../../domain/eips/eipMarkdownLinks';
 import {
   eipCallTypes,
   callTypeNames,
@@ -159,7 +160,6 @@ const LazyEipMarkdown = lazy(() =>
     ([{ default: ReactMarkdown }, { default: remarkGfm }]) => ({
       default: ({ children: rawChildren, navigate }: { children: string; navigate: (path: string) => void }) => {
         const children = normalizeHeadings(rawChildren);
-        const eipLinkPattern = /(?:\.\/eip-|\.\.\/EIPS\/eip-|https?:\/\/eips\.ethereum\.org\/EIPS\/eip-)(\d+)(?:\.md)?/;
         const headings = extractHeadings(children);
         const slugMap = new Map<string, number>();
         return (
@@ -213,22 +213,24 @@ const LazyEipMarkdown = lazy(() =>
               remarkPlugins={[remarkGfm]}
               components={{
                 a: ({ href, children: linkChildren, ...rest }) => {
-                  if (href) {
-                    const match = href.match(eipLinkPattern);
-                    if (match) {
+                  const eipLink = href ? resolveEipMarkdownLink(href, eipById) : null;
+                  if (eipLink) {
+                    if (eipLink.kind === 'internal') {
                       return (
                         <a
                           {...rest}
-                          href={`/eips/${match[1]}`}
+                          href={eipLink.href}
                           onClick={(e) => {
                             e.preventDefault();
-                            navigate(`/eips/${match[1]}`);
+                            navigate(eipLink.href);
                           }}
                         >
                           {linkChildren}
                         </a>
                       );
                     }
+
+                    return <a href={eipLink.href} target="_blank" rel="noopener noreferrer" {...rest}>{linkChildren}</a>;
                   }
                   return <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>{linkChildren}</a>;
                 },

--- a/src/domain/calls/upcomingCalls.test.ts
+++ b/src/domain/calls/upcomingCalls.test.ts
@@ -210,6 +210,47 @@ describe('fetchUpcomingCallsIfAvailable', () => {
 
     await expect(fetchUpcomingCallsIfAvailable()).resolves.toBeUndefined();
   });
+
+  it('sorts same-date calls by issue number for deterministic snapshots', async () => {
+    const scheduledBody = (series: string) => `### Call Series
+
+${series}
+
+### UTC Date & Time
+
+[January 2, 2099, 15:00 UTC](https://savvytime.com/converter/utc/jan-2-2099/3pm)`;
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'https://api.github.com/repos/ethereum/pm/issues?state=open&per_page=20') {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              title: 'All Core Devs - Execution (ACDE) #999, January 2, 2099',
+              html_url: 'https://github.com/ethereum/pm/issues/101',
+              number: 101,
+              body: scheduledBody('All Core Devs - Execution'),
+            },
+            {
+              title: 'All Core Devs - Consensus (ACDC) #999, January 2, 2099',
+              html_url: 'https://github.com/ethereum/pm/issues/100',
+              number: 100,
+              body: scheduledBody('All Core Devs - Consensus'),
+            },
+          ],
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => [],
+      };
+    }));
+
+    const calls = await fetchUpcomingCallsIfAvailable();
+
+    expect(calls?.map((call) => call.issueNumber)).toEqual([100, 101]);
+  });
 });
 
 describe('parseUpcomingCallFromIssue', () => {

--- a/src/domain/calls/upcomingCalls.ts
+++ b/src/domain/calls/upcomingCalls.ts
@@ -123,7 +123,7 @@ const fetchUpcomingCallsFromGitHub = async (): Promise<UpcomingCall[]> => {
 
   return parsedCalls
     .map((call, index): UpcomingCall => ({ ...call, youtubeUrl: youtubeUrls[index] }))
-    .sort((a, b) => a.date.localeCompare(b.date));
+    .sort((a, b) => a.date.localeCompare(b.date) || a.issueNumber - b.issueNumber);
 };
 
 // Fetch upcoming ACD calls from GitHub issues. Shares the parsing rules with the

--- a/src/domain/eips/eipMarkdownLinks.test.ts
+++ b/src/domain/eips/eipMarkdownLinks.test.ts
@@ -24,15 +24,15 @@ describe('resolveEipMarkdownLink', () => {
     }
   });
 
-  it('links pending EIPs to the canonical spec URL because no emitted page exists', () => {
+  it('links tracked pending EIPs internally because Forkcast emits their pages', () => {
     const eipsById = new Map([
-      [8208, { pendingPullRequest: { number: 123, url: 'https://github.com/ethereum/EIPs/pull/123' } }],
+      [8208, { id: 8208, pendingPullRequest: { number: 123, url: 'https://github.com/ethereum/EIPs/pull/123' } }],
     ]);
 
     expect(resolveEipMarkdownLink('../EIPS/eip-8208.md', eipsById)).toEqual({
-      kind: 'external',
+      kind: 'internal',
       eipId: 8208,
-      href: 'https://eips.ethereum.org/EIPS/eip-8208',
+      href: '/eips/8208',
     });
   });
 

--- a/src/domain/eips/eipMarkdownLinks.test.ts
+++ b/src/domain/eips/eipMarkdownLinks.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEipMarkdownLink } from './eipMarkdownLinks';
+
+describe('resolveEipMarkdownLink', () => {
+  it('links tracked emitted EIPs internally', () => {
+    const eipsById = new Map([[7702, {}]]);
+
+    expect(resolveEipMarkdownLink('./eip-7702.md', eipsById)).toEqual({
+      kind: 'internal',
+      eipId: 7702,
+      href: '/eips/7702',
+    });
+  });
+
+  it('links untracked EIP references to the canonical spec URL', () => {
+    const eipsById = new Map([[7702, {}]]);
+
+    for (const href of ['./eip-4337.md', 'EIPS/eip-4337.md']) {
+      expect(resolveEipMarkdownLink(href, eipsById)).toEqual({
+        kind: 'external',
+        eipId: 4337,
+        href: 'https://eips.ethereum.org/EIPS/eip-4337',
+      });
+    }
+  });
+
+  it('links pending EIPs to the canonical spec URL because no emitted page exists', () => {
+    const eipsById = new Map([
+      [8208, { pendingPullRequest: { number: 123, url: 'https://github.com/ethereum/EIPs/pull/123' } }],
+    ]);
+
+    expect(resolveEipMarkdownLink('../EIPS/eip-8208.md', eipsById)).toEqual({
+      kind: 'external',
+      eipId: 8208,
+      href: 'https://eips.ethereum.org/EIPS/eip-8208',
+    });
+  });
+
+  it('ignores non-EIP links', () => {
+    expect(resolveEipMarkdownLink('https://example.com', new Map())).toBeNull();
+  });
+});

--- a/src/domain/eips/eipMarkdownLinks.ts
+++ b/src/domain/eips/eipMarkdownLinks.ts
@@ -1,5 +1,3 @@
-import type { EIP } from '../../types/eip';
-
 const eipReferencePattern =
   /(?:\.\/eip-|(?:\.\.\/)?EIPS\/eip-|https?:\/\/eips\.ethereum\.org\/EIPS\/eip-)(\d+)(?:\.md)?/;
 
@@ -9,7 +7,7 @@ export type EipMarkdownLinkResolution =
 
 export function resolveEipMarkdownLink(
   href: string,
-  eipsById: ReadonlyMap<number, Pick<EIP, 'pendingPullRequest'>>
+  eipsById: ReadonlyMap<number, unknown>
 ): EipMarkdownLinkResolution | null {
   const match = href.match(eipReferencePattern);
   if (!match) return null;
@@ -17,7 +15,7 @@ export function resolveEipMarkdownLink(
   const eipId = Number(match[1]);
   const target = eipsById.get(eipId);
 
-  if (target && !target.pendingPullRequest) {
+  if (target) {
     return { kind: 'internal', eipId, href: `/eips/${eipId}` };
   }
 

--- a/src/domain/eips/eipMarkdownLinks.ts
+++ b/src/domain/eips/eipMarkdownLinks.ts
@@ -1,0 +1,29 @@
+import type { EIP } from '../../types/eip';
+
+const eipReferencePattern =
+  /(?:\.\/eip-|(?:\.\.\/)?EIPS\/eip-|https?:\/\/eips\.ethereum\.org\/EIPS\/eip-)(\d+)(?:\.md)?/;
+
+export type EipMarkdownLinkResolution =
+  | { kind: 'internal'; eipId: number; href: string }
+  | { kind: 'external'; eipId: number; href: string };
+
+export function resolveEipMarkdownLink(
+  href: string,
+  eipsById: ReadonlyMap<number, Pick<EIP, 'pendingPullRequest'>>
+): EipMarkdownLinkResolution | null {
+  const match = href.match(eipReferencePattern);
+  if (!match) return null;
+
+  const eipId = Number(match[1]);
+  const target = eipsById.get(eipId);
+
+  if (target && !target.pendingPullRequest) {
+    return { kind: 'internal', eipId, href: `/eips/${eipId}` };
+  }
+
+  return {
+    kind: 'external',
+    eipId,
+    href: `https://eips.ethereum.org/EIPS/eip-${eipId}`,
+  };
+}

--- a/src/domain/eips/stageChanges.test.ts
+++ b/src/domain/eips/stageChanges.test.ts
@@ -81,6 +81,21 @@ describe('getRecentStageChanges', () => {
     expect(getRecentStageChanges([older, newer], 1).map((c) => c.id)).toEqual([2]);
   });
 
+  it('orders same-date changes by EIP id for deterministic output', () => {
+    const higherId = makeEip({
+      id: 2,
+      title: 'EIP-2: Higher',
+      forkRelationships: [fork('Glamsterdam', [entry('Considered', '2025-03-15')])],
+    });
+    const lowerId = makeEip({
+      id: 1,
+      title: 'EIP-1: Lower',
+      forkRelationships: [fork('Glamsterdam', [entry('Considered', '2025-03-15')])],
+    });
+
+    expect(getRecentStageChanges([higherId, lowerId]).map((c) => c.id)).toEqual([1, 2]);
+  });
+
   it('skips EIPs whose status history has no dated entry', () => {
     const eip = makeEip({
       id: 9,

--- a/src/domain/eips/stageChanges.ts
+++ b/src/domain/eips/stageChanges.ts
@@ -66,7 +66,7 @@ export function getRecentStageChanges(eips: EIP[], count = 10): EipStageChange[]
   }
 
   return eipsWithDates
-    .sort((a, b) => b.lastUpdate.getTime() - a.lastUpdate.getTime())
+    .sort((a, b) => b.lastUpdate.getTime() - a.lastUpdate.getTime() || a.eip.id - b.eip.id)
     .slice(0, count)
     .map(({ eip, lastUpdate, forkName, currentStage }) => ({
       id: eip.id,

--- a/src/pages/calls/[type].astro
+++ b/src/pages/calls/[type].astro
@@ -12,7 +12,7 @@ import { upcomingCalls } from '../../domain/calls/upcomingCalls';
 export function getStaticPaths() {
   const types = new Set<string>();
   for (const call of protocolCalls) if (!isOneOffCall(call.type)) types.add(call.type);
-  for (const call of upcomingCalls) types.add(call.type);
+  for (const call of upcomingCalls) if (!isOneOffCall(call.type)) types.add(call.type);
 
   return [...types].map((type) => {
     const name = getCallTypeName(type);


### PR DESCRIPTION
## Summary

This fixes a set of Astro migration follow-ups around emitted routes and deterministic generated data.

- Route EIP markdown references internally only when Forkcast actually emits the target EIP page.
- Send untracked or pending EIP references to the canonical eips.ethereum.org spec URL instead of generating local links that 404.
- Add deterministic tie-breakers for same-date upcoming calls and same-date EIP stage changes.
- Keep one-off call types out of call-type route generation for upcoming calls too.
- Update the deploy artifact comment to describe Astro output.

## Root Cause

The EIP markdown renderer treated every recognizable EIP reference as an emitted Forkcast route. Some spec bodies reference EIPs that Forkcast does not track or cannot emit yet, so those links became local 404s after the Astro migration made route misses visible.

The generated-data ordering also relied on upstream order for equal dates, which could produce churn when upstream APIs returned same-date records in a different order.

## Validation

- `npm test`
- `npm run lint`
- `npm run check`