### PR TITLE
Add ACDT 84 breakout assets

### DIFF
--- a/public/artifacts/acdt-breakouts/2026-06-22_084/cl/chat.txt
+++ b/public/artifacts/acdt-breakouts/2026-06-22_084/cl/chat.txt
@@ -1,0 +1,95 @@
+10:29:31	 From Justin Traglia : https://github.com/ethereum/beacon-APIs/pull/580 
+https://github.com/ethereum/beacon-APIs/pull/608
+10:30:42	 From Barnabas : would be good to merge in 8282 too very soon
+10:30:47	 From Bharath : Reacted to "would be good to mer..." with 👍
+10:33:25	 From Barnabas : Maybe I’m missing something but why do we care which version someone is using?
+10:35:04	 From Mikhail Kalinin : Could we rely on the self-build for 2 epochs after the fork before the first bunch of builders is finalized?
+10:35:50	 From Nico Flaig : Replying to "would be good to mer..."
+
+you want that or beacon api stuff merged? hoping cayman can do that, but we need to clean this up a lot
+10:36:18	 From Nico Flaig : Replying to "would be good to mer..."
+
+we should also discuss the contracts futher somewhere, I saw Felix commented on the asm pr
+10:36:25	 From Barnabas : Replying to "would be good to mer..."
+
+why is it an or or ? 
+ we should get both in
+10:36:41	 From Eitan Seri-Levi : Replying to "Could we rely on the self-build for 2 epochs after the fork before the first bunch of builders is finalized?"
+
+It breaks dapps that rely on private order flow (e.g. cow swap)
+10:36:48	 From Barnabas : Reacted to "It breaks dapps that rely on private order flow (e.g. cow swap)" with 💯
+10:36:50	 From Mikhail Kalinin : Reacted to "It breaks dapps that rely on private order flow (e.g. cow swap)" with 👍
+10:36:57	 From Barnabas : Replying to "Could we rely on the..."
+
+for over 20 mins
+10:36:59	 From Dustin : why would they be needing the bids to be active before the fork?
+10:37:05	 From Barnabas : Replying to "Could we rely on the..."
+
+thats quite critical
+10:37:10	 From Mikhail Kalinin : Replying to "Could we rely on the..."
+
+agree
+10:37:16	 From Dustin : the builders maybe, but the bids?
+10:38:48	 From Eitan Seri-Levi : I agree with Potuz
+10:42:47	 From Nico Flaig : before? you mean fork slot -1?
+10:42:58	 From Mikhail Kalinin : Why would builder with any creds version be prohibited from propagating a bid?
+10:43:24	 From Barnabas : how are you gonna enable the whitelist if you don’t have a fork?
+10:43:26	 From Justin Traglia : Replying to "Why would builder wi..."
+
+They might not be a “payload builder"
+10:43:46	 From Justin Traglia : Replying to "Why would builder wi..."
+
+The could be responsible for something else, eg proofs.
+10:44:01	 From NC : Replying to "Why would builder with any creds version be prohibited from propagating a bid?"
+
+I think one of the arguments is that the protocol has implied preferred builder version, and forwarding bids from builders that is not that preferred version is garbage
+10:44:54	 From Dustin : Replying to "Why would builder ..."
+
+Yeah in general the protocol tries to distinguish garbage from nongarbage
+10:45:04	 From Dustin : Replying to "Why would builder ..."
+
+and this doesn't seem possible with Potuz's proposal
+10:45:50	 From Mikhail Kalinin : Reacted to "The could be responsible for something else, eg proofs." with 👍
+10:45:56	 From Dustin : those bids can't be for 10 slots in advance today, no matter their version
+10:46:04	 From Dustin : it's not a question of builder version
+10:46:55	 From Barnabas : it also opens up a new kinda attack surface no? 
+
+We would need to start testing 0x01 type builders then too
+10:47:13	 From Eitan Seri-Levi : This will either provide zero benefit or some benefit by the h fork. But wouldn’t cause any issues.
+10:47:28	 From Potuz : Replying to "This will either pro..."
+
+Yes, this is exactly the whole point
+10:47:39	 From Potuz : Replying to "This will either pro..."
+
+I expect this to never be used, but it is just crazy not to enable it
+10:48:13	 From Dustin : Unused flexiblity, generally speaking, is a cost, testing, attack surface, etc
+10:48:51	 From terence : Same for prysm
+10:48:54	 From terence : 1 day should be enough
+10:49:00	 From Barnabas : Reacted to "1 day should be enough" with 👍
+10:50:18	 From Mikhail Kalinin : have to jump off, thx everyone
+10:50:31	 From Justin Traglia : Replying to "have to jump off, th..."
+
+See ya!
+10:50:49	 From NC : Replying to "Unused flexiblity, generally speaking, is a cost, testing, attack surface, etc"
+
+So minor cost in exchange for no or some benefit
+10:52:50	 From Eitan Seri-Levi : Will try to get to it this week
+10:52:57	 From Bharath : Reacted to "Will try to get to i..." with 👍
+10:53:37	 From Barnabas : kill it
+10:53:49	 From Justin Traglia : Reacted to "kill it" with 💀
+10:54:13	 From Barnabas : can we aim to have devnet 7 as a required devnet with builder api support? - with multiplexing
+10:55:16	 From Barnabas : coming soon
+10:55:48	 From Bharath : Reacted to "coming soon" with 🎉
+10:56:02	 From Barnabas : full ssz pipeline from el to cl to vc to builder workflow lfg
+10:56:35	 From Eitan Seri-Levi : Replying to "full ssz pipeline from el to cl to vc to builder workflow lfg"
+
+EL stable containers wen?
+10:57:15	 From Barnabas : Replying to "full ssz pipeline fr..."
+
+CL stable containers wen?
+10:57:37	 From Eitan Seri-Levi : Reacted to "CL stable containers wen?" with 🥹
+10:58:19	 From Nico Flaig : yes we are
+10:58:26	 From Eitan Seri-Levi : yes we are
+10:58:37	 From terence : lol
+10:58:53	 From Barnabas : smells like prysm 😂
+10:59:01	 From Justin Traglia : Reacted to "smells like prysm 😂" with 😄

