### PR TITLE
Restore path-only Matomo tracking

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,13 +69,15 @@ const ogImage = image
     <meta name="twitter:image:alt" content={title} />
     <meta name="twitter:creator" content="@wolovim" />
 
-    <!-- Matomo: fires the initial pageview from the Astro shell. React handles
-         only interaction events from here on. -->
+    <!-- Matomo page views use canonical Astro route identity. Query strings
+         mostly represent UI state (tabs, filters, search, playback); track
+         query-level behavior as explicit events instead of fragmenting page URLs. -->
     <script is:inline>
       if (!['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'].includes(window.location.hostname)) {
         var _paq = (window._paq = window._paq || []);
         _paq.push(['setExcludedQueryParams', ['code', 'gist']]);
         _paq.push(['enableLinkTracking']);
+        _paq.push(['setCustomUrl', window.location.pathname]);
         _paq.push(['trackPageView']);
         (function () {
           var u = 'https://ethereumfoundation.matomo.cloud/';


### PR DESCRIPTION
## What changed

- Restores Matomo page URL tracking to pathname-only by setting `setCustomUrl(location.pathname)` before page views.
- Documents the metrics tradeoff directly in the analytics block.
- Guards repeated same-path page view tracking so query/hash-only UI state changes do not fragment route metrics.
- Registers an `astro:page-load` handler so page views continue to be recorded if Astro client-side navigation is enabled.

## Why

The old React analytics path reported page views by pathname. After the Astro migration, direct Matomo tracking would default to the full browser URL, causing query-backed UI state like tabs, filters, search, and playback links to appear as separate tracked URLs.

This chooses metrics continuity over query-level granularity.

Closes #342.

## Validation

- `npm run lint`
- `npm run check`