### PR TITLE
plataberg devnet page: add description, create buttons, fix EIP regex

### DIFF
--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -300,6 +300,7 @@ async function main() {
     const existing = JSON.parse(readFileSync(outPath, 'utf-8'));
     if (existing.canceled) spec.canceled = true;
     if (!spec.genesisTime && existing.pending) spec.pending = true;
+    if (existing.description) spec.description = existing.description;
     if (!spec.genesisTime && existing.genesisTime) {
       spec.genesisTime = existing.genesisTime;
     }

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -83,13 +83,14 @@ function parseEipTable(md) {
   // Find the EIP list table - look for rows with [EIP-NNNN](url)
   // Supports two layouts:
   //   A) | [EIP-NNNN](url) | title | status |        (shortcodes after title)
+  //   A') | [EIP-NNNN](url) [`spec@commit`](url) | title | status |  (extra link column after EIP link)
   //   B) | status_emoji | [EIP-NNNN](url) | title |  (emoji before EIP link)
   const eips = [];
   const rowRegex =
-    /\|([^[\n]*?)\[EIP-(\d+)\]\((https?:\/\/[^\s)]+)\)\s*\|\s*([^|\n]+)[^\S\n]*(?:\|[^\S\n]*([^|\n]*))?/g;
+    /\|([^[\n]*?)\[EIP-(\d+)\]\((https?:\/\/[^\s)]+)\)([^|\n]*)\s*\|\s*([^|\n]+)[^\S\n]*(?:\|[^\S\n]*([^|\n]*))?/g;
   let match;
   while ((match = rowRegex.exec(md)) !== null) {
-    const [, preEip, numberStr, url, title, postTitle] = match;
+    const [, preEip, numberStr, url, , title, postTitle] = match;
     const status = parseStatusCell(preEip) || (postTitle ? parseStatusCell(postTitle) : null);
 
     eips.push({

--- a/scripts/scrape-devnet-spec.mjs
+++ b/scripts/scrape-devnet-spec.mjs
@@ -299,6 +299,7 @@ async function main() {
   if (existsSync(outPath)) {
     const existing = JSON.parse(readFileSync(outPath, 'utf-8'));
     if (existing.canceled) spec.canceled = true;
+    if (!spec.genesisTime && existing.pending) spec.pending = true;
     if (!spec.genesisTime && existing.genesisTime) {
       spec.genesisTime = existing.genesisTime;
     }

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -335,7 +335,7 @@ function SpecHeaderButton({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      title={pending ? 'Goes live when the network launches' : undefined}
+      title={pending ? 'coming soon' : undefined}
       className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium rounded-md px-3 py-1.5 transition-colors ${
         pending
           ? 'border border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-purple-400 hover:text-purple-600 dark:hover:text-purple-300'
@@ -400,16 +400,20 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
                 </span>
               </>
             )}
-            <span>&middot;</span>
-            <span>
-              Scraped{' '}
-              {new Date(spec.scrapedAt).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })}
-            </span>
           </div>
+          {spec.description && (
+            <p className="mt-3 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+              {spec.description}
+            </p>
+          )}
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+            Scraped{' '}
+            {new Date(spec.scrapedAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
+          </p>
         </div>
 
         {/* Same-spec notice */}

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -330,22 +330,28 @@ function SpecHeaderButton({
   label: string;
   pending?: boolean;
 }) {
+  const className = `inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium rounded-md px-3 py-1.5 transition-colors ${
+    pending
+      ? 'border border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 cursor-not-allowed'
+      : 'bg-purple-600 hover:bg-purple-700 text-white'
+  }`;
+  const icon = (
+    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+    </svg>
+  );
+  if (pending) {
+    return (
+      <span title="coming soon" aria-disabled="true" className={className}>
+        {label}
+        {icon}
+      </span>
+    );
+  }
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      title={pending ? 'coming soon' : undefined}
-      className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium rounded-md px-3 py-1.5 transition-colors ${
-        pending
-          ? 'border border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-purple-400 hover:text-purple-600 dark:hover:text-purple-300'
-          : 'bg-purple-600 hover:bg-purple-700 text-white'
-      }`}
-    >
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
       {label}
-      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-      </svg>
+      {icon}
     </a>
   );
 }

--- a/src/components/DevnetSpecPage.tsx
+++ b/src/components/DevnetSpecPage.tsx
@@ -321,6 +321,35 @@ function DevnetPageLayout({
   );
 }
 
+function SpecHeaderButton({
+  href,
+  label,
+  pending,
+}: {
+  href: string;
+  label: string;
+  pending?: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={pending ? 'Goes live when the network launches' : undefined}
+      className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium rounded-md px-3 py-1.5 transition-colors ${
+        pending
+          ? 'border border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-purple-400 hover:text-purple-600 dark:hover:text-purple-300'
+          : 'bg-purple-600 hover:bg-purple-700 text-white'
+      }`}
+    >
+      {label}
+      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+      </svg>
+    </a>
+  );
+}
+
 function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec; networkEntry: NetworkEntry | null; metadata: { links: NetworkMetadataLink[] | null; description: string } | null }) {
   return (
     <DevnetPageLayout id={spec.id}>
@@ -329,7 +358,7 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
           <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
             {spec.title}
           </h1>
-          <div className="mt-2 flex items-center gap-3 text-sm text-slate-500 dark:text-slate-400">
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-slate-500 dark:text-slate-400">
             {networkEntry && (
               <>
                 <a
@@ -343,17 +372,24 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
                 <span>&middot;</span>
               </>
             )}
-            <a
-              href={spec.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-purple-600 dark:hover:text-purple-400 transition-colors underline decoration-1 underline-offset-2"
-            >
-              View Specification
-            </a>
-            <span>&middot;</span>
+            <SpecHeaderButton href={spec.sourceUrl} label="View Spec" />
+            {spec.pending && (
+              <>
+                <SpecHeaderButton
+                  href={`https://ethpandaops.io/networks/${spec.id}/`}
+                  label="Add Network"
+                  pending
+                />
+                <SpecHeaderButton
+                  href={`https://faucet.${spec.id}.ethpandaops.io/`}
+                  label="Faucet"
+                  pending
+                />
+              </>
+            )}
             {spec.genesisTime && (
               <>
+                <span>&middot;</span>
                 <span>
                   Launched{' '}
                   {new Date(spec.genesisTime * 1000).toLocaleDateString('en-US', {
@@ -362,9 +398,9 @@ function DevnetSpecContent({ spec, networkEntry, metadata }: { spec: DevnetSpec;
                     day: 'numeric',
                   })}
                 </span>
-                <span>&middot;</span>
               </>
             )}
+            <span>&middot;</span>
             <span>
               Scraped{' '}
               {new Date(spec.scrapedAt).toLocaleDateString('en-US', {

--- a/src/data/devnets/glamsterdam-devnet-8.json
+++ b/src/data/devnets/glamsterdam-devnet-8.json
@@ -2,15 +2,19 @@
   "id": "glamsterdam-devnet-8",
   "title": "Plataberget",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-8",
-  "scrapedAt": "2026-08-06T07:17:01.566Z",
-  "pending": true,
-  "description": "Plataberget (aka devnet-8) is a short-lived testnet that's available to the public for early testing of Glamsterdam features. This testnet will be followed by Glamsterdam on the longer-lived Sepolia and Hoodi testnets.",
+  "scrapedAt": "2026-08-07T04:49:39.574Z",
   "announcements": [
     "Plataberget targets to launch in early August 2026. **Exact date deferred to ACDT #90 (2026-08-03)**",
     "**Scope.** Short-lived fork-transition devnet: all clients fork together from a big pre-fork state (config similar to devnet-7). EL discovery runs **discv5-only** (per-client flags under Networking); QUIC stays enabled on the CL. The new **builder API** flow (Beacon API / Keymanager / Builder Specs PRs below) is **best effort**. **Repricing numbers are frozen** (ACDT #90) and the EIP has merged; EELS still needs a follow-up release to carry them. Stress goals: SSZ/stable-container performance and builder lifecycle at scale (see Testing focus). devnet-9 (non-finality testing) follows within the month.",
     "8282 system contracts are unchanged from devnet-7 (no sys-asm bytecode changes since):\n\n| Req | type | Address | \n|---------|------|--------------------------------------------|\n| deposit | 0x03 | 0x0000bff46984e3725691fa540a8c7589300d8282 | \n| exit | 0x04 | 0x000064d678505ad48f8ccb093bc65613800e8282 |"
   ],
   "eips": [
+    {
+      "number": 2780,
+      "title": "Reduce intrinsic transaction gas — transfer log cost folded into `TX_VALUE_COST`; intrinsic contract-creation 23,000 → 24,000 (tracks `CREATE_ACCESS`)",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-2780"
+    },
     {
       "number": 7610,
       "title": "Revert creation in case of non-empty storage",
@@ -24,10 +28,28 @@
       "url": "https://eips.ethereum.org/EIPS/eip-7688"
     },
     {
+      "number": 7708,
+      "title": "ETH transfers emit a log",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7708"
+    },
+    {
       "number": 7732,
       "title": "Enshrined Proposer-Builder Separation",
       "status": null,
       "url": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7732.md"
+    },
+    {
+      "number": 7778,
+      "title": "Block Gas Accounting without Refunds",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7778"
+    },
+    {
+      "number": 7843,
+      "title": "SLOTNUM opcode",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7843"
     },
     {
       "number": 7904,
@@ -36,10 +58,58 @@
       "url": "https://eips.ethereum.org/EIPS/eip-7904"
     },
     {
+      "number": 7928,
+      "title": "Block-Level Access Lists — recipient excluded when a runtime halt precedes",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-7928"
+    },
+    {
+      "number": 7954,
+      "title": "Increase Maximum Contract Size (→ 64 KiB)",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7954"
+    },
+    {
       "number": 7975,
       "title": "eth/70 - partial block receipt lists",
       "status": null,
       "url": "https://eips.ethereum.org/EIPS/eip-7975"
+    },
+    {
+      "number": 7976,
+      "title": "Increase Calldata Floor Cost (64/64)",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7976"
+    },
+    {
+      "number": 7981,
+      "title": "Increase Access List Cost",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-7981"
+    },
+    {
+      "number": 7997,
+      "title": "Deterministic Factory Predeploy — spec unchanged; clients must not check contract existence at the fork boundary (no BAL read, no witness)",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-7997"
+    },
+    {
+      "number": 8024,
+      "title": "Backward compatible SWAPN, DUPN, EXCHANGE",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-8024"
+    },
+    {
+      "number": 8037,
+      "title": "State Creation Gas — CPSB=1530, source-based refunds; \"regular gas\" renamed to \"execution gas\" (terminology only)",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-8037"
+    },
+    {
+      "number": 8038,
+      "title": "State-access gas cost update — `COLD_STORAGE_ACCESS` stays 2,100 (no longer raised); `ACCOUNT_WRITE` 9,000, `CREATE_ACCESS` 12,000, `STORAGE_CLEAR_REFUND` 11,616, `ACCESS_LIST_STORAGE_KEY_COST` 2,000, `ACCESS_LIST_ADDRESS_COST` 2,900, `CALL_VALUE` 11,300; `COLD_ACCOUNT_ACCESS` 3,000 and `STORAGE_WRITE` 10,000 unchanged",
+      "status": "updated",
+      "url": "https://eips.ethereum.org/EIPS/eip-8038"
     },
     {
       "number": 8045,
@@ -54,10 +124,40 @@
       "url": "https://eips.ethereum.org/EIPS/eip-8061"
     },
     {
+      "number": 8070,
+      "title": "Sparse Blobpool — Engine API half now required: `engine_getBlobsV3` *and* `V4` both served, FCU v4 `custody_columns`. eth/72 cell exchange stays optional; cell-level DAS deferred",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-8070"
+    },
+    {
+      "number": 8136,
+      "title": "Cell-Level Deltas for Data Column Broadcast",
+      "status": "new",
+      "url": "https://eips.ethereum.org/EIPS/eip-8136"
+    },
+    {
       "number": 8159,
       "title": "eth/71 - Block Access List Exchange",
       "status": null,
       "url": "https://eips.ethereum.org/EIPS/eip-8159"
+    },
+    {
+      "number": 8189,
+      "title": "snap/2 - BAL-Based State Healing",
+      "status": "new",
+      "url": "https://eips.ethereum.org/EIPS/eip-8189"
+    },
+    {
+      "number": 8246,
+      "title": "Remove SELFDESTRUCT Burn",
+      "status": null,
+      "url": "https://eips.ethereum.org/EIPS/eip-8246"
+    },
+    {
+      "number": 8282,
+      "title": "Add builder execution requests",
+      "status": null,
+      "url": "https://github.com/ethereum/EIPs/pull/11760"
     }
   ],
   "elClientSupport": {
@@ -71,5 +171,7 @@
   "specReferences": {
     "consensusSpecs": null,
     "executionSpecs": null
-  }
+  },
+  "pending": true,
+  "description": "Plataberget (aka devnet-8) is a short-lived testnet that's available to the public for early testing of Glamsterdam features. This testnet will be followed by Glamsterdam on the longer-lived Sepolia and Hoodi testnets."
 }

--- a/src/data/devnets/glamsterdam-devnet-8.json
+++ b/src/data/devnets/glamsterdam-devnet-8.json
@@ -3,6 +3,7 @@
   "title": "Plataberget",
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-8",
   "scrapedAt": "2026-08-06T07:17:01.566Z",
+  "pending": true,
   "announcements": [
     "Plataberget targets to launch in early August 2026. **Exact date deferred to ACDT #90 (2026-08-03)**",
     "**Scope.** Short-lived fork-transition devnet: all clients fork together from a big pre-fork state (config similar to devnet-7). EL discovery runs **discv5-only** (per-client flags under Networking); QUIC stays enabled on the CL. The new **builder API** flow (Beacon API / Keymanager / Builder Specs PRs below) is **best effort**. **Repricing numbers are frozen** (ACDT #90) and the EIP has merged; EELS still needs a follow-up release to carry them. Stress goals: SSZ/stable-container performance and builder lifecycle at scale (see Testing focus). devnet-9 (non-finality testing) follows within the month.",

--- a/src/data/devnets/glamsterdam-devnet-8.json
+++ b/src/data/devnets/glamsterdam-devnet-8.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-8",
   "scrapedAt": "2026-08-06T07:17:01.566Z",
   "pending": true,
+  "description": "Plataberget (aka devnet-8) is a short-lived testnet that's available to the public for early testing of Glamsterdam features. This testnet will be followed by Glamsterdam on the longer-lived Sepolia and Hoodi testnets.",
   "announcements": [
     "Plataberget targets to launch in early August 2026. **Exact date deferred to ACDT #90 (2026-08-03)**",
     "**Scope.** Short-lived fork-transition devnet: all clients fork together from a big pre-fork state (config similar to devnet-7). EL discovery runs **discv5-only** (per-client flags under Networking); QUIC stays enabled on the CL. The new **builder API** flow (Beacon API / Keymanager / Builder Specs PRs below) is **best effort**. **Repricing numbers are frozen** (ACDT #90) and the EIP has merged; EELS still needs a follow-up release to carry them. Stress goals: SSZ/stable-container performance and builder lifecycle at scale (see Testing focus). devnet-9 (non-finality testing) follows within the month.",

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -38,6 +38,8 @@ export interface DevnetSpec {
   sameSpecAs?: string;
   /** Unix timestamp (seconds) of the devnet genesis, from cartographoor. */
   genesisTime?: number;
+  /** Manually-set flag: network not launched yet; resource links are pending. */
+  pending?: boolean;
   announcements: string[];
   eips: DevnetSpecEip[];
   elClientSupport: ClientSupportMatrix;

--- a/src/types/devnet-spec.ts
+++ b/src/types/devnet-spec.ts
@@ -40,6 +40,8 @@ export interface DevnetSpec {
   genesisTime?: number;
   /** Manually-set flag: network not launched yet; resource links are pending. */
   pending?: boolean;
+  /** Manually-curated short description shown in the page header. */
+  description?: string;
   announcements: string[];
   eips: DevnetSpecEip[];
   elClientSupport: ClientSupportMatrix;


### PR DESCRIPTION
getting forkcast ready to link for plataberg devnet resource:
- add a description about the devnet/testnet
- make the spec link a little more obvious with a button
- optimistically add buttons for "add network" and faucet pages, assuming pandaops makes new ones
- fix the EIP regex that was scraping so the list is complete