### PR TITLE
data: mark EIP-8080 declined for Glamsterdam (ACDC #181)

### DIFF
--- a/src/data/eips/8080.json
+++ b/src/data/eips/8080.json
@@ -18,6 +18,11 @@
           "status": "Considered",
           "call": "acdc/171",
           "date": "2025-12-11"
+        },
+        {
+          "status": "Declined",
+          "call": "acdc/181",
+          "date": "2026-06-25"
         }
       ],
       "champions": [


### PR DESCRIPTION
EIP-8080 (Let exits use the consolidation queue) is currently listed as `Considered` for Glamsterdam, but it was moved to DFI (Declined) on **All Core Devs – Consensus #181 (2026-06-25)**.

> "the next EIP to discuss is EIP 8080. We had signaled intent to DFI this EIP... then we will move EIP 8080 to DFI." — [ACDC #181 @ 30:59](https://www.youtube.com/watch?v=D_uiQpt1jog&t=1854s)
