### PR TITLE
Fail route snapshot on YouTube comment fetch errors

### DIFF
--- a/scripts/snapshot-runtime-routes.mjs
+++ b/scripts/snapshot-runtime-routes.mjs
@@ -60,18 +60,18 @@ const bucketDate = (call) => {
 
 const todayUtc = () => new Date().toISOString().slice(0, 10);
 
-async function fetchYouTubeUrl(issueNumber) {
-  try {
-    const res = await fetch(
-      `https://api.github.com/repos/ethereum/pm/issues/${issueNumber}/comments`,
-      { headers: githubHeaders() },
-    );
-    if (!res.ok) return undefined;
-    return extractYouTubeUrl(await res.json());
-  } catch {
-    // Ignore — the watch page still works without an embedded video URL.
-    return undefined;
-  }
+export async function fetchYouTubeUrl(issueNumber) {
+  const res = await fetch(
+    `https://api.github.com/repos/ethereum/pm/issues/${issueNumber}/comments`,
+    { headers: githubHeaders() },
+  );
+
+  if (!res.ok) throw new Error(`GitHub issue comments fetch failed for #${issueNumber}: ${res.status}`);
+
+  // A successful comments fetch with no YouTube Live link means "no video yet".
+  // A failed comments fetch is snapshot-critical because treating it the same
+  // way could silently remove an already-emitted upcoming-call watch route.
+  return extractYouTubeUrl(await res.json());
 }
 
 async function buildUpcomingCalls() {
@@ -158,31 +158,33 @@ async function buildNetworksSnapshot() {
   return canonicalizeNetworksSnapshot(await res.json());
 }
 
-fs.mkdirSync(GENERATED_DIR, { recursive: true });
-console.log('Refreshing route snapshots...');
-try {
-  // Fetch + build both snapshots before writing either, so a partial failure leaves
-  // the committed snapshots untouched: the builds run concurrently and a rejection
-  // here propagates before any file is written.
-  const [upcomingCalls, networksSnapshot] = await Promise.all([
-    buildUpcomingCalls(),
-    buildNetworksSnapshot(),
-  ]);
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  fs.mkdirSync(GENERATED_DIR, { recursive: true });
+  console.log('Refreshing route snapshots...');
+  try {
+    // Fetch + build both snapshots before writing either, so a partial failure leaves
+    // the committed snapshots untouched: the builds run concurrently and a rejection
+    // here propagates before any file is written.
+    const [upcomingCalls, networksSnapshot] = await Promise.all([
+      buildUpcomingCalls(),
+      buildNetworksSnapshot(),
+    ]);
 
-  writeJson(UPCOMING_CALLS_FILE, upcomingCalls);
-  console.log(`  ✓ upcoming-calls.json (${upcomingCalls.length} calls)`);
+    writeJson(UPCOMING_CALLS_FILE, upcomingCalls);
+    console.log(`  ✓ upcoming-calls.json (${upcomingCalls.length} calls)`);
 
-  const activeCount = Object.values(networksSnapshot.networks).filter(
-    (n) => n?.status === 'active',
-  ).length;
-  writeJson(NETWORKS_FILE, networksSnapshot);
-  console.log(
-    `  ✓ devnet-networks.json (${Object.keys(networksSnapshot.networks).length} networks, ${activeCount} active)`,
-  );
-} catch (error) {
-  // Nothing is written until both fetches succeed, so the committed snapshots are
-  // left intact. Exit non-zero and re-run when the upstream is reachable.
-  console.error(`✖ snapshot refresh failed: ${error.message}`);
-  process.exit(1);
+    const activeCount = Object.values(networksSnapshot.networks).filter(
+      (n) => n?.status === 'active',
+    ).length;
+    writeJson(NETWORKS_FILE, networksSnapshot);
+    console.log(
+      `  ✓ devnet-networks.json (${Object.keys(networksSnapshot.networks).length} networks, ${activeCount} active)`,
+    );
+  } catch (error) {
+    // Nothing is written until both fetches succeed, so the committed snapshots are
+    // left intact. Exit non-zero and re-run when the upstream is reachable.
+    console.error(`✖ snapshot refresh failed: ${error.message}`);
+    process.exit(1);
+  }
+  console.log('✨ Snapshots ready.');
 }
-console.log('✨ Snapshots ready.');

--- a/scripts/snapshot-runtime-routes.mjs
+++ b/scripts/snapshot-runtime-routes.mjs
@@ -158,9 +158,10 @@ async function buildNetworksSnapshot() {
   return canonicalizeNetworksSnapshot(await res.json());
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+async function main() {
   fs.mkdirSync(GENERATED_DIR, { recursive: true });
   console.log('Refreshing route snapshots...');
+
   try {
     // Fetch + build both snapshots before writing either, so a partial failure leaves
     // the committed snapshots untouched: the builds run concurrently and a rejection
@@ -186,5 +187,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.error(`✖ snapshot refresh failed: ${error.message}`);
     process.exit(1);
   }
+
   console.log('✨ Snapshots ready.');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/scripts/snapshot-runtime-routes.test.mjs
+++ b/scripts/snapshot-runtime-routes.test.mjs
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchYouTubeUrl } from './snapshot-runtime-routes.mjs';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchYouTubeUrl', () => {
+  it('returns the YouTube URL from successfully fetched issue comments', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { body: '✅ **YouTube Live**: [Watch Live](https://www.youtube.com/watch?v=abc123)' },
+      ],
+    }));
+
+    await expect(fetchYouTubeUrl(1234)).resolves.toBe('https://www.youtube.com/watch?v=abc123');
+  });
+
+  it('returns undefined when comments are fetched and no YouTube URL exists yet', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ body: 'Agenda only.' }],
+    }));
+
+    await expect(fetchYouTubeUrl(1234)).resolves.toBeUndefined();
+  });
+
+  it('rejects failed comment fetches so transient failures cannot remove watch routes', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    }));
+
+    await expect(fetchYouTubeUrl(1234)).rejects.toThrow(
+      'GitHub issue comments fetch failed for #1234: 503',
+    );
+  });
+
+  it('rejects network errors so snapshot refreshes keep the previous committed routes', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('socket hang up')));
+
+    await expect(fetchYouTubeUrl(1234)).rejects.toThrow('socket hang up');
+  });
+});


### PR DESCRIPTION
## Summary

- Treat failed GitHub issue comment fetches as route snapshot refresh failures.
- Keep successful comment fetches with no YouTube Live link as the only `undefined`/no-video case.
- Add focused tests for URL extraction, no-video comments, non-2xx responses, and network errors.

## Why

Upcoming watch pages are emitted from the build-time snapshot. A transient comments API failure could previously look like "no video yet" and silently remove an emitted watch route from the refreshed snapshot.

Closes #341.

## Validation

- `npx vitest run scripts/snapshot-runtime-routes.test.mjs`
- `npm run lint`
- `npm test`