### PR TITLE
data: backfill EL/CL layer on 16 shipped EIPs

### DIFF
--- a/src/data/eips/2537.json
+++ b/src/data/eips/2537.json
@@ -9,6 +9,7 @@
   "createdDate": "2020-02-21",
   "discussionLink": "https://ethereum-magicians.org/t/eip2537-bls12-precompile-discussion-thread/4187",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/2935.json
+++ b/src/data/eips/2935.json
@@ -9,6 +9,7 @@
   "createdDate": "2020-09-03",
   "discussionLink": "https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565",
   "reviewer": "staff",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7549.json
+++ b/src/data/eips/7549.json
@@ -9,6 +9,7 @@
   "createdDate": "2023-11-01",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7549-move-committee-index-outside-attestation/16390",
   "reviewer": "bot",
+  "layer": "CL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7623.json
+++ b/src/data/eips/7623.json
@@ -9,6 +9,7 @@
   "createdDate": "2024-02-13",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7623-increase-calldata-cost/18647",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7642.json
+++ b/src/data/eips/7642.json
@@ -9,6 +9,7 @@
   "createdDate": "2024-02-29",
   "discussionLink": "https://ethereum-magicians.org/t/eth-70-drop-pre-merge-fields-from-eth-protocol/19005",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7702.json
+++ b/src/data/eips/7702.json
@@ -9,6 +9,7 @@
   "createdDate": "2024-05-07",
   "discussionLink": "https://ethereum-magicians.org/t/eip-set-eoa-account-code-for-one-transaction/19923",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7823.json
+++ b/src/data/eips/7823.json
@@ -9,6 +9,7 @@
   "createdDate": "2024-11-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7823-set-upper-bounds-for-modexp/21798",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7825.json
+++ b/src/data/eips/7825.json
@@ -9,6 +9,7 @@
   "createdDate": "2024-11-23",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7825-transaction-gas-limit-cap/21848",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7840.json
+++ b/src/data/eips/7840.json
@@ -8,6 +8,7 @@
   "createdDate": "2024-12-12",
   "discussionLink": "https://ethereum-magicians.org/t/add-blob-schedule-to-execution-client-configuration-files/22182",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",

--- a/src/data/eips/7883.json
+++ b/src/data/eips/7883.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-02-11",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7883-modexp-gas-cost-increase/22841",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7917.json
+++ b/src/data/eips/7917.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-03-24",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7917-deterministic-proposer-lookahead/23259",
   "reviewer": "bot",
+  "layer": "CL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7918.json
+++ b/src/data/eips/7918.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-03-25",
   "discussionLink": "https://ethereum-magicians.org/t/eip-blob-base-fee-bounded-by-price-of-blob-carrying-transaction/23271",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7934.json
+++ b/src/data/eips/7934.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-04-16",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7934-add-bytesize-limit-to-blocks/23589",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7935.json
+++ b/src/data/eips/7935.json
@@ -8,6 +8,7 @@
   "createdDate": "2025-04-22",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-60m/23789",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7939.json
+++ b/src/data/eips/7939.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-04-28",
   "discussionLink": "https://ethereum-magicians.org/t/create-a-new-opcode-for-counting-leading-zeros-clz/10805",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Fusaka",

--- a/src/data/eips/7951.json
+++ b/src/data/eips/7951.json
@@ -9,6 +9,7 @@
   "createdDate": "2025-05-27",
   "discussionLink": "https://ethereum-magicians.org/t/eip-7951-precompile-for-secp256r1-curve-support/24360",
   "reviewer": "bot",
+  "layer": "EL",
   "forkRelationships": [
     {
       "forkName": "Pectra",


### PR DESCRIPTION
Adds the missing `layer` (EL/CL) field to 16 EIPs on shipped forks (Pectra/Fusaka). 

Each value is provable from the EIP's own specification:

| EIP | Fork | Layer | Rationale |
|-----|------|-------|-----------|
| 2537 | Pectra | EL | BLS12-381 precompile (EVM) |
| 2935 | Pectra | EL | Block hashes in system-contract storage |
| 7549 | Pectra | CL | Committee index in Attestation container |
| 7623 | Pectra | EL | Calldata gas cost |
| 7642 | Pectra | EL | eth/69 devp2p wire protocol |
| 7702 | Pectra | EL | New tx type, account code (EVM/state) |
| 7823 | Fusaka | EL | MODEXP precompile bounds |
| 7825 | Fusaka | EL | Per-transaction gas limit cap |
| 7840 | Pectra | EL | Blob schedule in EL config files |
| 7883 | Fusaka | EL | ModExp precompile gas |
| 7917 | Fusaka | CL | Proposer lookahead in beacon_state |
| 7918 | Fusaka | EL | Blob base fee (`calc_excess_blob_gas`) |
| 7934 | Fusaka | EL | RLP execution block size limit |
| 7935 | Fusaka | EL | EL client default gas limit |
| 7939 | Fusaka | EL | CLZ EVM opcode |
| 7951 | Pectra | EL | secp256r1 precompile |

Verified with `npm run audit-eips` (none of the 16 still flagged), `compile-eips`, and `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)