--- a/public/artifacts/acdt-breakouts/2026-06-22_084/el/chat.txt
+++ b/public/artifacts/acdt-breakouts/2026-06-22_084/el/chat.txt
@@ -1,0 +1,21 @@
+10:18:24	 From Dragan Rakita : rip
+10:18:29	 From Iván | ethrex : Reacted to "rip" with ☝️
+10:18:29	 From Toni Wahrstätter : let it retire
+10:18:58	 From Toni Wahrstätter : https://discord.com/channels/595666850260713488/1517173399695261868
+10:19:05	 From Toni Wahrstätter : dragans original message
+10:24:56	 From Luis Pinto | Besu : Yeah I feel both would be equal in terms of consensus
+10:26:11	 From Dragan Rakita : Reacted to "Yeah I feel both wou..." with 👍
+10:27:49	 From Karim T. (matkt) : We don’t decided to keep the current implementation on discord ?
+10:28:10	 From Maria Silva : https://github.com/ethereum/EIPs/pull/11778
+10:28:11	 From Mario Vega : Replying to "We don’t decided to ..."
+
+That’s another PR I think
+10:28:17	 From Karim T. (matkt) : Replying to "We don’t decided to ..."
+
+Ah ok
+10:30:05	 From Dragan Rakita : Pass tests, run devnet, and ship 🚢
+10:30:17	 From Iván | ethrex : Reacted to "Pass tests, run devn..." with 🚢
+10:30:19	 From Stefan Starflinger : Reacted to "Pass tests, run devnet, and ship 🚢" with 🚢
+10:30:19	 From Maria Silva : Reacted to "Pass tests, run devn..." with 🚢
+10:30:47	 From marc | wolovim : Reacted to "Pass tests, run devn..." with 🚢
+10:30:49	 From danceratopz : https://github.com/ethereum/hive/pull/1550/changes#diff-a9c610dfadbc01fe9fb6098829d95cac563c1c956df4cf16a6e2298a80bb68fc

--- a/public/artifacts/acdt/2026-06-22_084/config.json
+++ b/public/artifacts/acdt/2026-06-22_084/config.json
@@ -2,7 +2,7 @@
   "issue": 2126,
   "videoUrl": "https://www.youtube.com/watch?v=AFJAFr6ibM4",
   "sync": {
-    "transcriptStartTime": "00:09:03",
-    "videoStartTime": "00:00:54"
+    "transcriptStartTime": "00:10:28",
+    "videoStartTime": "00:02:19"
   }
 }

