### PR TITLE
rank: group EIPs by category

### DIFF
--- a/src/components/RankPage.tsx
+++ b/src/components/RankPage.tsx
@@ -5,11 +5,10 @@ import {
   getLaymanTitle,
   getProposalPrefix,
   getEipLayer,
-  getForkRelationship,
 } from "../utils/eip";
 import { useAnalytics } from "../hooks/useAnalytics";
-import { eipsData } from "../data/eips";
 import { groupByCategory } from "../domain/eips/eipCategories";
+import { getRankableEips } from "../domain/eips/rankableEips";
 import { EipDrawer } from "./eip/EipDrawer";
 import { decodeRankingsHash, encodeRankingsHash } from "../utils/rankShare";
 
@@ -70,21 +69,12 @@ const TIER_IDS = TIERS.map((tier) => tier.id);
 const STORAGE_KEY = "hegota-rankings";
 
 // The unranked starting board: active Hegota EIPs, minus selected headliners
-const buildTierItems = (): TierItem[] => {
-  const ACTIVE_STATUSES = new Set(['Proposed', 'Considered', 'Scheduled', 'Included']);
-  return eipsData
-    .filter((eip) => {
-      const rel = getForkRelationship(eip, "hegota");
-      if (!rel || rel.isHeadliner) return false;
-      const latest = rel.statusHistory[rel.statusHistory.length - 1]?.status;
-      return ACTIVE_STATUSES.has(latest);
-    })
-    .map((eip) => ({
-      id: `eip-${eip.id}`,
-      eip,
-      tier: null,
-    }));
-};
+const buildTierItems = (): TierItem[] =>
+  getRankableEips().map((eip) => ({
+    id: `eip-${eip.id}`,
+    eip,
+    tier: null,
+  }));
 
 // Merge the viewer's saved tier assignments onto the current board
 const applySavedRankings = (allItems: TierItem[]): TierItem[] => {

--- a/src/components/RankPage.tsx
+++ b/src/components/RankPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "../utils/eip";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { eipsData } from "../data/eips";
+import { groupByCategory } from "../domain/eips/eipCategories";
 import { EipDrawer } from "./eip/EipDrawer";
 import { decodeRankingsHash, encodeRankingsHash } from "../utils/rankShare";
 
@@ -1029,80 +1030,88 @@ const RankPage: React.FC = () => {
                       </svg>
                     </button>
                     {isExpanded && (
-                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 p-3">
-                        {layerItems.map((item) => (
-                          <div
-                            key={item.id}
-                            draggable={!isTouchDevice}
-                            onDragStart={
-                              !isTouchDevice
-                                ? (e) => handleDragStart(e, item.id)
-                                : undefined
-                            }
-                            onDragEnd={!isTouchDevice ? handleDragEnd : undefined}
-                            onTouchStart={
-                              isTouchDevice
-                                ? () => setSelectedMobileItem(item.id)
-                                : undefined
-                            }
-                            onTouchEnd={
-                              isTouchDevice
-                                ? () => {
-                                    editItems((prev) =>
-                                      prev.map((item) =>
-                                        item.id === selectedMobileItem
-                                          ? { ...item, tier: dragOverTier || null }
-                                          : item
-                                      )
-                                    );
-                                    setSelectedMobileItem(null);
-                                  }
-                                : undefined
-                            }
-                            onClick={
-                              isTouchDevice
-                                ? () => handleMobileItemClick(item.id)
-                                : undefined
-                            }
-                            className={`relative p-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg cursor-move hover:shadow-md transition-all touch-manipulation ${
-                              draggedItem === item.id ? "opacity-50" : ""
-                            } ${
-                              selectedMobileItem === item.id
-                                ? "ring-2 ring-purple-400 bg-purple-50 dark:bg-purple-900/20"
-                                : ""
-                            }`}
-                          >
-                            <div className="flex items-center gap-2 flex-nowrap">
-                              <span
-                                className="text-xs font-mono text-purple-600 dark:text-purple-400 cursor-pointer inline-flex items-center flex-shrink-0 whitespace-nowrap hover:text-purple-800 dark:hover:text-purple-300 transition-colors"
-                                style={{
-                                  borderBottom: '1px dotted currentColor',
-                                  marginBottom: '-2px'
-                                }}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  if (item.eip) setDrawerEipId(item.eip.id);
-                                }}
-                              >
-                                {getItemDisplayId(item)}
-                              </span>
-                              {getItemLayer(item) && (
-                                <span
-                                  className={`px-1 py-0.5 text-xs font-medium rounded flex-shrink-0 ${
-                                    getItemLayer(item) === "EL"
-                                      ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300"
-                                      : "bg-teal-100 text-teal-700 dark:bg-teal-900/20 dark:text-teal-300"
-                                  }`}
-                                >
-                                  {getItemLayer(item)}
+                      <div className="flex flex-col gap-4 p-3">
+                        {groupByCategory(layerItems, (item) => item.eip?.id).map(
+                          ({ name, items: categoryItems }) => (
+                            <div key={name} className="flex flex-col gap-2">
+                              <div className="flex items-center gap-2">
+                                <h5 className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                  {name}
+                                </h5>
+                                <span className="text-[10px] font-medium text-slate-400 dark:text-slate-500">
+                                  {categoryItems.length}
                                 </span>
-                              )}
-                              <span className="font-medium text-xs text-slate-900 dark:text-slate-100 truncate">
-                                {getItemTitle(item)}
-                              </span>
+                                <span className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+                              </div>
+                              <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
+                                {categoryItems.map((item) => (
+                                  <div
+                                    key={item.id}
+                                    draggable={!isTouchDevice}
+                                    onDragStart={
+                                      !isTouchDevice
+                                        ? (e) => handleDragStart(e, item.id)
+                                        : undefined
+                                    }
+                                    onDragEnd={
+                                      !isTouchDevice ? handleDragEnd : undefined
+                                    }
+                                    onTouchStart={
+                                      isTouchDevice
+                                        ? () => setSelectedMobileItem(item.id)
+                                        : undefined
+                                    }
+                                    onTouchEnd={
+                                      isTouchDevice
+                                        ? () => {
+                                            editItems((prev) =>
+                                              prev.map((item) =>
+                                                item.id === selectedMobileItem
+                                                  ? { ...item, tier: dragOverTier || null }
+                                                  : item
+                                              )
+                                            );
+                                            setSelectedMobileItem(null);
+                                          }
+                                        : undefined
+                                    }
+                                    onClick={
+                                      isTouchDevice
+                                        ? () => handleMobileItemClick(item.id)
+                                        : undefined
+                                    }
+                                    className={`relative p-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg cursor-move hover:shadow-md transition-all touch-manipulation ${
+                                      draggedItem === item.id ? "opacity-50" : ""
+                                    } ${
+                                      selectedMobileItem === item.id
+                                        ? "ring-2 ring-purple-400 bg-purple-50 dark:bg-purple-900/20"
+                                        : ""
+                                    }`}
+                                  >
+                                    <div className="flex items-center gap-2 flex-nowrap">
+                                      <span
+                                        className="text-xs font-mono text-purple-600 dark:text-purple-400 cursor-pointer inline-flex items-center flex-shrink-0 whitespace-nowrap hover:text-purple-800 dark:hover:text-purple-300 transition-colors"
+                                        style={{
+                                          borderBottom: '1px dotted currentColor',
+                                          marginBottom: '-2px'
+                                        }}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          if (item.eip) setDrawerEipId(item.eip.id);
+                                        }}
+                                      >
+                                        {getItemDisplayId(item)}
+                                      </span>
+                                      <span className="font-medium text-xs text-slate-900 dark:text-slate-100 truncate">
+                                        {getItemTitle(item)}
+                                      </span>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
                             </div>
-                          </div>
-                        ))}
+                          )
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/data/eip-categories.ts
+++ b/src/data/eip-categories.ts
@@ -1,0 +1,112 @@
+// Thematic categories for the proposals shown on the rank page. Grouping is by
+// what a proposal is *for*, not by its dependency graph.
+//
+// Categories are declared in display order. The page groups by layer first, so a
+// category shows up under every layer its EIPs belong to. EIPs listed here that
+// are not up for ranking are ignored, and EIPs in no category at all fall into a
+// trailing "Other".
+
+export interface EipCategory {
+  /** Slug, stable across renames of `name`. */
+  id: string;
+  name: string;
+  /** Member EIPs, in display order. */
+  eips: number[];
+}
+
+export const eipCategories: EipCategory[] = [
+  // --- Execution layer ---
+  {
+    id: 'frame-transactions',
+    name: 'Frame Transactions',
+    // 8141 is the transaction type; the rest amend or build on its frames.
+    eips: [8141, 7906, 8250, 8272]
+  },
+  {
+    id: 'account-abstraction',
+    name: 'Account Abstraction & Delegation',
+    eips: [7645, 7819, 7851, 8151, 8298]
+  },
+  {
+    id: 'evm-features',
+    name: 'EVM Features',
+    eips: [5920, 7979, 8163, 8173]
+  },
+  {
+    id: 'repricing',
+    name: 'Repricing',
+    eips: [7686, 7709, 7923, 7971, 7973, 8058, 8131, 8279]
+  },
+  {
+    id: 'precompiles-cryptography',
+    name: 'Precompiles & Cryptography',
+    eips: [7666, 8030, 8200]
+  },
+  {
+    id: 'block-state-data',
+    name: 'Block & State Data',
+    eips: [7807, 8115, 8116, 8188, 8268, 8304]
+  },
+  {
+    id: 'privacy',
+    name: 'Privacy',
+    eips: [8182]
+  },
+
+  // --- Consensus layer ---
+  {
+    id: 'beacon-block-data',
+    name: 'Beacon Block Data',
+    eips: [8237, 8341, 8359]
+  },
+  {
+    id: 'block-propagation',
+    name: 'Block Propagation & Validation',
+    eips: [8146]
+  },
+  {
+    id: 'attestations',
+    name: 'Attestations',
+    eips: [8243, 8334]
+  },
+  {
+    id: 'consensus-fork-choice',
+    name: 'Consensus & Fork Choice',
+    eips: [8198, 8321, 8333]
+  },
+  {
+    id: 'staking-features',
+    name: 'Staking Features',
+    eips: [8148, 8205, 8365, 8367]
+  },
+  {
+    id: 'rewards-penalties',
+    name: 'Rewards & Penalties',
+    eips: [7716, 8363]
+  },
+  {
+    id: 'data-availability',
+    name: 'Data Availability & Proofs',
+    eips: [8025, 8142, 8371]
+  },
+  {
+    id: 'censorship-resistance',
+    name: 'Censorship Resistance',
+    eips: [8369]
+  },
+
+  // --- Spans both layers, so these are declared last and render last everywhere ---
+  {
+    id: 'state-transition',
+    name: 'State Transition',
+    eips: [8253, 7862]
+  },
+  {
+    id: 'cleanup-deprecations',
+    name: 'Cleanup & Deprecations',
+    eips: [2488, 4758, 7668, 8015]
+  }
+];
+
+/** Bucket for EIPs that have not been categorized yet. */
+export const UNCATEGORIZED = 'Other';

--- a/src/data/eip-categories.ts
+++ b/src/data/eip-categories.ts
@@ -4,7 +4,7 @@
 // Categories are declared in display order. The page groups by layer first, so a
 // category shows up under every layer its EIPs belong to. EIPs listed here that
 // are not up for ranking are ignored, and EIPs in no category at all fall into a
-// trailing "Other".
+// trailing "Uncategorized".
 
 export interface EipCategory {
   /** Slug, stable across renames of `name`. */
@@ -108,5 +108,7 @@ export const eipCategories: EipCategory[] = [
   }
 ];
 
+// Deliberately not "Other": the rank page already uses that name for the
+// section holding EIPs with no layer.
 /** Bucket for EIPs that have not been categorized yet. */
-export const UNCATEGORIZED = 'Other';
+export const UNCATEGORIZED = 'Uncategorized';

--- a/src/domain/eips/eipCategories.test.ts
+++ b/src/domain/eips/eipCategories.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { EipCategory, eipCategories } from '../../data/eip-categories';
+import { groupByCategory } from './eipCategories';
+
+const categories: EipCategory[] = [
+  { id: 'repricing', name: 'Repricing', eips: [8131, 8279] },
+  { id: 'evm', name: 'EVM Features', eips: [5920, 7979] }
+];
+
+const item = (id: number) => ({ id });
+const names = <T>(groups: Array<{ name: string; items: T[] }>) => groups.map(g => g.name);
+
+describe('groupByCategory', () => {
+  it('groups in declared category order, not in item order', () => {
+    const groups = groupByCategory(
+      [item(7979), item(8131), item(5920)],
+      i => i.id,
+      categories
+    );
+
+    expect(names(groups)).toEqual(['Repricing', 'EVM Features']);
+    expect(groups[1].items.map(i => i.id)).toEqual([5920, 7979]);
+  });
+
+  it('orders items within a category as the category lists them', () => {
+    const groups = groupByCategory([item(8279), item(8131)], i => i.id, categories);
+
+    expect(groups[0].items.map(i => i.id)).toEqual([8131, 8279]);
+  });
+
+  it('drops categories with nothing to show', () => {
+    const groups = groupByCategory([item(5920)], i => i.id, categories);
+
+    expect(names(groups)).toEqual(['EVM Features']);
+  });
+
+  it('collects unknown and missing EIPs into a trailing Other group', () => {
+    const groups = groupByCategory(
+      [item(9999), item(5920), { id: undefined as number | undefined }],
+      i => i.id,
+      categories
+    );
+
+    expect(names(groups)).toEqual(['EVM Features', 'Other']);
+    expect(groups[1].items).toHaveLength(2);
+  });
+});
+
+describe('eipCategories data', () => {
+  it('never lists the same EIP twice', () => {
+    const seen = new Map<number, string>();
+    for (const category of eipCategories) {
+      for (const eipId of category.eips) {
+        expect(seen.has(eipId), `EIP-${eipId} in both ${seen.get(eipId)} and ${category.name}`).toBe(false);
+        seen.set(eipId, category.name);
+      }
+    }
+  });
+
+  it('has unique category ids and names', () => {
+    expect(new Set(eipCategories.map(c => c.id)).size).toBe(eipCategories.length);
+    expect(new Set(eipCategories.map(c => c.name)).size).toBe(eipCategories.length);
+  });
+});

--- a/src/domain/eips/eipCategories.test.ts
+++ b/src/domain/eips/eipCategories.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { EipCategory, eipCategories } from '../../data/eip-categories';
 import { groupByCategory } from './eipCategories';
+import { getRankableEips } from './rankableEips';
 
 const categories: EipCategory[] = [
   { id: 'repricing', name: 'Repricing', eips: [8131, 8279] },
@@ -34,14 +35,14 @@ describe('groupByCategory', () => {
     expect(names(groups)).toEqual(['EVM Features']);
   });
 
-  it('collects unknown and missing EIPs into a trailing Other group', () => {
+  it('collects unknown and missing EIPs into a trailing Uncategorized group', () => {
     const groups = groupByCategory(
       [item(9999), item(5920), { id: undefined as number | undefined }],
       i => i.id,
       categories
     );
 
-    expect(names(groups)).toEqual(['EVM Features', 'Other']);
+    expect(names(groups)).toEqual(['EVM Features', 'Uncategorized']);
     expect(groups[1].items).toHaveLength(2);
   });
 });
@@ -60,5 +61,17 @@ describe('eipCategories data', () => {
   it('has unique category ids and names', () => {
     expect(new Set(eipCategories.map(c => c.id)).size).toBe(eipCategories.length);
     expect(new Set(eipCategories.map(c => c.name)).size).toBe(eipCategories.length);
+  });
+
+  // Uncategorized EIPs still render, so nothing on the page breaks when this
+  // fails — it just means newly proposed EIPs are piling up in a nameless
+  // bucket and someone needs to file them.
+  it('covers every EIP on the rank page', () => {
+    const categorized = new Set(eipCategories.flatMap(c => c.eips));
+    const missing = getRankableEips()
+      .filter(eip => !categorized.has(eip.id))
+      .map(eip => eip.title);
+
+    expect(missing, `add these to src/data/eip-categories.ts:\n${missing.join('\n')}`).toEqual([]);
   });
 });

--- a/src/domain/eips/eipCategories.ts
+++ b/src/domain/eips/eipCategories.ts
@@ -1,0 +1,70 @@
+import { EipCategory, eipCategories, UNCATEGORIZED } from '../../data/eip-categories';
+
+export interface CategoryGroup<T> {
+  name: string;
+  items: T[];
+}
+
+interface Placement {
+  category: number;
+  position: number;
+}
+
+/** Where each EIP sits: which category, and where inside it. First listing wins. */
+const buildPlacements = (categories: EipCategory[]): Map<number, Placement> => {
+  const placements = new Map<number, Placement>();
+  categories.forEach((category, index) => {
+    category.eips.forEach((eipId, position) => {
+      if (!placements.has(eipId)) {
+        placements.set(eipId, { category: index, position });
+      }
+    });
+  });
+  return placements;
+};
+
+/**
+ * Split items into their categories, in the order the categories are declared,
+ * and within a category in the order it lists its EIPs. Empty categories are
+ * dropped; anything uncategorized trails in a single "Other" group so newly
+ * proposed EIPs still show up on the page.
+ */
+export function groupByCategory<T>(
+  items: T[],
+  eipIdOf: (item: T) => number | null | undefined,
+  categories: EipCategory[] = eipCategories
+): CategoryGroup<T>[] {
+  const placements = buildPlacements(categories);
+  const placementOf = (item: T) => placements.get(eipIdOf(item) ?? -1);
+
+  const buckets = new Map<number, T[]>();
+  const uncategorized: T[] = [];
+
+  for (const item of items) {
+    const placement = placementOf(item);
+    if (!placement) {
+      uncategorized.push(item);
+      continue;
+    }
+    const bucket = buckets.get(placement.category);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      buckets.set(placement.category, [item]);
+    }
+  }
+
+  const groups: CategoryGroup<T>[] = [];
+  categories.forEach((category, index) => {
+    const bucket = buckets.get(index);
+    if (!bucket) return;
+    bucket.sort((a, b) => placementOf(a)!.position - placementOf(b)!.position);
+    groups.push({ name: category.name, items: bucket });
+  });
+
+  if (uncategorized.length > 0) {
+    groups.push({ name: UNCATEGORIZED, items: uncategorized });
+  }
+
+  return groups;
+}

--- a/src/domain/eips/eipCategories.ts
+++ b/src/domain/eips/eipCategories.ts
@@ -23,19 +23,34 @@ const buildPlacements = (categories: EipCategory[]): Map<number, Placement> => {
   return placements;
 };
 
+// Grouping happens on every render, so keep the derived index around rather
+// than rebuilding it each time.
+const placementCache = new WeakMap<EipCategory[], Map<number, Placement>>();
+
+const placementsFor = (categories: EipCategory[]): Map<number, Placement> => {
+  const cached = placementCache.get(categories);
+  if (cached) return cached;
+  const placements = buildPlacements(categories);
+  placementCache.set(categories, placements);
+  return placements;
+};
+
 /**
  * Split items into their categories, in the order the categories are declared,
  * and within a category in the order it lists its EIPs. Empty categories are
- * dropped; anything uncategorized trails in a single "Other" group so newly
- * proposed EIPs still show up on the page.
+ * dropped; anything uncategorized trails in a single "Uncategorized" group so
+ * newly proposed EIPs still show up on the page.
  */
 export function groupByCategory<T>(
   items: T[],
   eipIdOf: (item: T) => number | null | undefined,
   categories: EipCategory[] = eipCategories
 ): CategoryGroup<T>[] {
-  const placements = buildPlacements(categories);
-  const placementOf = (item: T) => placements.get(eipIdOf(item) ?? -1);
+  const placements = placementsFor(categories);
+  const placementOf = (item: T) => {
+    const eipId = eipIdOf(item);
+    return eipId == null ? undefined : placements.get(eipId);
+  };
 
   const buckets = new Map<number, T[]>();
   const uncategorized: T[] = [];

--- a/src/domain/eips/rankableEips.ts
+++ b/src/domain/eips/rankableEips.ts
@@ -1,0 +1,20 @@
+import { EIP } from '../../types/eip';
+import { eipsData } from '../../data/eips';
+import { getForkRelationship } from '../../utils/eip';
+
+/** The fork whose proposals the rank page ranks. */
+export const RANK_FORK = 'hegota';
+
+const ACTIVE_STATUSES = new Set(['Proposed', 'Considered', 'Scheduled', 'Included']);
+
+/**
+ * The proposals that make up the rank page's board: EIPs still in play for the
+ * fork, minus the headliners (which are chosen separately, not ranked).
+ */
+export const getRankableEips = (eips: EIP[] = eipsData): EIP[] =>
+  eips.filter(eip => {
+    const relationship = getForkRelationship(eip, RANK_FORK);
+    if (!relationship || relationship.isHeadliner) return false;
+    const history = relationship.statusHistory;
+    return ACTIVE_STATUSES.has(history[history.length - 1]?.status);
+  });


### PR DESCRIPTION
The rank page now groups all EIPs into categories within the existing EL and CL sections.