--- a/public/artifacts/acdt/2026-06-22_084/key_decisions.json
+++ b/public/artifacts/acdt/2026-06-22_084/key_decisions.json
@@ -2,13 +2,13 @@
   "meeting": "ACDT #84 - June 22, 2026",
   "key_decisions": [
     {
-      "original_text": "No decision yet on EIP-7688 for devnet-7; defer to ACDC after observing devnet-6 stability",
+      "original_text": "No ACDT decision on EIP-7688 for devnet-7; revisit at ACDC after seeing devnet-6 stability and CL-breakout feedback",
       "timestamp": "00:20:12",
       "type": "other",
       "eips": [
         7688
       ],
-      "context": "defer to ACDC after observing devnet-6 stability"
+      "context": "revisit at ACDC after seeing devnet-6 stability and CL-breakout feedback"
     }
   ]
 }

--- a/public/artifacts/acdt/2026-06-22_084/tldr.json
+++ b/public/artifacts/acdt/2026-06-22_084/tldr.json
@@ -8,10 +8,10 @@
       },
       {
         "timestamp": "00:11:13",
-        "highlight": "devnet-6 targeting launch in 1-2 days; requires at least 3 ELs (ethrex confirmed; Nimbus/Lighthouse branches also now available)"
+        "highlight": "devnet-6 targeting launch in 1-2 days; ethrex is the only confirmed EL branch, with Lodestar/Teku plus likely Nimbus/Lighthouse on CL; launch needs at least two more ELs"
       },
       {
-        "timestamp": "00:13:20",
+        "timestamp": "00:16:59",
         "highlight": "glamsterdam-devnet@v6.0.0 EL test release published; another release expected Tuesday with EIP-8037/8038 coverage"
       },
       {
@@ -30,7 +30,7 @@
       },
       {
         "timestamp": "00:17:47",
-        "highlight": "Prysm builder API testing urged at devnet level before any 'final devnet' designation; Besu echoed need for unhappy-path testing"
+        "highlight": "Builder API testing urged at devnet level before any 'final devnet' designation; Besu echoed need for unhappy-path testing"
       },
       {
         "timestamp": "00:21:01",
@@ -55,14 +55,14 @@
   "action_items": [
     {
       "timestamp": "00:20:12",
-      "action": "Discuss EIP-7688 inclusion in devnet-7 and builder API scope at ACDC Thursday",
-      "owner": "All CL teams"
+      "action": "Revisit EIP-7688 inclusion in devnet-7 and builder API testing scope at ACDC Thursday",
+      "owner": "Client teams / ACDC participants"
     }
   ],
   "decisions": [
     {
       "timestamp": "00:20:12",
-      "decision": "No decision yet on EIP-7688 for devnet-7; defer to ACDC after observing devnet-6 stability"
+      "decision": "No ACDT decision on EIP-7688 for devnet-7; revisit at ACDC after seeing devnet-6 stability and CL-breakout feedback"
     }
   ],
   "targets": [

--- a/src/data/breakouts.ts
+++ b/src/data/breakouts.ts
@@ -29,4 +29,6 @@ export const breakouts: Breakout[] = [
   { parentPath: 'acdt/082', kind: 'cl',   artifactDir: 'acdt-breakouts/2026-06-08_082/cl',   videoUrl: 'https://youtu.be/WYVjX_QuIQo' },
   { parentPath: 'acdt/083', kind: 'el',   artifactDir: 'acdt-breakouts/2026-06-15_083/el',   videoUrl: 'https://youtu.be/3k5QNb2hzKM' },
   { parentPath: 'acdt/083', kind: 'cl',   artifactDir: 'acdt-breakouts/2026-06-15_083/cl',   videoUrl: 'https://youtu.be/dvYGLINyn-M' },
+  { parentPath: 'acdt/084', kind: 'el',   artifactDir: 'acdt-breakouts/2026-06-22_084/el',   videoUrl: 'https://youtu.be/ahPaqalqYW8' },
+  { parentPath: 'acdt/084', kind: 'cl',   artifactDir: 'acdt-breakouts/2026-06-22_084/cl',   videoUrl: 'https://youtu.be/2EEysqQIkME' },
 ];


### PR DESCRIPTION
## Summary

- add EL and CL breakout chat artifacts for ACDT 84
- wire the ACDT 84 breakout tabs to their YouTube recordings
- adjust the main ACDT 84 sync offset to start at the formal opening
- tighten the generated TLDR and key-decision summaries for accuracy

## Validation

- npm run check
- npm test -- src/domain/chat/zoomChat.test.ts
- local call page returned 200 OK at /calls/acdt/084